### PR TITLE
Add simple detection of missed HPy extension names for the common case when there are only HPy extensions

### DIFF
--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -150,6 +150,14 @@ def remember_hpy_extension(f):
     """
     @functools.wraps(f)
     def wrapper(self, ext_name):
+        if self._only_hpy_extensions:
+            assert is_hpy_extension(ext_name), (
+                "Extension name %r is not marked as an HPyExtensionName"
+                " but only HPy extensions are present. This is almost"
+                " certainly a bug in HPy's overriding of setuptools"
+                " build_ext. Please report this error the HPy maintainers."
+                % (ext_name,)
+            )
         result = f(self, ext_name)
         if is_hpy_extension(ext_name):
             result = HPyExtensionName(result)
@@ -199,6 +207,7 @@ class build_hpy_ext_mixin:
 
     def finalize_options(self):
         self._extensions = self.distribution.ext_modules or []
+        self._only_hpy_extensions = not bool(self._extensions)
         hpy_ext_modules = self.distribution.hpy_ext_modules or []
         for ext in hpy_ext_modules:
             self._finalize_hpy_ext(ext)

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -207,6 +207,9 @@ class build_hpy_ext_mixin:
 
     def finalize_options(self):
         self._extensions = self.distribution.ext_modules or []
+        # _only_hpy_extensions is used only as a sanity check that no
+        # hpy extensions are misidentified as legacy C API extensions in the
+        # case where only hpy extensions are present.
         self._only_hpy_extensions = not bool(self._extensions)
         hpy_ext_modules = self.distribution.hpy_ext_modules or []
         for ext in hpy_ext_modules:


### PR DESCRIPTION
We'd like to catch issues in the HPy extension name detection and raise good error messages rather than end up with obscure bugs.

See #134 for where `.translate(...)` was added. We almost missed spotting that case in PyPy and there might be others lurking out there in other versions of setuptools / distutils.