### PR TITLE
Add dev requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,18 @@ def get_scm_config():
 
     return {} # use the default config
 
+dev_requirements = [
+    "pytest",
+    "pytest-xdist",
+]
+
 setup(
     name="hpy.devel",
     packages = ['hpy.devel'],
     include_package_data=True,
+    extras_require={
+        "dev": dev_requirements,
+    },
     ext_modules = [
         Extension('hpy.universal',
                   ['hpy/universal/src/hpymodule.c',


### PR DESCRIPTION
At the moment this just install pytest and pytest-xdist so that contributors can easily see what's needed to run the tests.

This allows one to do `pip install -e '.[dev]'` to get the pytest requirements.