### PR TITLE
Rename HPyTracker_Free to _Close and _RemoveAll to _ForgetAll

### DIFF
--- a/hpy/devel/include/common/runtime/ctx_tracker.h
+++ b/hpy/devel/include/common/runtime/ctx_tracker.h
@@ -13,6 +13,6 @@ _HPy_HIDDEN void
 ctx_Tracker_RemoveAll(HPyContext ctx, HPyTracker ht);
 
 _HPy_HIDDEN void
-ctx_Tracker_Free(HPyContext ctx, HPyTracker ht);
+ctx_Tracker_Close(HPyContext ctx, HPyTracker ht);
 
 #endif /* HPY_COMMON_RUNTIME_CTX_TRACKER_H */

--- a/hpy/devel/include/common/runtime/ctx_tracker.h
+++ b/hpy/devel/include/common/runtime/ctx_tracker.h
@@ -10,7 +10,7 @@ _HPy_HIDDEN int
 ctx_Tracker_Add(HPyContext ctx, HPyTracker ht, HPy h);
 
 _HPy_HIDDEN void
-ctx_Tracker_RemoveAll(HPyContext ctx, HPyTracker ht);
+ctx_Tracker_ForgetAll(HPyContext ctx, HPyTracker ht);
 
 _HPy_HIDDEN void
 ctx_Tracker_Close(HPyContext ctx, HPyTracker ht);

--- a/hpy/devel/include/cpython/hpy.h
+++ b/hpy/devel/include/cpython/hpy.h
@@ -264,9 +264,9 @@ HPyTracker_RemoveAll(HPyContext ctx, HPyTracker ht)
 }
 
 HPyAPI_FUNC(void)
-HPyTracker_Free(HPyContext ctx, HPyTracker ht)
+HPyTracker_Close(HPyContext ctx, HPyTracker ht)
 {
-    ctx_Tracker_Free(ctx, ht);
+    ctx_Tracker_Close(ctx, ht);
 }
 
 #endif /* !HPy_CPYTHON_H */

--- a/hpy/devel/include/cpython/hpy.h
+++ b/hpy/devel/include/cpython/hpy.h
@@ -258,9 +258,9 @@ HPyTracker_Add(HPyContext ctx, HPyTracker ht, HPy h)
 }
 
 HPyAPI_FUNC(void)
-HPyTracker_RemoveAll(HPyContext ctx, HPyTracker ht)
+HPyTracker_ForgetAll(HPyContext ctx, HPyTracker ht)
 {
-    ctx_Tracker_RemoveAll(ctx, ht);
+    ctx_Tracker_ForgetAll(ctx, ht);
 }
 
 HPyAPI_FUNC(void)

--- a/hpy/devel/include/universal/autogen_ctx.h
+++ b/hpy/devel/include/universal/autogen_ctx.h
@@ -132,6 +132,6 @@ struct _HPyContext_s {
     void (*ctx_TupleBuilder_Cancel)(HPyContext ctx, HPyTupleBuilder builder);
     HPyTracker (*ctx_Tracker_New)(HPyContext ctx, HPy_ssize_t size);
     int (*ctx_Tracker_Add)(HPyContext ctx, HPyTracker ht, HPy h);
-    void (*ctx_Tracker_RemoveAll)(HPyContext ctx, HPyTracker ht);
+    void (*ctx_Tracker_ForgetAll)(HPyContext ctx, HPyTracker ht);
     void (*ctx_Tracker_Close)(HPyContext ctx, HPyTracker ht);
 };

--- a/hpy/devel/include/universal/autogen_ctx.h
+++ b/hpy/devel/include/universal/autogen_ctx.h
@@ -133,5 +133,5 @@ struct _HPyContext_s {
     HPyTracker (*ctx_Tracker_New)(HPyContext ctx, HPy_ssize_t size);
     int (*ctx_Tracker_Add)(HPyContext ctx, HPyTracker ht, HPy h);
     void (*ctx_Tracker_RemoveAll)(HPyContext ctx, HPyTracker ht);
-    void (*ctx_Tracker_Free)(HPyContext ctx, HPyTracker ht);
+    void (*ctx_Tracker_Close)(HPyContext ctx, HPyTracker ht);
 };

--- a/hpy/devel/include/universal/autogen_trampolines.h
+++ b/hpy/devel/include/universal/autogen_trampolines.h
@@ -436,7 +436,7 @@ static inline void HPyTracker_RemoveAll(HPyContext ctx, HPyTracker ht) {
      ctx->ctx_Tracker_RemoveAll ( ctx, ht ); 
 }
 
-static inline void HPyTracker_Free(HPyContext ctx, HPyTracker ht) {
-     ctx->ctx_Tracker_Free ( ctx, ht ); 
+static inline void HPyTracker_Close(HPyContext ctx, HPyTracker ht) {
+     ctx->ctx_Tracker_Close ( ctx, ht ); 
 }
 

--- a/hpy/devel/include/universal/autogen_trampolines.h
+++ b/hpy/devel/include/universal/autogen_trampolines.h
@@ -432,8 +432,8 @@ static inline int HPyTracker_Add(HPyContext ctx, HPyTracker ht, HPy h) {
      return ctx->ctx_Tracker_Add ( ctx, ht, h ); 
 }
 
-static inline void HPyTracker_RemoveAll(HPyContext ctx, HPyTracker ht) {
-     ctx->ctx_Tracker_RemoveAll ( ctx, ht ); 
+static inline void HPyTracker_ForgetAll(HPyContext ctx, HPyTracker ht) {
+     ctx->ctx_Tracker_ForgetAll ( ctx, ht ); 
 }
 
 static inline void HPyTracker_Close(HPyContext ctx, HPyTracker ht) {

--- a/hpy/devel/src/runtime/ctx_tracker.c
+++ b/hpy/devel/src/runtime/ctx_tracker.c
@@ -138,7 +138,7 @@ ctx_Tracker_Add(HPyContext ctx, HPyTracker ht, HPy h)
 }
 
 _HPy_HIDDEN void
-ctx_Tracker_RemoveAll(HPyContext ctx, HPyTracker ht)
+ctx_Tracker_ForgetAll(HPyContext ctx, HPyTracker ht)
 {
     _HPyTracker_s *hp = _ht2hp(ht);
     hp->next = 0;

--- a/hpy/devel/src/runtime/ctx_tracker.c
+++ b/hpy/devel/src/runtime/ctx_tracker.c
@@ -10,8 +10,8 @@
  *    the handle passed to it has been tracked (internally it does this by
  *    maintaining space for one more handle).
  *
- *    After HPyTracker_Add fails, HPyTracker_Free should be called without
- *    any further calls to HPyTracker_Add. Calling HPyTracker_Free will close
+ *    After HPyTracker_Add fails, HPyTracker_Close should be called without
+ *    any further calls to HPyTracker_Add. Calling HPyTracker_Close will close
  *    all the tracked handles, including the handled passed to the failed call
  *    to HPyTracker_Add.
  *
@@ -47,11 +47,11 @@
  * }
  *
  * success:
- *    HPyTracker_Free(ctx, ht);
+ *    HPyTracker_Close(ctx, ht);
  *    return dict;
  *
  * error:
- *    HPyTracker_Free(ctx, ht);
+ *    HPyTracker_Close(ctx, ht);
  *    HPy_Close(ctx, dict);
  *    // HPyErr will already have been set by the error that occurred.
  *    return HPy_NULL;
@@ -145,7 +145,7 @@ ctx_Tracker_RemoveAll(HPyContext ctx, HPyTracker ht)
 }
 
 _HPy_HIDDEN void
-ctx_Tracker_Free(HPyContext ctx, HPyTracker ht)
+ctx_Tracker_Close(HPyContext ctx, HPyTracker ht)
 {
     _HPyTracker_s *hp = _ht2hp(ht);
     HPy_ssize_t i;

--- a/hpy/tools/autogen/parse.py
+++ b/hpy/tools/autogen/parse.py
@@ -216,7 +216,7 @@ SPECIAL_CASES = {
     'HPyTracker_New': None,
     'HPyTracker_Add': None,
     'HPyTracker_RemoveAll': None,
-    'HPyTracker_Free': None,
+    'HPyTracker_Close': None,
 }
 
 

--- a/hpy/tools/autogen/parse.py
+++ b/hpy/tools/autogen/parse.py
@@ -215,7 +215,7 @@ SPECIAL_CASES = {
     'HPyTupleBuilder_Cancel': None,
     'HPyTracker_New': None,
     'HPyTracker_Add': None,
-    'HPyTracker_RemoveAll': None,
+    'HPyTracker_ForgetAll': None,
     'HPyTracker_Close': None,
 }
 

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -199,7 +199,7 @@ void HPyTupleBuilder_Cancel(HPyContext ctx, HPyTupleBuilder builder);
 HPyTracker HPyTracker_New(HPyContext ctx, HPy_ssize_t size);
 int HPyTracker_Add(HPyContext ctx, HPyTracker ht, HPy h);
 void HPyTracker_RemoveAll(HPyContext ctx, HPyTracker ht);
-void HPyTracker_Free(HPyContext ctx, HPyTracker ht);
+void HPyTracker_Close(HPyContext ctx, HPyTracker ht);
 
 /* *******
    hpyfunc

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -198,7 +198,7 @@ void HPyTupleBuilder_Cancel(HPyContext ctx, HPyTupleBuilder builder);
 
 HPyTracker HPyTracker_New(HPyContext ctx, HPy_ssize_t size);
 int HPyTracker_Add(HPyContext ctx, HPyTracker ht, HPy h);
-void HPyTracker_RemoveAll(HPyContext ctx, HPyTracker ht);
+void HPyTracker_ForgetAll(HPyContext ctx, HPyTracker ht);
 void HPyTracker_Close(HPyContext ctx, HPyTracker ht);
 
 /* *******

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -133,5 +133,5 @@ struct _HPyContext_s global_ctx = {
     .ctx_Tracker_New = &ctx_Tracker_New,
     .ctx_Tracker_Add = &ctx_Tracker_Add,
     .ctx_Tracker_RemoveAll = &ctx_Tracker_RemoveAll,
-    .ctx_Tracker_Free = &ctx_Tracker_Free,
+    .ctx_Tracker_Close = &ctx_Tracker_Close,
 };

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -132,6 +132,6 @@ struct _HPyContext_s global_ctx = {
     .ctx_TupleBuilder_Cancel = &ctx_TupleBuilder_Cancel,
     .ctx_Tracker_New = &ctx_Tracker_New,
     .ctx_Tracker_Add = &ctx_Tracker_Add,
-    .ctx_Tracker_RemoveAll = &ctx_Tracker_RemoveAll,
+    .ctx_Tracker_ForgetAll = &ctx_Tracker_ForgetAll,
     .ctx_Tracker_Close = &ctx_Tracker_Close,
 };

--- a/test/test_tracker.py
+++ b/test/test_tracker.py
@@ -23,7 +23,7 @@ class TestHPyTracker(HPyTest):
                     return HPy_NULL;
                 }}
                 {ops}
-                HPyTracker_Free(ctx, ht);
+                HPyTracker_Close(ctx, ht);
                 if (HPy_IsNull(result))
                     result = HPy_Dup(ctx, ctx->h_None);
                 return result;
@@ -102,11 +102,11 @@ class TestHPyTracker(HPyTest):
                         goto error;
                 }
 
-                HPyTracker_Free(ctx, ht);
+                HPyTracker_Close(ctx, ht);
                 return dict;
 
                 error:
-                    HPyTracker_Free(ctx, ht);
+                    HPyTracker_Close(ctx, ht);
                     HPy_Close(ctx, dict);
                     HPyErr_SetString(ctx, ctx->h_ValueError, "Failed!");
                     return HPy_NULL;

--- a/test/test_tracker.py
+++ b/test/test_tracker.py
@@ -50,13 +50,13 @@ class TestHPyTracker(HPyTest):
     def test_add_and_remove_all(self):
         mod = self.hpytracker_module(ops="""
             HPyTracker_Add(ctx, ht, args[0]);
-            HPyTracker_RemoveAll(ctx, ht);
+            HPyTracker_ForgetAll(ctx, ht);
         """)
         assert mod.f(5) is None
 
     def test_remove_all_on_nothing(self):
         mod = self.hpytracker_module(ops="""
-            HPyTracker_RemoveAll(ctx, ht);
+            HPyTracker_ForgetAll(ctx, ht);
         """)
         assert mod.f() is None
 


### PR DESCRIPTION
After some discussion on IRC we decided that HPyTracker_Close communicates the more important part of what the _Free method does (i.e. closes the handles) and that HPyTracker_ForgetAll better communicates that the handles are "forgotten" (i.e. no longer tracked).