### PR TITLE
Replace alloca() with variable length arrays

### DIFF
--- a/hpy/universal/src/api.h
+++ b/hpy/universal/src/api.h
@@ -6,16 +6,4 @@
 #define HPyAPI_STORAGE _HPy_HIDDEN
 extern struct _HPyContext_s global_ctx;
 
-/* declare alloca() */
-#if defined(_MSC_VER)
-# include <malloc.h>   /* for alloca() */
-#else
-# include <stdint.h>
-# if (defined (__SVR4) && defined (__sun)) || defined(_AIX) || defined(__hpux)
-#  include <alloca.h>
-# endif
-#endif
-
-
-
 #endif /* HPY_API_H */

--- a/hpy/universal/src/ctx_meth.c
+++ b/hpy/universal/src/ctx_meth.c
@@ -23,7 +23,7 @@ ctx_CallRealFunctionFromTrampoline(HPyContext ctx, HPyFunc_Signature sig,
         HPyFunc_varargs f = (HPyFunc_varargs)func;
         _HPyFunc_args_VARARGS *a = (_HPyFunc_args_VARARGS*)args;
         Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-        HPy *h_args = alloca(nargs * sizeof(HPy));
+        HPy h_args[nargs * sizeof(HPy)];
         for (Py_ssize_t i = 0; i < nargs; i++) {
             h_args[i] = _py2h(PyTuple_GET_ITEM(a->args, i));
         }
@@ -34,7 +34,7 @@ ctx_CallRealFunctionFromTrampoline(HPyContext ctx, HPyFunc_Signature sig,
        HPyFunc_keywords f = (HPyFunc_keywords)func;
        _HPyFunc_args_KEYWORDS *a = (_HPyFunc_args_KEYWORDS*)args;
        Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-       HPy *h_args = alloca(nargs * sizeof(HPy));
+       HPy h_args[nargs * sizeof(HPy)];
        for (Py_ssize_t i = 0; i < nargs; i++) {
            h_args[i] = _py2h(PyTuple_GET_ITEM(a->args, i));
        }
@@ -45,7 +45,7 @@ ctx_CallRealFunctionFromTrampoline(HPyContext ctx, HPyFunc_Signature sig,
        HPyFunc_initproc f = (HPyFunc_initproc)func;
        _HPyFunc_args_INITPROC *a = (_HPyFunc_args_INITPROC*)args;
        Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-       HPy *h_args = alloca(nargs * sizeof(HPy));
+       HPy h_args[nargs * sizeof(HPy)];
        for (Py_ssize_t i = 0; i < nargs; i++) {
            h_args[i] = _py2h(PyTuple_GET_ITEM(a->args, i));
        }

--- a/hpy/universal/src/misc_win32.h
+++ b/hpy/universal/src/misc_win32.h
@@ -28,8 +28,6 @@ static void *dlsym(void *handle, const char *symbol)
         */
         int i;
         char mangled_name[1 + strlen(symbol) + 1 + 3 + 1];
-        if (!mangled_name)
-            return NULL;
         for (i = 0; i < 32; i++) {
             sprintf(mangled_name, "_%s@%d", symbol, i * 4);
             address = GetProcAddress((HMODULE)handle, mangled_name);

--- a/hpy/universal/src/misc_win32.h
+++ b/hpy/universal/src/misc_win32.h
@@ -1,6 +1,3 @@
-#include <malloc.h>   /* for alloca() */
-
-
 /************************************************************/
 /* Emulate dlopen()&co. from the Windows API */
 
@@ -30,7 +27,7 @@ static void *dlsym(void *handle, const char *symbol)
            for __stdcall functions.
         */
         int i;
-        char *mangled_name = alloca(1 + strlen(symbol) + 1 + 3 + 1);
+        char mangled_name[1 + strlen(symbol) + 1 + 3 + 1];
         if (!mangled_name)
             return NULL;
         for (i = 0; i < 32; i++) {


### PR DESCRIPTION
This fixes the warning in #72 regarding the usage of alloca.
Merging this PR means that we aim to support C99 and above, which is in my opinion a reasonable assumption these days.