### PR TITLE
Replace usage of a deprecated setting in infer with the new one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ cppcheck: cppcheck-build-dir
 
 infer:
 	python3 setup.py build_ext -if -U NDEBUG | compiledb
-	@infer --fail-on-bug --compilation-database compile_commands.json
+	@infer --fail-on-issue --compilation-database compile_commands.json
 
 valgrind:
 	PYTHONMALLOC=malloc valgrind --suppressions=hpy/tools/valgrind/python.supp --suppressions=hpy/tools/valgrind/hpy.supp --leak-check=full --show-leak-kinds=definite,indirect --log-file=/tmp/valgrind-output python -m pytest --valgrind --valgrind-log=/tmp/valgrind-output test/


### PR DESCRIPTION
This avoids the following warning:
`WARNING: '--fail-on-bug' is deprecated. Use '--fail-on-issue' instead.`