### PR TITLE
Cache pip and extension compilation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,11 +15,34 @@ jobs:
         python.version: '3.7'
       py38:
         python.version: '3.8'
+  variables:
+    PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
   steps:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(python.version)'
     displayName: 'Use Python $(python.version)'
+
+  - script: |
+      sudo apt update && sudo apt install -y ccache
+      echo "##vso[task.prependpath]/usr/lib/ccache"
+    displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
+
+  - task: Cache@2
+    inputs:
+      key: 'ccache | "$(Agent.OS)" | "$(python.version)"'
+      path: $(CCACHE_DIR)
+    displayName: ccache
+
+  - task: Cache@2
+    inputs:
+      key: 'python | "$(Agent.OS)"'
+      restoreKeys: |
+        python | "$(Agent.OS)"
+        python
+      path: $(PIP_CACHE_DIR)
+    displayName: Cache pip packages
 
   - script: |
       python -m pip install --upgrade pip wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
     inputs:
       key: 'ccache | "$(Agent.OS)" | "$(python.version)"'
       path: $(CCACHE_DIR)
-    displayName: ccache
+    displayName: Cache C compilation with ccache
 
   - task: Cache@2
     inputs:
@@ -69,11 +69,34 @@ jobs:
         python.version: '3.7'
       py38:
         python.version: '3.8'
+  variables:
+    PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
   steps:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(python.version)'
     displayName: 'Use Python $(python.version)'
+
+  - script: |
+      sudo apt update && sudo apt install -y ccache
+      echo "##vso[task.prependpath]/usr/lib/ccache"
+    displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
+
+  - task: Cache@2
+    inputs:
+      key: 'ccache | "$(Agent.OS)" | "$(python.version)"'
+      path: $(CCACHE_DIR)
+    displayName: Cache C compilation with ccache
+
+  - task: Cache@2
+    inputs:
+      key: 'python | "$(Agent.OS)"'
+      restoreKeys: |
+        python | "$(Agent.OS)"
+        python
+      path: $(PIP_CACHE_DIR)
+    displayName: Cache pip packages
 
   - script: |
       proof-of-concept/build_wheel_nodeps.sh


### PR DESCRIPTION
Since we constantly compile code when testing and the tests rarely change,
it'd be wise to setup ccache for them.

I've also went ahead and cached pypi packages for good measure.