### PR TITLE
use __VA_ARGS__ also for HPyDef_METH

### DIFF
--- a/hpy/devel/include/common/hpydef.h
+++ b/hpy/devel/include/common/hpydef.h
@@ -126,7 +126,7 @@ typedef struct {
     };
 
 
-#define HPyDef_METH(SYM, NAME, IMPL, SIG)                               \
+#define HPyDef_METH(SYM, NAME, IMPL, SIG, ...)                          \
     HPyFunc_DECLARE(IMPL, SIG);                                         \
     HPyFunc_TRAMPOLINE(SYM##_trampoline, IMPL, SIG);                    \
     HPyDef SYM = {                                                      \
@@ -135,7 +135,8 @@ typedef struct {
             .name = NAME,                                               \
             .impl = IMPL,                                               \
             .cpy_trampoline = SYM##_trampoline,                         \
-            .signature = SIG                                            \
+            .signature = SIG,                                           \
+            __VA_ARGS__                                                 \
         }                                                               \
     };
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -36,7 +36,7 @@ class TestBasic(HPyTest):
 
     def test_noop_function(self):
         mod = self.make_module("""
-            HPyDef_METH(f, "f", f_impl, HPyFunc_NOARGS)
+            HPyDef_METH(f, "f", f_impl, HPyFunc_NOARGS, .doc="hello world")
             static HPy f_impl(HPyContext ctx, HPy self)
             {
                 return HPy_Dup(ctx, ctx->h_None);
@@ -46,6 +46,7 @@ class TestBasic(HPyTest):
             @INIT
         """)
         assert mod.f() is None
+        assert mod.f.__doc__ == 'hello world'
 
     def test_self_is_module(self):
         mod = self.make_module("""


### PR DESCRIPTION
use `__VA_ARGS__` also for `HPyDef_METH`, as we already do for `_MEMBER`, `_GETSET`, etc.