### PR TITLE
Preserve the process environment in the subprocess Python call in the HPy_FatalError test.

### DIFF
--- a/test/test_hpyerr.py
+++ b/test/test_hpyerr.py
@@ -41,12 +41,12 @@ class TestErr(HPyTest):
             return
         # subprocess is not importable in pypy app-level tests
         import subprocess
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.path.dirname(mod.__file__)
         result = subprocess.run([
             sys.executable,
             "-c", "import {} as mod; mod.f()".format(mod.__name__)
-        ], env={
-            "PYTHONPATH": os.path.dirname(mod.__file__),
-        }, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        ], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         assert result.returncode == -6
         assert result.stdout == b""
         assert result.stderr.startswith(b"Fatal Python error: boom!\n")


### PR DESCRIPTION
The test works without this in simple cases (e.g. current HPy tests on CPython) but fails in more complex cases (e.g. pypy translated tests). Preserving the environment as part of the call is probably a good idea regardless.