### PR TITLE
Install cppcheck via apt.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ cppcheck-build-dir:
 	mkdir -p $(or ${CPPCHECK_BUILD_DIR}, .cppcheck)
 
 cppcheck: cppcheck-build-dir
-	cppcheck --error-exitcode=1 --cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) --enable=warning,performance,portability,information,unusedFunction,missingInclude --report-progress -I hpy/devel/include/ -I hpy/devel/include/common/ -I hpy/devel/include/cpython/ -I hpy/devel/include/universal/ -I hpy/universal/src/ --suppress=nullPointerRedundantCheck --force -D NULL=0 .
+	cppcheck --error-exitcode=1 --cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) --enable=warning,performance,portability,information,missingInclude --report-progress -I hpy/devel/include/ -I hpy/devel/include/common/ -I hpy/devel/include/cpython/ -I hpy/devel/include/universal/ -I hpy/universal/src/ --force -D NULL=0 .
 
 infer:
 	python3 setup.py build_ext -if -U NDEBUG | compiledb

--- a/azure-templates/cppcheck.yml
+++ b/azure-templates/cppcheck.yml
@@ -14,7 +14,7 @@ steps:
   - script: echo "##vso[task.setvariable variable=CPPCHECK_BUILD_DIR]${{ parameters.CPPCHECK_BUILD_DIR }}"
     displayName: Set CPPCHECK_BUILD_DIR to ${{ parameters.CPPCHECK_BUILD_DIR }}
 
-  - script: sudo snap install cppcheck --channel=latest/edge
+  - script: sudo apt update && sudo apt install -y cppcheck
     displayName: Install CPPCheck
 
   - task: Cache@2


### PR DESCRIPTION
Unfortunately the cppcheck snap has broken again. This time it is just completely gone from snapcraft.io. Given that we have limited time to spend fixing build issues, I think it's an okay trade-off to get older less comprehensive cppcheck tests in favour of not having to fix the installation of cppcheck every month. Maybe in awhile the Ubuntu repositories will get a newer version of cppcheck.

See #131 and #132 for previous issues.