### PR TITLE
Handle the memory error case in ctx_ListBuilder_Cancel and ctx_TupleBuilder_Cancel.

### DIFF
--- a/hpy/devel/src/runtime/ctx_listbuilder.c
+++ b/hpy/devel/src/runtime/ctx_listbuilder.c
@@ -47,6 +47,9 @@ _HPy_HIDDEN void
 ctx_ListBuilder_Cancel(HPyContext ctx, HPyListBuilder builder)
 {
     PyObject *lst = (PyObject *)builder._lst;
+    if (lst == NULL) {
+        return;
+    }
     builder._lst = 0;
     Py_XDECREF(lst);
 }

--- a/hpy/devel/src/runtime/ctx_listbuilder.c
+++ b/hpy/devel/src/runtime/ctx_listbuilder.c
@@ -48,6 +48,9 @@ ctx_ListBuilder_Cancel(HPyContext ctx, HPyListBuilder builder)
 {
     PyObject *lst = (PyObject *)builder._lst;
     if (lst == NULL) {
+        // we don't report the memory error here: the builder
+        // is being cancelled (so the result of the builder is not being used)
+        // and likely it's being cancelled during the handling of another error
         return;
     }
     builder._lst = 0;

--- a/hpy/devel/src/runtime/ctx_tuplebuilder.c
+++ b/hpy/devel/src/runtime/ctx_tuplebuilder.c
@@ -55,6 +55,9 @@ ctx_TupleBuilder_Cancel(HPyContext ctx, HPyTupleBuilder builder)
 {
     PyObject *tup = (PyObject *)builder._tup;
     if (tup == NULL) {
+        // we don't report the memory error here: the builder
+        // is being cancelled (so the result of the builder is not being used)
+        // and likely it's being cancelled during the handling of another error
         return;
     }
     builder._tup = 0;

--- a/hpy/devel/src/runtime/ctx_tuplebuilder.c
+++ b/hpy/devel/src/runtime/ctx_tuplebuilder.c
@@ -54,7 +54,9 @@ _HPy_HIDDEN void
 ctx_TupleBuilder_Cancel(HPyContext ctx, HPyTupleBuilder builder)
 {
     PyObject *tup = (PyObject *)builder._tup;
+    if (tup == NULL) {
+        return;
+    }
     builder._tup = 0;
     Py_XDECREF(tup);
 }
-


### PR DESCRIPTION
Currently ctx_ListBuilder_Cancel and ctx_TupleBuilder_Cancel don't cater for the case where a memory error occurred when the builder was created.

Caveats:
* This doesn't raise a memory error like _Build does, but on the other hand the result of the building wasn't needed, so maybe its fine to swallow the memory error? Since _Cancel is likely to be called when an error is already set, it probably shouldn't raise errors of its own.
* No idea how to test this case.

Assuming _Cancel is called when an error is detected, it might be more likely that _Cancel is called after a MemoryError rather than _Build.