### PR TITLE
fix build on pypy

### DIFF
--- a/hpy/universal/src/hpymodule.c
+++ b/hpy/universal/src/hpymodule.c
@@ -12,6 +12,10 @@
 #include "handles.h"
 #include "common/version.h"
 
+#ifdef PYPY_VERSION
+#  error "Cannot build hpy.univeral on top of PyPy. PyPy comes with its own version of it"
+#endif
+
 typedef HPy (*InitFuncPtr)(HPyContext ctx);
 
 static PyObject *set_debug(PyObject *self, PyObject *args)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from setuptools import setup, Extension
 
@@ -39,19 +40,9 @@ def get_scm_config():
 
     return {} # use the default config
 
-dev_requirements = [
-    "pytest",
-    "pytest-xdist",
-]
-
-setup(
-    name="hpy.devel",
-    packages = ['hpy.devel'],
-    include_package_data=True,
-    extras_require={
-        "dev": dev_requirements,
-    },
-    ext_modules = [
+EXT_MODULES = []
+if sys.implementation.name == 'cpython':
+    EXT_MODULES += [
         Extension('hpy.universal',
                   ['hpy/universal/src/hpymodule.c',
                    'hpy/universal/src/handles.c',
@@ -73,8 +64,24 @@ setup(
                   extra_compile_args=[
                       '-DHPY_UNIVERSAL_ABI',
                   ] + EXTRA_COMPILE_ARGS
-        )],
-      entry_points={
+                  )
+        ]
+
+
+DEV_REQUIREMENTS = [
+    "pytest",
+    "pytest-xdist",
+]
+
+setup(
+    name="hpy.devel",
+    packages = ['hpy.devel'],
+    include_package_data=True,
+    extras_require={
+        "dev": DEV_REQUIREMENTS,
+    },
+    ext_modules = EXT_MODULES,
+    entry_points={
           "distutils.setup_keywords": [
               "hpy_ext_modules = hpy.devel:handle_hpy_ext_modules",
           ],


### PR DESCRIPTION
As reported by #17 , the current behavior of `setup.py` is confusing: if you run it on top of PyPy it also tries to build `hpy.universal`: this is doubly wrong because:
1. The point of `hpy/universal/src` is to run on CPython only
2. the built module is ignored on PyPy anyway, because it is shadowed by `lib_pypy/hpy/universal.py` (which is shipped with PyPy)

This PR makes sure that:

1. you error out if you try to compile `hpy.universal` on PyPy
2. `hpy.universal` is built&installed only on CPython

