### PR TITLE
Add handle tracking to HPyArg_Parse and HPyArg_ParseKeywords

### DIFF
--- a/hpy/devel/include/common/runtime/argparse.h
+++ b/hpy/devel/include/common/runtime/argparse.h
@@ -4,10 +4,10 @@
 #include "hpy.h"
 
 HPyAPI_RUNTIME_FUNC(int)
-HPyArg_Parse(HPyContext ctx, HPy *args, HPy_ssize_t nargs, const char *fmt, ...);
+HPyArg_Parse(HPyContext ctx, HPyTracker *ht, HPy *args, HPy_ssize_t nargs, const char *fmt, ...);
 
 HPyAPI_RUNTIME_FUNC(int)
-HPyArg_ParseKeywords(HPyContext ctx, HPy *args, HPy_ssize_t nargs, HPy kw,
+HPyArg_ParseKeywords(HPyContext ctx, HPyTracker *ht, HPy *args, HPy_ssize_t nargs, HPy kw,
                      const char *fmt, const char *keywords[], ...);
 
 

--- a/hpy/devel/src/runtime/argparse.c
+++ b/hpy/devel/src/runtime/argparse.c
@@ -32,10 +32,6 @@
  *     must be passed and on successful return HPyTracker_Close must be called
  *     to close any handles that were created.
  *
- * O+ (object) [HPy *]
- *     Returns a new handle. The new handle must be closed if the argument
- *     parsing returns successfully.
- *
  * Options
  * -------
  *

--- a/hpy/devel/src/runtime/argparse.c
+++ b/hpy/devel/src/runtime/argparse.c
@@ -27,10 +27,14 @@
  * -------
  *
  * O (object) [HPy *]
- *     Returns an handle. When using HPyArg_ParseKeywords, this might retrieve
- *     a new handle from the keywords dictionary, so an HPyTracker pointer
- *     must be passed and on successful return HPyTracker_Close must be called
- *     to close any handles that were created.
+ *     Store a handle pointing to a generic Python object.
+ *
+ *     When using O with HPyArg_ParseKeywords, an HPyTracker is created and
+ *     returned via the parameter `ht`. If HPyArg_ParseKeywords returns
+ *     successfully, you must call HPyTracker_Close on `ht` once the
+ *     returned handles are no longer needed. This will close all the handles
+ *     created during argument parsing. There is no need to call
+ *     `HPyTracker_Close` on failure -- the argument parser does this for you.
  *
  * Options
  * -------

--- a/proof-of-concept/pof.c
+++ b/proof-of-concept/pof.c
@@ -16,7 +16,7 @@ HPyDef_METH(add_ints, "add_ints", add_ints_impl, HPyFunc_VARARGS)
 static HPy add_ints_impl(HPyContext ctx, HPy self, HPy *args, HPy_ssize_t nargs)
 {
     long a, b;
-    if (!HPyArg_Parse(ctx, args, nargs, "ll", &a, &b))
+    if (!HPyArg_Parse(ctx, NULL, args, nargs, "ll", &a, &b))
         return HPy_NULL;
     return HPyLong_FromLong(ctx, a+b);
 }
@@ -27,7 +27,7 @@ static HPy add_ints_kw_impl(HPyContext ctx, HPy self, HPy *args, HPy_ssize_t nar
 {
     long a, b;
     const char* kwlist[] = {"a", "b", NULL};
-    if (!HPyArg_ParseKeywords(ctx, args, nargs, kw, "ll", kwlist, &a, &b))
+    if (!HPyArg_ParseKeywords(ctx, NULL, args, nargs, kw, "ll", kwlist, &a, &b))
         return HPy_NULL;
     return HPyLong_FromLong(ctx, a+b);
 }
@@ -44,7 +44,7 @@ static HPy Point_new_impl (HPyContext ctx, HPy cls, HPy *args,
 {
     // FIXME: we should use double, but HPyArg_Parse does not support "d" yet
     long x, y;
-    if (!HPyArg_Parse(ctx, args, nargs, "ll", &x, &y))
+    if (!HPyArg_Parse(ctx, NULL, args, nargs, "ll", &x, &y))
         return HPy_NULL;
     HPy_Point *point;
     HPy h_point = HPy_New(ctx, cls, &point);

--- a/test/test_argparse.py
+++ b/test/test_argparse.py
@@ -17,7 +17,7 @@ class TestParseItem(HPyTest):
                               HPy *args, HPy_ssize_t nargs)
             {{
                 {type} a;
-                if (!HPyArg_Parse(ctx, args, nargs, "{fmt}", &a))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "{fmt}", &a))
                     return HPy_NULL;
                 return {hpy_converter}(ctx, a);
             }}
@@ -61,7 +61,7 @@ class TestArgParse(HPyTest):
                 HPy a;
                 HPy b = HPy_NULL;
                 HPy res;
-                if (!HPyArg_Parse(ctx, args, nargs, "{fmt}", &a, &b))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "{fmt}", &a, &b))
                     return HPy_NULL;
                 if (HPy_IsNull(b)) {{
                     b = HPyLong_FromLong(ctx, 5);
@@ -84,7 +84,7 @@ class TestArgParse(HPyTest):
                               HPy *args, HPy_ssize_t nargs)
             {
                 long a, b, c, d, e;
-                if (!HPyArg_Parse(ctx, args, nargs, "lllll",
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "lllll",
                                   &a, &b, &c, &d, &e))
                     return HPy_NULL;
                 return HPyLong_FromLong(ctx,
@@ -102,7 +102,7 @@ class TestArgParse(HPyTest):
                               HPy *args, HPy_ssize_t nargs)
             {
                 HPy a, b;
-                if (!HPyArg_Parse(ctx, args, nargs, "OO", &a, &b))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "OO", &a, &b))
                     return HPy_NULL;
                 return HPy_Add(ctx, a, b);
             }
@@ -173,12 +173,16 @@ class TestArgParseKeywords(HPyTest):
             static HPy f_impl(HPyContext ctx, HPy self,
                               HPy *args, HPy_ssize_t nargs, HPy kw)
             {{
-                HPy a, b;
+                HPy a, b, result;
+                HPyTracker ht;
                 static const char *kwlist[] = {{ "a", "b", NULL }};
-                if (!HPyArg_ParseKeywords(ctx, args, nargs, kw, "{fmt}",
-                                          kwlist, &a, &b))
+                if (!HPyArg_ParseKeywords(ctx, &ht, args, nargs, kw, "{fmt}",
+                                          kwlist, &a, &b)) {{
                     return HPy_NULL;
-                return HPy_Add(ctx, a, b);
+                }}
+                result = HPy_Add(ctx, a, b);
+                HPyTracker_Close(ctx, ht);
+                return result;
             }}
             @EXPORT(f)
             @INIT
@@ -186,7 +190,7 @@ class TestArgParseKeywords(HPyTest):
         return mod
 
     def test_handle_two_arguments(self):
-        mod = self.make_two_arg_add("O+O+")
+        mod = self.make_two_arg_add("OO")
         assert mod.f("x", b="y") == "xy"
 
     def test_handle_reordered_arguments(self):
@@ -195,11 +199,15 @@ class TestArgParseKeywords(HPyTest):
             static HPy f_impl(HPyContext ctx, HPy self,
                               HPy *args, HPy_ssize_t nargs, HPy kw)
             {
-                HPy a, b;
+                HPy a, b, result;
+                HPyTracker ht;
                 static const char *kwlist[] = { "a", "b", NULL };
-                if (!HPyArg_ParseKeywords(ctx, args, nargs, kw, "O+O+", kwlist, &a, &b))
+                if (!HPyArg_ParseKeywords(ctx, &ht, args, nargs, kw, "OO", kwlist, &a, &b)) {
                     return HPy_NULL;
-                return HPy_Add(ctx, a, b);
+                }
+                result = HPy_Add(ctx, a, b);
+                HPyTracker_Close(ctx, ht);
+                return result;
             }
             @EXPORT(f)
             @INIT
@@ -214,16 +222,18 @@ class TestArgParseKeywords(HPyTest):
             {
                 HPy a;
                 HPy b = HPy_NULL;
+                HPyTracker ht;
                 HPy res;
                 static const char *kwlist[] = { "a", "b", NULL };
-                if (!HPyArg_ParseKeywords(ctx, args, nargs, kw, "O+|O+", kwlist, &a, &b))
+                if (!HPyArg_ParseKeywords(ctx, &ht, args, nargs, kw, "O|O", kwlist, &a, &b)) {
                     return HPy_NULL;
-                if (HPy_IsNull(b)) {{
+                }
+                if (HPy_IsNull(b)) {
                     b = HPyLong_FromLong(ctx, 5);
-                }}
+                    HPyTracker_Add(ctx, ht, b);
+                }
                 res = HPy_Add(ctx, a, b);
-                HPy_Close(ctx, a);
-                HPy_Close(ctx, b);
+                HPyTracker_Close(ctx, ht);
                 return res;
             }
             @EXPORT(f)
@@ -243,21 +253,21 @@ class TestArgParseKeywords(HPyTest):
 
     def test_missing_required_argument(self):
         import pytest
-        mod = self.make_two_arg_add(fmt="O+O+:add_two")
+        mod = self.make_two_arg_add(fmt="OO:add_two")
         with pytest.raises(TypeError) as exc:
             mod.f(1)
         assert str(exc.value) == "add_two() no value for required argument"
 
     def test_mismatched_args_too_few_keywords(self):
         import pytest
-        mod = self.make_two_arg_add(fmt="O+O+O+:add_two")
+        mod = self.make_two_arg_add(fmt="OOO:add_two")
         with pytest.raises(TypeError) as exc:
             mod.f(1, 2)
         assert str(exc.value) == "add_two() mismatched args (too few keywords for fmt)"
 
     def test_mismatched_args_too_many_keywords(self):
         import pytest
-        mod = self.make_two_arg_add(fmt="O+:add_two")
+        mod = self.make_two_arg_add(fmt="O:add_two")
         with pytest.raises(TypeError) as exc:
             mod.f(1, 2)
         assert str(exc.value) == "add_two() mismatched args (too many keywords for fmt)"
@@ -269,9 +279,9 @@ class TestArgParseKeywords(HPyTest):
             static HPy f_impl(HPyContext ctx, HPy self,
                               HPy *args, HPy_ssize_t nargs, HPy kw)
             {
-                HPy a, b, c;
+                long a, b, c;
                 static const char *kwlist[] = { "", "b", "", NULL };
-                if (!HPyArg_ParseKeywords(ctx, args, nargs, kw, "NNN", kwlist,
+                if (!HPyArg_ParseKeywords(ctx, NULL, args, nargs, kw, "lll", kwlist,
                                           &a, &b, &c))
                     return HPy_NULL;
                 return HPy_Dup(ctx, ctx->h_None);
@@ -292,17 +302,18 @@ class TestArgParseKeywords(HPyTest):
             {
                 HPy a;
                 HPy b = HPy_NULL;
+                HPyTracker ht;
                 HPy res;
                 static const char *kwlist[] = { "", "b", NULL };
-                if (!HPyArg_ParseKeywords(ctx, args, nargs, kw, "O+|O+", kwlist, &a, &b))
+                if (!HPyArg_ParseKeywords(ctx, &ht, args, nargs, kw, "O|O", kwlist, &a, &b)) {
                     return HPy_NULL;
+                }
                 if (HPy_IsNull(b)) {
                     b = HPyLong_FromLong(ctx, 5);
-                } else {
-                    b = HPy_Dup(ctx, b);
+                    HPyTracker_Add(ctx, ht, b);
                 }
                 res = HPy_Add(ctx, a, b);
-                HPy_Close(ctx, b);
+                HPyTracker_Close(ctx, ht);
                 return res;
             }
             @EXPORT(f)
@@ -317,7 +328,7 @@ class TestArgParseKeywords(HPyTest):
 
     def test_keyword_only_argument(self):
         import pytest
-        mod = self.make_two_arg_add(fmt="O+$O+")
+        mod = self.make_two_arg_add(fmt="O$O")
         assert mod.f(1, b=2) == 3
         assert mod.f(a=1, b=2) == 3
         with pytest.raises(TypeError) as exc:
@@ -327,21 +338,21 @@ class TestArgParseKeywords(HPyTest):
 
     def test_error_default_message(self):
         import pytest
-        mod = self.make_two_arg_add(fmt="O+O+O+")
+        mod = self.make_two_arg_add(fmt="OOO")
         with pytest.raises(TypeError) as exc:
             mod.f(1, 2)
         assert str(exc.value) == "function mismatched args (too few keywords for fmt)"
 
     def test_error_with_function_name(self):
         import pytest
-        mod = self.make_two_arg_add(fmt="O+O+O+:my_func")
+        mod = self.make_two_arg_add(fmt="OOO:my_func")
         with pytest.raises(TypeError) as exc:
             mod.f(1, 2)
         assert str(exc.value) == "my_func() mismatched args (too few keywords for fmt)"
 
     def test_error_with_overridden_message(self):
         import pytest
-        mod = self.make_two_arg_add(fmt="O+O+O+;my-error-message")
+        mod = self.make_two_arg_add(fmt="OOO;my-error-message")
         with pytest.raises(TypeError) as exc:
             mod.f(1, 2)
         assert str(exc.value) == "my-error-message"

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -271,7 +271,7 @@ class TestBasic(HPyTest):
             static HPy h_impl(HPyContext ctx, HPy self, HPy *args, HPy_ssize_t nargs)
             {
                 long a, b;
-                if (!HPyArg_Parse(ctx, args, nargs, "ll", &a, &b))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "ll", &a, &b))
                     return HPy_NULL;
                 return HPyLong_FromLong(ctx, 10*a + b);
             }
@@ -281,7 +281,7 @@ class TestBasic(HPyTest):
             {
                 long a, b;
                 static const char *kwlist[] = { "a", "b", NULL };
-                if (!HPyArg_ParseKeywords(ctx, args, nargs, kw, "ll", kwlist, &a, &b))
+                if (!HPyArg_ParseKeywords(ctx, NULL, args, nargs, kw, "ll", kwlist, &a, &b))
                     return HPy_NULL;
                 return HPyLong_FromLong(ctx, 10*a + b);
             }

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -32,7 +32,7 @@ class PointTemplate(DefaultExtensionTemplate):
                                       HPy_ssize_t nargs, HPy kw)
             {
                 long x, y;
-                if (!HPyArg_Parse(ctx, args, nargs, "ll", &x, &y))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "ll", &x, &y))
                     return HPy_NULL;
                 PointObject *point;
                 HPy h_point = HPy_New(ctx, cls, &point);

--- a/test/test_number.py
+++ b/test/test_number.py
@@ -56,7 +56,7 @@ class TestNumber(HPyTest):
                                   HPy *args, HPy_ssize_t nargs)
                 {
                     HPy a, b;
-                    if (!HPyArg_Parse(ctx, args, nargs, "OO", &a, &b))
+                    if (!HPyArg_Parse(ctx, NULL, args, nargs, "OO", &a, &b))
                         return HPy_NULL;
                     return HPy_%s(ctx, a, b);
                 }
@@ -73,7 +73,7 @@ class TestNumber(HPyTest):
                               HPy *args, HPy_ssize_t nargs)
             {
                 HPy a, b, c;
-                if (!HPyArg_Parse(ctx, args, nargs, "OOO", &a, &b, &c))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "OOO", &a, &b, &c))
                     return HPy_NULL;
                 return HPy_Power(ctx, a, b, c);
             }
@@ -95,7 +95,7 @@ class TestNumber(HPyTest):
                               HPy *args, HPy_ssize_t nargs)
             {
                 HPy a, b;
-                if (!HPyArg_Parse(ctx, args, nargs, "OO", &a, &b))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "OO", &a, &b))
                     return HPy_NULL;
                 return HPy_MatrixMultiply(ctx, a, b);
             }
@@ -125,7 +125,7 @@ class TestNumber(HPyTest):
                                   HPy *args, HPy_ssize_t nargs)
                 {
                     HPy a, b;
-                    if (!HPyArg_Parse(ctx, args, nargs, "OO", &a, &b))
+                    if (!HPyArg_Parse(ctx, NULL, args, nargs, "OO", &a, &b))
                         return HPy_NULL;
                     return HPy_InPlace%s(ctx, a, b);
                 }
@@ -145,7 +145,7 @@ class TestNumber(HPyTest):
                               HPy *args, HPy_ssize_t nargs)
             {
                 HPy a, b, c;
-                if (!HPyArg_Parse(ctx, args, nargs, "OOO", &a, &b, &c))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "OOO", &a, &b, &c))
                     return HPy_NULL;
                 return HPy_InPlacePower(ctx, a, b, c);
             }
@@ -174,7 +174,7 @@ class TestNumber(HPyTest):
                               HPy *args, HPy_ssize_t nargs)
             {
                 HPy a, b;
-                if (!HPyArg_Parse(ctx, args, nargs, "OO", &a, &b))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "OO", &a, &b))
                     return HPy_NULL;
                 return HPy_InPlaceMatrixMultiply(ctx, a, b);
             }

--- a/test/test_slots.py
+++ b/test/test_slots.py
@@ -16,7 +16,7 @@ class TestSlots(HPyTest):
                                        HPy_ssize_t nargs, HPy kw)
             {
                 long x, y;
-                if (!HPyArg_Parse(ctx, args, nargs, "ll", &x, &y))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "ll", &x, &y))
                     return -1;
 
                 PointObject *p = HPy_CAST(ctx, PointObject, self);

--- a/test/test_tracker.py
+++ b/test/test_tracker.py
@@ -10,7 +10,7 @@ from .support import HPyTest
 
 
 class TestHPyTracker(HPyTest):
-    def hpytracker_module(self, ops, new="HPyTracker_New(ctx, 0)"):
+    def hpytracker_module(self, ops, size=0):
         return self.make_module("""
             HPyDef_METH(f, "f", f_impl, HPyFunc_VARARGS)
             static HPy f_impl(HPyContext ctx, HPy self,
@@ -18,7 +18,7 @@ class TestHPyTracker(HPyTest):
             {{
                 HPyTracker ht;
                 HPy result = HPy_NULL;
-                ht = {new};
+                ht = HPyTracker_New(ctx, {size});
                 if HPy_IsNull(ht) {{
                     return HPy_NULL;
                 }}
@@ -30,15 +30,14 @@ class TestHPyTracker(HPyTest):
             }}
             @EXPORT(f)
             @INIT
-        """.format(ops=ops, new=new))
+        """.format(ops=ops, size=size))
 
     def test_new_and_free(self):
         mod = self.hpytracker_module(ops="")
         mod.f()
 
     def test_new_with_size_and_free(self):
-        mod = self.hpytracker_module(
-            ops="", new="HPyTracker_New(ctx, 10)")
+        mod = self.hpytracker_module(ops="", size=10)
         mod.f()
 
     def test_add_and_free(self):
@@ -73,7 +72,7 @@ class TestHPyTracker(HPyTest):
                 HPy key, value;
                 HPyTracker ht;
 
-                if (!HPyArg_Parse(ctx, args, nargs, "l|l", &n, &n_err))
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "l|l", &n, &n_err))
                     return HPy_NULL;
 
                 ht = HPyTracker_New(ctx, 0);  // track key-value pairs


### PR DESCRIPTION
Adds an optional `HPyTracker *ht` argument to both `HPyArg_Parse` and `HPyArg_ParseKeywords`. One can pass `NULL` if the tracker is not needed.

* Both `HPyArg_Parse` and `HPyArg_ParseKeywords` create the tracker if `ht` is not `NULL`.
* `HPyArg_Parse` currently doesn't use the tracker itself, but it still creates one if requested. The idea is that we will need tracking for other format types that create temporary storage in the future.
* `HPyArg_ParseKeywords` doesn't require a tracker unless `O` is used as a format, in which case it raises an error and complains that a tracker is required in this case.
* `O+` is gone, and `O` now calls `HPy_Dup(current_arg)` and `HPyTracker_Add(ctx, ht, output)` when `current_arg` needs to be dup'ed (i.e. when called by `HPyArg_ParseKeywords`).

This replaces the argument parsing portions of #75. #116 removes `HPyDict_GetItem` and `HPyDict_SetItem`.