### PR TITLE
Add a .translate(...) wrapper to HPyExtensionName.

### DIFF
--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -134,6 +134,10 @@ class HPyExtensionName(str):
         result = str.split(self, *args, **kw)
         return [self.__class__(s) for s in result]
 
+    def translate(self, *args, **kw):
+        result = str.translate(self, *args, **kw)
+        return self.__class__(result)
+
 
 def is_hpy_extension(ext_name):
     """ Return True if the extension name is for an HPy extension. """


### PR DESCRIPTION
The `.translate(...)` method is used by the version of distutils shipped with Python 2.7, and PyPy's app-level tests run the compilation under 2.7, so we need to support that here.

See https://foss.heptapod.net/pypy/pypy/-/merge_requests/783#note_149515 for where this was discovered.