### PR TITLE
Fix type refcount in _HPy_New()

### DIFF
--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -428,6 +428,10 @@ ctx_New(HPyContext ctx, HPy h_type, void **data)
     PyObject *result = PyObject_New(PyObject, (PyTypeObject*)tp);
     if (!result)
         return HPy_NULL;
+#if PY_VERSION_HEX < 0x03080000
+    // Workaround for Python issue 35810; no longer necessary in Python 3.8
+    Py_INCREF(tp);
+#endif
 
     *data = (void*)result;
     return _py2h(result);

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -187,6 +187,23 @@ class TestType(HPyTest):
         p2 = mod.Point(4, 2)
         assert p2.foo() == 42
 
+    def test_refcount(self):
+        import pytest
+        import sys
+        if not self.should_check_refcount():
+            pytest.skip()
+        mod = self.make_module("""
+            @DEFINE_PointObject
+            @DEFINE_Point_new
+            @EXPORT_POINT_TYPE(&Point_new)
+            @INIT
+        """)
+        tp = mod.Point
+        init_refcount = sys.getrefcount(tp)
+        p = tp(1, 2)
+        assert sys.getrefcount(tp) == init_refcount + 1
+        p = None
+        assert sys.getrefcount(tp) == init_refcount
 
     def test_HPyDef_Member(self):
         mod = self.make_module("""


### PR DESCRIPTION
On CPython <3.8, PyObject_New doesn't incref the type, so we need to do it ourselves. On 3.8+, it does incref the type iff it's a heap type, so we don't have to do anything.

Cf. https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-the-c-api and https://bugs.python.org/issue35810