### PR TITLE
Fix ctx_sources docstring that says the opposite of what it should.

### DIFF
--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -38,7 +38,7 @@ class HPyDevel:
         ]))
 
     def get_ctx_sources(self):
-        """ Extra sources needed only in Universal mode.
+        """ Extra sources needed only in the CPython ABI mode.
         """
         return list(map(str, self.src_dir.glob('ctx_*.c')))
 


### PR DESCRIPTION
Reported in #145.