### PR TITLE
Use pytest-xdist to run tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
     displayName: 'Use Python $(python.version)'
 
   - script: |
-      python -m pip install --upgrade pip
+      python -m pip install --upgrade pip wheel
     displayName: 'Install dependencies'
 
   - script: |
@@ -30,8 +30,8 @@ jobs:
     displayName: 'Build project'
 
   - script: |
-      pip install pytest pytest-azurepipelines
-      pytest test/
+      pip install pytest pytest-azurepipelines pytest-xdist
+      pytest -n auto test/
     displayName: 'pytest'
 
 - job: ExampleTests


### PR DESCRIPTION
Using xdist cuts the build time significantlly.
I see no reason why we shouldn't use it.