### PR TITLE
Run facebook infer in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ cppcheck-build-dir:
 
 cppcheck: cppcheck-build-dir
 	@cppcheck --error-exitcode=1 --cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) --enable=warning,performance,portability,information,unusedFunction,missingInclude --report-progress -I hpy/devel/include/ -I hpy/devel/include/common/ -I hpy/devel/include/cpython/ -I hpy/devel/include/universal/ -I hpy/universal/src/ -I ${PYTHON_INCLUDE_DIR} --force -D NULL=0 .
+
+infer:
+	python3 setup.py build_ext -if | compiledb
+	@infer --fail-on-bug --compilation-database compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,5 @@ cppcheck: cppcheck-build-dir
 	@cppcheck --error-exitcode=1 --cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) --enable=warning,performance,portability,information,unusedFunction,missingInclude --report-progress -I hpy/devel/include/ -I hpy/devel/include/common/ -I hpy/devel/include/cpython/ -I hpy/devel/include/universal/ -I hpy/universal/src/ -I ${PYTHON_INCLUDE_DIR} --force -D NULL=0 .
 
 infer:
-	python3 setup.py build_ext -if | compiledb
+	python3 setup.py build_ext -if -U NDEBUG | compiledb
 	@infer --fail-on-bug --compilation-database compile_commands.json

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,3 +139,21 @@ jobs:
 
   - script: make cppcheck
     displayName: Run CPPCheck
+- job: infer
+  pool:
+    vmImage: 'ubuntu-latest'
+  displayName: "Run infer"
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+    displayName: 'Use Python 3.8'
+  - script: |
+      pip install compiledb wheel;
+      VERSION=0.17.0; \
+      curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux64-v$VERSION.tar.xz" \
+      | sudo tar -C /opt -xJ && \
+      echo "##vso[task.prependpath]/opt/infer-linux64-v$VERSION/bin"
+    displayName: Install infer
+  - script: make infer
+    displayName: Run infer

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -420,10 +420,7 @@ _HPy_HIDDEN HPy
 ctx_New(HPyContext ctx, HPy h_type, void **data)
 {
     PyObject *tp = _h2py(h_type);
-    if (tp == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "HPy_New arg 1 must not be a null handle");
-        return HPy_NULL;
-    }
+    assert(tp != NULL);
     if (!PyType_Check(tp)) {
         PyErr_SetString(PyExc_TypeError, "HPy_New arg 1 must be a type");
         return HPy_NULL;
@@ -446,10 +443,7 @@ _HPy_HIDDEN HPy
 ctx_Type_GenericNew(HPyContext ctx, HPy h_type, HPy *args, HPy_ssize_t nargs, HPy kw)
 {
     PyObject *tp = _h2py(h_type);
-    if (tp == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "HPy_Type_GenericNew arg 1 must not be a null handle");
-        return HPy_NULL;
-    }
+    assert(tp != NULL);
     if (!PyType_Check(tp)) {
         PyErr_SetString(PyExc_TypeError, "HPy_Type_GenericNew arg 1 must be a type");
         return HPy_NULL;

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -420,6 +420,10 @@ _HPy_HIDDEN HPy
 ctx_New(HPyContext ctx, HPy h_type, void **data)
 {
     PyObject *tp = _h2py(h_type);
+    if (tp == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "HPy_New arg 1 must not be a null handle");
+        return HPy_NULL;
+    }
     if (!PyType_Check(tp)) {
         PyErr_SetString(PyExc_TypeError, "HPy_New arg 1 must be a type");
         return HPy_NULL;
@@ -441,7 +445,16 @@ ctx_New(HPyContext ctx, HPy h_type, void **data)
 _HPy_HIDDEN HPy
 ctx_Type_GenericNew(HPyContext ctx, HPy h_type, HPy *args, HPy_ssize_t nargs, HPy kw)
 {
-    PyTypeObject *type = (PyTypeObject *)_h2py(h_type);
-    PyObject *res = type->tp_alloc(type, 0);
+    PyObject *tp = _h2py(h_type);
+    if (tp == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "HPy_Type_GenericNew arg 1 must not be a null handle");
+        return HPy_NULL;
+    }
+    if (!PyType_Check(tp)) {
+        PyErr_SetString(PyExc_TypeError, "HPy_Type_GenericNew arg 1 must be a type");
+        return HPy_NULL;
+    }
+
+    PyObject *res = ((PyTypeObject*) tp)->tp_alloc((PyTypeObject*) tp, 0);
     return _py2h(res);
 }


### PR DESCRIPTION
This PR runs facebook infer in CI.
[infer](https://fbinfer.com/) is a static analysis tool much like coverity, only free for use with much better UX.

I run it locally and got two potential null pointer de-references.
Unlike CPPCheck, it does not check for style or unused code etc.
Instead, it analyzes the code by traversing the IR bytecode from LLVM.