### PR TITLE
Add tests for converting objects with __int__ and __index__ to integers.

### DIFF
--- a/test/test_hpylong.py
+++ b/test/test_hpylong.py
@@ -21,6 +21,15 @@ class TestLong(HPyTest):
                 return v
         return MagicIndex()
 
+    def python_supports_magic_index(self):
+        """ Return True if the Python version is 3.8 or later and thus
+            should support calling __index__ in the various HPyLong_As...
+            methods.
+        """
+        import sys
+        vi = sys.version_info
+        return (vi.major > 3 or (vi.major == 3 and vi.minor >= 8))
+
     def test_Long_FromLong(self):
         mod = self.make_module("""
             HPyDef_METH(f, "f", f_impl, HPyFunc_NOARGS)
@@ -52,7 +61,8 @@ class TestLong(HPyTest):
         with pytest.raises(TypeError):
             mod.f("this is not a number")
         assert mod.f(self.magic_int(2)) == 4
-        assert mod.f(self.magic_index(2)) == 4
+        if self.python_supports_magic_index():
+            assert mod.f(self.magic_index(2)) == 4
 
     def test_Long_FromUnsignedLong(self):
         mod = self.make_module("""
@@ -110,7 +120,8 @@ class TestLong(HPyTest):
         with pytest.raises(TypeError):
             mod.f("this is not a number")
         assert mod.f(self.magic_int(2)) == 2
-        assert mod.f(self.magic_index(2)) == 2
+        if self.python_supports_magic_index():
+            assert mod.f(self.magic_index(2)) == 2
 
     def test_Long_FromLongLong(self):
         mod = self.make_module("""
@@ -145,7 +156,8 @@ class TestLong(HPyTest):
         with pytest.raises(TypeError):
             mod.f("this is not a number")
         assert mod.f(self.magic_int(2)) == 2
-        assert mod.f(self.magic_index(2)) == 2
+        if self.python_supports_magic_index():
+            assert mod.f(self.magic_index(2)) == 2
 
     def test_Long_FromUnsignedLongLong(self):
         mod = self.make_module("""
@@ -204,7 +216,8 @@ class TestLong(HPyTest):
         with pytest.raises(TypeError):
             mod.f("this is not a number")
         assert mod.f(self.magic_int(2)) == 2
-        assert mod.f(self.magic_index(2)) == 2
+        if self.python_supports_magic_index():
+            assert mod.f(self.magic_index(2)) == 2
 
     def test_Long_FromSize_t(self):
         mod = self.make_module("""

--- a/test/test_hpylong.py
+++ b/test/test_hpylong.py
@@ -3,6 +3,24 @@ from .support import HPyTest
 
 class TestLong(HPyTest):
 
+    def magic_int(self, v):
+        """ Return an instance of a class that implements __int__
+            and returns value v.
+        """
+        class MagicInt(object):
+            def __int__(self):
+                return v
+        return MagicInt()
+
+    def magic_index(self, v):
+        """ Return an instance of a class that implements __index__
+            and returns value v.
+        """
+        class MagicIndex(object):
+            def __index__(self):
+                return v
+        return MagicIndex()
+
     def test_Long_FromLong(self):
         mod = self.make_module("""
             HPyDef_METH(f, "f", f_impl, HPyFunc_NOARGS)
@@ -33,6 +51,8 @@ class TestLong(HPyTest):
         assert mod.f(45) == 90
         with pytest.raises(TypeError):
             mod.f("this is not a number")
+        assert mod.f(self.magic_int(2)) == 4
+        assert mod.f(self.magic_index(2)) == 4
 
     def test_Long_FromUnsignedLong(self):
         mod = self.make_module("""
@@ -66,6 +86,10 @@ class TestLong(HPyTest):
             mod.f(-91)
         with pytest.raises(TypeError):
             mod.f("this is not a number")
+        with pytest.raises(TypeError):
+            mod.f(self.magic_int(2))
+        with pytest.raises(TypeError):
+            mod.f(self.magic_index(2))
 
     def test_Long_AsUnsignedLongMask(self):
         import pytest
@@ -85,6 +109,8 @@ class TestLong(HPyTest):
         assert mod.f(-1) == 2**64 - 1
         with pytest.raises(TypeError):
             mod.f("this is not a number")
+        assert mod.f(self.magic_int(2)) == 2
+        assert mod.f(self.magic_index(2)) == 2
 
     def test_Long_FromLongLong(self):
         mod = self.make_module("""
@@ -118,6 +144,8 @@ class TestLong(HPyTest):
         assert mod.f(-2147483648) == -2147483648
         with pytest.raises(TypeError):
             mod.f("this is not a number")
+        assert mod.f(self.magic_int(2)) == 2
+        assert mod.f(self.magic_index(2)) == 2
 
     def test_Long_FromUnsignedLongLong(self):
         mod = self.make_module("""
@@ -152,6 +180,10 @@ class TestLong(HPyTest):
             mod.f(-4294967296)
         with pytest.raises(TypeError):
             mod.f("this is not a number")
+        with pytest.raises(TypeError):
+            mod.f(self.magic_int(2))
+        with pytest.raises(TypeError):
+            mod.f(self.magic_index(2))
 
     def test_Long_AsUnsignedLongLongMask(self):
         import pytest
@@ -171,6 +203,8 @@ class TestLong(HPyTest):
         assert mod.f(-1) == 2**64 - 1
         with pytest.raises(TypeError):
             mod.f("this is not a number")
+        assert mod.f(self.magic_int(2)) == 2
+        assert mod.f(self.magic_index(2)) == 2
 
     def test_Long_FromSize_t(self):
         mod = self.make_module("""
@@ -205,6 +239,10 @@ class TestLong(HPyTest):
             mod.f(-2147483648)
         with pytest.raises(TypeError):
             mod.f("this is not a number")
+        with pytest.raises(TypeError):
+            mod.f(self.magic_int(2))
+        with pytest.raises(TypeError):
+            mod.f(self.magic_index(2))
 
     def test_Long_FromSsize_t(self):
         mod = self.make_module("""
@@ -241,3 +279,7 @@ class TestLong(HPyTest):
         assert mod.f(-41) == -41
         with pytest.raises(TypeError):
             mod.f("this is not a number")
+        with pytest.raises(TypeError):
+            mod.f(self.magic_int(2))
+        with pytest.raises(TypeError):
+            mod.f(self.magic_index(2))


### PR DESCRIPTION
Note that support for `__int__` in these methods is deprecated since Python 3.8. Since deprecated is not the same as gone, I've kept the tests for them, even though they display the deprecation warnings.

We could suppress the warnings, but I'm not sure PyPy's pytest supports that feature.