### PR TITLE
Move HPyErr_ tests into test_hpyerr.

### DIFF
--- a/test/test_argparse.py
+++ b/test/test_argparse.py
@@ -41,9 +41,8 @@ class TestParseItem(HPyTest):
         mod = self.make_parse_item("d", "double", "HPyFloat_FromDouble")
         assert mod.f(1.) == 1.
         assert mod.f(-2) == -2.
-        with pytest.raises(TypeError) as err:
+        with pytest.raises(TypeError):
             mod.f("x")
-        assert str(err.value) == "must be real number, not str"
 
     def test_O(self):
         mod = self.make_parse_item("O", "HPy", "HPy_Dup")

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -164,46 +164,7 @@ class TestBasic(HPyTest):
             mod.f(20)
         assert str(exc.value) == 'hello world'
 
-    def test_exception_occurred(self):
-        import pytest
-        mod = self.make_module("""
-            HPyDef_METH(f, "f", f_impl, HPyFunc_O)
-            static HPy f_impl(HPyContext ctx, HPy self, HPy arg)
-            {
-                HPyLong_AsLong(ctx, arg);
-                if (HPyErr_Occurred(ctx)) {
-                    HPyErr_SetString(ctx, ctx->h_ValueError, "hello world");
-                    return HPy_NULL;
-                }
-                return HPyLong_FromLong(ctx, -1002);
-            }
-            @EXPORT(f)
-            @INIT
-        """)
-        assert mod.f(-10) == -1002
-        with pytest.raises(ValueError) as exc:
-            mod.f("not an integer")
-        assert str(exc.value) == 'hello world'
-
-    def test_exception_cleared(self):
-        import pytest
-        import sys
-        mod = self.make_module("""
-            HPyDef_METH(f, "f", f_impl, HPyFunc_NOARGS)
-            static HPy f_impl(HPyContext ctx, HPy self)
-            {
-                HPyErr_SetString(ctx, ctx->h_ValueError, "hello world");
-                HPyErr_Clear(ctx);
-                return HPy_Dup(ctx, ctx->h_None);
-            }
-            @EXPORT(f)
-            @INIT
-        """)
-        assert mod.f() is None
-        assert sys.exc_info() == (None, None, None)
-
     def test_builtin_handles(self):
-        import pytest
         mod = self.make_module("""
             HPyDef_METH(f, "f", f_impl, HPyFunc_O)
             static HPy f_impl(HPyContext ctx, HPy self, HPy arg)

--- a/test/test_hpyerr.py
+++ b/test/test_hpyerr.py
@@ -32,3 +32,40 @@ class TestErr(HPyTest):
         """)
         # Calling mod.f() gives a fatal error, ending in abort().
         # How to check that?  For now we just check that the above compiles
+
+    def test_HPyErr_Occurred(self):
+        import pytest
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", f_impl, HPyFunc_O)
+            static HPy f_impl(HPyContext ctx, HPy self, HPy arg)
+            {
+                HPyLong_AsLong(ctx, arg);
+                if (HPyErr_Occurred(ctx)) {
+                    HPyErr_SetString(ctx, ctx->h_ValueError, "hello world");
+                    return HPy_NULL;
+                }
+                return HPyLong_FromLong(ctx, -1002);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f(-10) == -1002
+        with pytest.raises(ValueError) as exc:
+            mod.f("not an integer")
+        assert str(exc.value) == 'hello world'
+
+    def test_HPyErr_Cleared(self):
+        import sys
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", f_impl, HPyFunc_NOARGS)
+            static HPy f_impl(HPyContext ctx, HPy self)
+            {
+                HPyErr_SetString(ctx, ctx->h_ValueError, "hello world");
+                HPyErr_Clear(ctx);
+                return HPy_Dup(ctx, ctx->h_None);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f() is None
+        assert sys.exc_info() == (None, None, None)


### PR DESCRIPTION
Seems only logical. :)

This PR also removes an argparse exception message test raised when trying to parse a non-double argument as a double. The error message is different on PyPy and possibly other implementations, which makes testing there harder.