### PR TITLE
Use the debug mode in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ cppcheck: cppcheck-build-dir
 		--cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) \
 		--output-file=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck)/output.txt \
 		--enable=warning,performance,portability,information,missingInclude \
+		--inline-suppr \
 		-I hpy/devel/include/ \
 		-I hpy/devel/include/common/ \
 		-I hpy/devel/include/cpython/ \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ cppcheck-build-dir:
 	mkdir -p $(or ${CPPCHECK_BUILD_DIR}, .cppcheck)
 
 cppcheck: cppcheck-build-dir
-	cppcheck --error-exitcode=1 --cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) --enable=warning,performance,portability,information,missingInclude --report-progress -I hpy/devel/include/ -I hpy/devel/include/common/ -I hpy/devel/include/cpython/ -I hpy/devel/include/universal/ -I hpy/universal/src/ --force -D NULL=0 .
+	cppcheck --error-exitcode=1 --cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) --enable=warning,performance,portability,information,missingInclude -I hpy/devel/include/ -I hpy/devel/include/common/ -I hpy/devel/include/cpython/ -I hpy/devel/include/universal/ -I hpy/universal/src/ --force -D NULL=0 . 2>&1
 
 infer:
 	python3 setup.py build_ext -if -U NDEBUG | compiledb

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ cppcheck: cppcheck-build-dir
 
 infer:
 	python3 setup.py build_ext -if -U NDEBUG | compiledb
+	# see commit cd8cd6e for why we need to ignore debug_ctx.c
 	@infer --fail-on-issue --compilation-database compile_commands.json --report-blacklist-path-regex "hpy/debug/src/debug_ctx.c"
 
 valgrind:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,20 @@ cppcheck-build-dir:
 	mkdir -p $(or ${CPPCHECK_BUILD_DIR}, .cppcheck)
 
 cppcheck: cppcheck-build-dir
-	cppcheck --error-exitcode=1 --cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) --enable=warning,performance,portability,information,missingInclude -I hpy/devel/include/ -I hpy/devel/include/common/ -I hpy/devel/include/cpython/ -I hpy/devel/include/universal/ -I hpy/universal/src/ --force -D NULL=0 . 2>&1
+	# azure pipelines doesn't show stderr, so we write the errors to a file and cat it later :(
+	cppcheck \
+		--error-exitcode=1 \
+		--cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) \
+		--output-file=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck)/output.txt \
+		--enable=warning,performance,portability,information,missingInclude \
+		-I hpy/devel/include/ \
+		-I hpy/devel/include/common/ \
+		-I hpy/devel/include/cpython/ \
+		-I hpy/devel/include/universal/ \
+		-I hpy/universal/src/ \
+		--force \
+		-D NULL=0 \
+		. || (cat $(or ${CPPCHECK_BUILD_DIR}, .cppcheck)/output.txt && false)
 
 infer:
 	python3 setup.py build_ext -if -U NDEBUG | compiledb

--- a/hpy/debug/__init__.py
+++ b/hpy/debug/__init__.py
@@ -1,1 +1,1 @@
-from .leakdetector import HPyError, HPyLeak, LeakDetector
+from .leakdetector import HPyDebugError, HPyLeak, LeakDetector

--- a/hpy/debug/__init__.py
+++ b/hpy/debug/__init__.py
@@ -1,1 +1,1 @@
-from .leakdetector import HPyDebugError, HPyLeak, LeakDetector
+from .leakdetector import HPyDebugError, HPyLeakError, LeakDetector

--- a/hpy/debug/leakdetector.py
+++ b/hpy/debug/leakdetector.py
@@ -1,9 +1,9 @@
 from hpy.universal import _debug
 
-class HPyError(Exception):
+class HPyDebugError(Exception):
     pass
 
-class HPyLeak(HPyError):
+class HPyLeak(HPyDebugError):
     def __init__(self, leaks):
         super().__init__()
         self.leaks = leaks

--- a/hpy/debug/leakdetector.py
+++ b/hpy/debug/leakdetector.py
@@ -3,14 +3,16 @@ from hpy.universal import _debug
 class HPyDebugError(Exception):
     pass
 
-class HPyLeak(HPyDebugError):
+class HPyLeakError(HPyDebugError):
     def __init__(self, leaks):
         super().__init__()
         self.leaks = leaks
 
     def __str__(self):
         lines = []
-        lines.append('%s handles have not been closed properly:' % len(self.leaks))
+        n = len(self.leaks)
+        s = 's' if n > 1 else ''
+        lines.append(f'{n} unclosed handle{s}:')
         for dh in self.leaks:
             lines.append('    %r' % dh)
         return '\n'.join(lines)
@@ -31,7 +33,7 @@ class LeakDetector:
             raise ValueError('LeakDetector not started yet')
         leaks = _debug.get_open_handles(self.generation)
         if leaks:
-            raise HPyLeak(leaks)
+            raise HPyLeakError(leaks)
 
     def __enter__(self):
         self.start()

--- a/hpy/debug/leakdetector.py
+++ b/hpy/debug/leakdetector.py
@@ -11,7 +11,7 @@ class HPyLeakError(HPyDebugError):
     def __str__(self):
         lines = []
         n = len(self.leaks)
-        s = 's' if n > 1 else ''
+        s = 's' if n != 1 else ''
         lines.append(f'{n} unclosed handle{s}:')
         for dh in self.leaks:
             lines.append('    %r' % dh)

--- a/hpy/debug/pytest.py
+++ b/hpy/debug/pytest.py
@@ -1,0 +1,23 @@
+# hpy.debug / pytest integration
+
+import pytest
+from .leakdetector import LeakDetector
+
+# For now "hpy_debug" just does leak detection, but in the future it might
+# grows extra features: that's why it's called generically "hpy_debug" instead
+# of "detect_leaks".
+
+# NOTE: the fixture itself is currently untested :(. It turns out that testing
+# that the fixture raises during the teardown is complicated and probably
+# requires to write a full-fledged plugin. We might want to turn this into a
+# real plugin in the future, but for now I think this is enough.
+
+@pytest.fixture
+def hpy_debug(request):
+    """
+    pytest fixture which makes it possible to control hpy.debug from within a test.
+
+    In particular, it automatically check that the test doesn't leak.
+    """
+    with LeakDetector() as ld:
+        yield ld

--- a/hpy/debug/src/_debugmod.c
+++ b/hpy/debug/src/_debugmod.c
@@ -130,6 +130,7 @@ static UHPy DebugHandle_repr_impl(HPyContext uctx, UHPy self)
     UHPy uh_args = HPy_NULL;
     UHPy uh_result = HPy_NULL;
 
+    // XXX: switch to HPyUnicode_FromFormat when we have it
     uh_fmt = HPyUnicode_FromString(uctx, "<DebugHandle 0x%x for %r>");
     if (HPy_IsNull(uh_fmt))
         goto exit;

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -587,26 +587,6 @@ void debug_ctx_TupleBuilder_Cancel(HPyContext dctx, HPyTupleBuilder builder)
     HPyTupleBuilder_Cancel(get_info(dctx)->uctx, builder);
 }
 
-HPyTracker debug_ctx_Tracker_New(HPyContext dctx, HPy_ssize_t size)
-{
-    return HPyTracker_New(get_info(dctx)->uctx, size);
-}
-
-int debug_ctx_Tracker_Add(HPyContext dctx, HPyTracker ht, DHPy h)
-{
-    return HPyTracker_Add(get_info(dctx)->uctx, ht, DHPy_unwrap(h));
-}
-
-void debug_ctx_Tracker_ForgetAll(HPyContext dctx, HPyTracker ht)
-{
-    HPyTracker_ForgetAll(get_info(dctx)->uctx, ht);
-}
-
-void debug_ctx_Tracker_Close(HPyContext dctx, HPyTracker ht)
-{
-    HPyTracker_Close(get_info(dctx)->uctx, ht);
-}
-
 void debug_ctx_Dump(HPyContext dctx, DHPy h)
 {
     _HPy_Dump(get_info(dctx)->uctx, DHPy_unwrap(h));

--- a/hpy/debug/src/debug_ctx.c
+++ b/hpy/debug/src/debug_ctx.c
@@ -41,6 +41,10 @@ static int debug_ctx_init(HPyContext dctx, HPyContext uctx)
 HPyContext hpy_debug_get_ctx(HPyContext uctx)
 {
     HPyContext dctx = &g_debug_ctx;
+    if (uctx == dctx) {
+        HPy_FatalError(uctx, "hpy_debug_get_ctx: expected an universal ctx, "
+                             "got a debug ctx");
+    }
     if (debug_ctx_init(dctx, uctx) < 0)
         return NULL;
     return dctx;

--- a/hpy/debug/src/debug_ctx.c
+++ b/hpy/debug/src/debug_ctx.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include "debug_internal.h"
 #include "autogen_debug_ctx_init.h"
+#include "common/runtime/ctx_tracker.h"
 
 static struct _HPyContext_s g_debug_ctx = {
     .name = "HPy Debug Mode ABI",
@@ -122,4 +123,63 @@ DHPy debug_ctx_Type_FromSpec(HPyContext dctx, HPyType_Spec *spec, HPyType_SpecPa
         return DHPy_wrap(dctx, HPyType_FromSpec(get_info(dctx)->uctx, spec, uparams));
     }
     return DHPy_wrap(dctx, HPyType_FromSpec(get_info(dctx)->uctx, spec, NULL));
+}
+
+/* ~~~ debug mode implementation of HPyTracker ~~~
+
+   This is a bit special and it's worth explaining what is going on.
+
+   The HPyTracker functions need their own debug mode implementation because
+   the debug moe needs to be aware of when a DHPy is closed, for the same
+   reason for why we need debug_ctx_Close.
+
+   So, in theory here we should have our own implementation of a
+   DebugHPyTracker which manages a growable list of handles, and which calls
+   debug_ctx_Close at the end. But, we ALREADY have the logic available, it's
+   implemented in ctx_tracker.c.
+
+   So, here we simply implement debug_ctx_Tracker_* in terms of ctx_Tracker_*:
+   but note that it's VERY different than what the autogen wrappers do:
+
+     - the autogen wrappers DHPy_unwrap() all the handles before calling the
+       "super" implementation. Here we don't, we pass the DHPys directly.
+
+     - the autogen wrappers pass the uctx to the "super" implementation, here
+       we pass the dctx.
+
+   Conceptually, it is equivalent to just have our own implementation of a
+   growable array, but by using this trick we can easily reuse the existing
+   code.
+
+   It is better understood if you think of what happens on PyPy (or any other
+   universal implementation): normally, on PyPy HPyTracker_Add calls PyPy's
+   own implementation (see interp_tracker.py). But when in debug mode,
+   HPyTracker_Add will call the ctx_Tracker_Add defined in ctx_tracker.c,
+   completely bypassing PyPy's own tracker (which is fine). Incidentally, this
+   also means that if PyPy wants to bundle the debug mode, it also needs to
+   compile ctx_tracker.c
+*/
+
+HPyTracker debug_ctx_Tracker_New(HPyContext dctx, HPy_ssize_t size)
+{
+    return ctx_Tracker_New(dctx, size);
+}
+
+int debug_ctx_Tracker_Add(HPyContext dctx, HPyTracker ht, DHPy dh)
+{
+    return ctx_Tracker_Add(dctx, ht, dh);
+}
+
+void debug_ctx_Tracker_ForgetAll(HPyContext dctx, HPyTracker ht)
+{
+    ctx_Tracker_ForgetAll(dctx, ht);
+}
+
+void debug_ctx_Tracker_Close(HPyContext dctx, HPyTracker ht)
+{
+    // note: ctx_Tracker_Close internally calls HPy_Close() to close each
+    // handle: since we are calling it with the dctx, it will end up calling
+    // debug_ctx_Close, which is exactly what we need to properly record that
+    // the handles were closed.
+    ctx_Tracker_Close(dctx, ht);
 }

--- a/hpy/debug/src/debug_ctx_cpython.c
+++ b/hpy/debug/src/debug_ctx_cpython.c
@@ -71,11 +71,13 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext dctx,
         for (Py_ssize_t i = 0; i < nargs; i++) {
             dh_args[i] = _py2dh(dctx, PyTuple_GET_ITEM(a->args, i));
         }
-        a->result = _dh2py(f(dctx, dh_self, dh_args, nargs));
+        DHPy dh_result = f(dctx, dh_self, dh_args, nargs);
+        a->result = _dh2py(dh_result);
         DHPy_close(dctx, dh_self);
         for (Py_ssize_t i = 0; i < nargs; i++) {
             DHPy_close(dctx, dh_args[i]);
         }
+        DHPy_close(dctx, dh_result);
         return;
     }
     case HPyFunc_KEYWORDS: {

--- a/hpy/debug/src/debug_ctx_cpython.c
+++ b/hpy/debug/src/debug_ctx_cpython.c
@@ -90,12 +90,14 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext dctx,
             dh_args[i] = _py2dh(dctx, PyTuple_GET_ITEM(a->args, i));
         }
         DHPy dh_kw = _py2dh(dctx, a->kw);
-        a->result = _dh2py(f(dctx, dh_self, dh_args, nargs, dh_kw));
+        DHPy dh_result = f(dctx, dh_self, dh_args, nargs, dh_kw);
+        a->result = _dh2py(dh_result);
         DHPy_close(dctx, dh_self);
         for (Py_ssize_t i = 0; i < nargs; i++) {
             DHPy_close(dctx, dh_args[i]);
         }
         DHPy_close(dctx, dh_kw);
+        DHPy_close(dctx, dh_result);
         return;
     }
     case HPyFunc_INITPROC: {

--- a/hpy/debug/src/debug_ctx_cpython.c
+++ b/hpy/debug/src/debug_ctx_cpython.c
@@ -67,7 +67,7 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext dctx,
         _HPyFunc_args_VARARGS *a = (_HPyFunc_args_VARARGS*)args;
         DHPy dh_self = _py2dh(dctx, a->self);
         Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-        DHPy dh_args[nargs * sizeof(DHPy)];
+        DHPy dh_args[nargs * sizeof(DHPy)]; // VLA, should be killed by #157
         for (Py_ssize_t i = 0; i < nargs; i++) {
             dh_args[i] = _py2dh(dctx, PyTuple_GET_ITEM(a->args, i));
         }
@@ -83,7 +83,7 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext dctx,
         _HPyFunc_args_KEYWORDS *a = (_HPyFunc_args_KEYWORDS*)args;
         DHPy dh_self = _py2dh(dctx, a->self);
         Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-        DHPy dh_args[nargs * sizeof(DHPy)];
+        DHPy dh_args[nargs * sizeof(DHPy)]; // VLA, should be killed by #157
         for (Py_ssize_t i = 0; i < nargs; i++) {
             dh_args[i] = _py2dh(dctx, PyTuple_GET_ITEM(a->args, i));
         }
@@ -101,7 +101,7 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext dctx,
         _HPyFunc_args_INITPROC *a = (_HPyFunc_args_INITPROC*)args;
         DHPy dh_self = _py2dh(dctx, a->self);
         Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-        DHPy dh_args[nargs * sizeof(DHPy)];
+        DHPy dh_args[nargs * sizeof(DHPy)]; // VLA, should be killed by #157
         for (Py_ssize_t i = 0; i < nargs; i++) {
             dh_args[i] = _py2dh(dctx, PyTuple_GET_ITEM(a->args, i));
         }

--- a/hpy/debug/src/include/hpy_debug.h
+++ b/hpy/debug/src/include/hpy_debug.h
@@ -3,7 +3,28 @@
 
 #include "hpy.h"
 
-HPyContext hpy_debug_get_ctx(HPyContext original_ctx);
+/*
+  This is the main public API for the debug mode, and it's meant to be used
+  by hpy.universal implementations (including but not limited to the
+  CPython's version of hpy.universal which is included in this repo).
+
+  The idea is that for every uctx there is a corresponding unique dctx which
+  wraps it.
+
+  If you call hpy_debug_get_ctx twice on the same uctx, you get the same
+  result.
+
+  IMPLEMENTATION NOTE: at the moment of writing, the only knonw user of the
+  debug mode is CPython's hpy.universal: in that module, the uctx is a
+  statically allocated singleton, so for simplicity of implementation
+  currently we do the same inside debug_ctx.c, with a sanity check to ensure
+  that we don't call hpy_debug_get_ctx with different uctxs. But this is a
+  limitation of the current implementation and users should not rely on it. It
+  is likely that we will need to change it in the future, e.g. if we want to
+  have per-subinterpreter uctxs.
+*/
+
+HPyContext hpy_debug_get_ctx(HPyContext uctx);
 
 // this is the HPy init function created by HPy_MODINIT. In CPython's version
 // of hpy.universal the code is embedded inside the extension, so we can call

--- a/hpy/debug/src/include/hpy_debug.h
+++ b/hpy/debug/src/include/hpy_debug.h
@@ -14,7 +14,7 @@
   If you call hpy_debug_get_ctx twice on the same uctx, you get the same
   result.
 
-  IMPLEMENTATION NOTE: at the moment of writing, the only knonw user of the
+  IMPLEMENTATION NOTE: at the moment of writing, the only known user of the
   debug mode is CPython's hpy.universal: in that module, the uctx is a
   statically allocated singleton, so for simplicity of implementation
   currently we do the same inside debug_ctx.c, with a sanity check to ensure

--- a/hpy/devel/src/runtime/ctx_tracker.c
+++ b/hpy/devel/src/runtime/ctx_tracker.c
@@ -57,7 +57,6 @@
  *    return HPy_NULL;
  */
 
-#include <Python.h>
 #include "hpy.h"
 #include "common/runtime/ctx_type.h"
 
@@ -89,13 +88,13 @@ ctx_Tracker_New(HPyContext ctx, HPy_ssize_t capacity)
 
     hp = malloc(sizeof(_HPyTracker_s));
     if (hp == NULL) {
-        PyErr_NoMemory();
+        HPyErr_NoMemory(ctx);
         return _hp2ht(0);
     }
     hp->handles = calloc(capacity, sizeof(HPy));
     if (hp->handles == NULL) {
         free(hp);
-        PyErr_NoMemory();
+        HPyErr_NoMemory(ctx);
         return _hp2ht(0);
     }
     hp->capacity = capacity;
@@ -112,12 +111,12 @@ tracker_resize(HPyContext ctx, _HPyTracker_s *hp, HPy_ssize_t capacity)
     if (capacity <= hp->length) {
         // refuse a resize that would either 1) lose handles or  2) not leave
         // space for one new handle
-        PyErr_SetString(PyExc_ValueError, "HPyTracker resize would lose handles");
+        HPyErr_SetString(ctx, ctx->h_ValueError, "HPyTracker resize would lose handles");
         return -1;
     }
     new_handles = realloc(hp->handles, capacity * sizeof(HPy));
     if (new_handles == NULL) {
-        PyErr_NoMemory();
+        HPyErr_NoMemory(ctx);
         return -1;
     }
     hp->capacity = capacity;

--- a/hpy/devel/src/runtime/ctx_tracker.c
+++ b/hpy/devel/src/runtime/ctx_tracker.c
@@ -60,14 +60,6 @@
 #include "hpy.h"
 #include "common/runtime/ctx_type.h"
 
-#ifdef HPY_UNIVERSAL_ABI
-#define _ht2hp(x) ((_HPyTracker_s *) (x)._i)
-#define _hp2ht(x) ((HPyTracker) {(HPy_ssize_t) (hp)})
-#else
-#define _ht2hp(x) ((_HPyTracker_s *) (x)._o)
-#define _hp2ht(x) ((HPyTracker) {(void *) (hp)})
-#endif
-
 static const HPy_ssize_t HPYTRACKER_INITIAL_CAPACITY = 5;
 
 typedef struct {
@@ -75,6 +67,23 @@ typedef struct {
     HPy_ssize_t length;    // used handles
     HPy *handles;
 } _HPyTracker_s;
+
+
+#ifdef HPY_UNIVERSAL_ABI
+static inline _HPyTracker_s *_ht2hp(HPyTracker ht) {
+    return (_HPyTracker_s *) (ht)._i;
+}
+static inline HPyTracker _hp2ht(_HPyTracker_s *hp) {
+    return (HPyTracker) {(HPy_ssize_t) (hp)};
+}
+#else
+static inline _HPyTracker_s *_ht2hp(HPyTracker ht) {
+    return (_HPyTracker_s *) (ht)._o;
+}
+static inline HPyTracker _hp2ht(_HPyTracker_s *hp) {
+    return (HPyTracker) {(void *) (hp)};
+}
+#endif
 
 
 _HPy_HIDDEN HPyTracker

--- a/hpy/devel/src/runtime/ctx_tracker.c
+++ b/hpy/devel/src/runtime/ctx_tracker.c
@@ -108,6 +108,11 @@ ctx_Tracker_New(HPyContext ctx, HPy_ssize_t capacity)
     }
     hp->capacity = capacity;
     hp->length = 0;
+    // cppcheck thinks that hp->handles is a memory leak because we cast the
+    // pointer to an int (and thus the pointer is "lost" from its POV, I
+    // suppose). But it's not a real leak because we free it in
+    // ctx_Tracker_Close:
+    // cppcheck-suppress memleak
     return _hp2ht(hp);
 }
 

--- a/hpy/tools/autogen/debug.py
+++ b/hpy/tools/autogen/debug.py
@@ -63,6 +63,10 @@ class autogen_debug_wrappers(AutoGenFile):
         'HPyTuple_FromArray',
         'HPyType_GenericNew',
         'HPyType_FromSpec',
+        'HPyTracker_New',
+        'HPyTracker_Add',
+        'HPyTracker_ForgetAll',
+        'HPyTracker_Close',
         ])
 
     def generate(self):

--- a/hpy/universal/src/ctx_meth.c
+++ b/hpy/universal/src/ctx_meth.c
@@ -23,7 +23,7 @@ ctx_CallRealFunctionFromTrampoline(HPyContext ctx, HPyFunc_Signature sig,
         HPyFunc_varargs f = (HPyFunc_varargs)func;
         _HPyFunc_args_VARARGS *a = (_HPyFunc_args_VARARGS*)args;
         Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-        HPy h_args[nargs * sizeof(HPy)];
+        HPy h_args[nargs * sizeof(HPy)]; // VLA, should be killed by #157
         for (Py_ssize_t i = 0; i < nargs; i++) {
             h_args[i] = _py2h(PyTuple_GET_ITEM(a->args, i));
         }
@@ -34,7 +34,7 @@ ctx_CallRealFunctionFromTrampoline(HPyContext ctx, HPyFunc_Signature sig,
         HPyFunc_keywords f = (HPyFunc_keywords)func;
         _HPyFunc_args_KEYWORDS *a = (_HPyFunc_args_KEYWORDS*)args;
         Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-        HPy h_args[nargs * sizeof(HPy)];
+        HPy h_args[nargs * sizeof(HPy)]; // VLA, should be killed by #157
         for (Py_ssize_t i = 0; i < nargs; i++) {
             h_args[i] = _py2h(PyTuple_GET_ITEM(a->args, i));
         }
@@ -45,7 +45,7 @@ ctx_CallRealFunctionFromTrampoline(HPyContext ctx, HPyFunc_Signature sig,
         HPyFunc_initproc f = (HPyFunc_initproc)func;
         _HPyFunc_args_INITPROC *a = (_HPyFunc_args_INITPROC*)args;
         Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-        HPy h_args[nargs * sizeof(HPy)];
+        HPy h_args[nargs * sizeof(HPy)]; // VLA, should be killed by #157
         for (Py_ssize_t i = 0; i < nargs; i++) {
             h_args[i] = _py2h(PyTuple_GET_ITEM(a->args, i));
         }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from .support import ExtensionCompiler
+from hpy.debug.pytest import hpy_debug # make it available to all tests
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/test/debug/test_handles.py
+++ b/test/debug/test_handles.py
@@ -1,5 +1,7 @@
 from test.support import HPyDebugTest
 
+from hpy.debug.pytest import hpy_debug
+
 class TestHandles(HPyDebugTest):
 
     def test_get_open_handles(self):
@@ -76,23 +78,22 @@ class TestHandles(HPyDebugTest):
 
     def test_LeakDetector(self):
         import pytest
-        from hpy.debug import LeakDetector, HPyLeak
+        from hpy.debug import LeakDetector, HPyLeakError
         mod = self.make_leak_module()
         ld = LeakDetector()
         ld.start()
         mod.leak('hello')
-        mod.leak('world')
-        with pytest.raises(HPyLeak) as exc:
+        with pytest.raises(HPyLeakError) as exc:
             ld.stop()
-        assert str(exc.value).startswith('2 handles have not been closed properly:')
+        assert str(exc.value).startswith('1 unclosed handle:')
         #
-        with pytest.raises(HPyLeak) as exc:
+        with pytest.raises(HPyLeakError) as exc:
             with LeakDetector():
                 mod.leak('foo')
                 mod.leak('bar')
                 mod.leak('baz')
         msg = str(exc.value)
-        assert msg.startswith('3 handles have not been closed properly:')
+        assert msg.startswith('3 unclosed handles:')
         assert 'foo' in msg
         assert 'bar' in msg
         assert 'baz' in msg

--- a/test/debug/test_handles.py
+++ b/test/debug/test_handles.py
@@ -1,5 +1,5 @@
 import pytest
-from .support import HPyTest
+from test.support import HPyTest
 
 
 class TestDebug(HPyTest):

--- a/test/debug/test_handles.py
+++ b/test/debug/test_handles.py
@@ -1,26 +1,6 @@
-import pytest
-from test.support import HPyTest
+from test.support import HPyDebugTest
 
-
-class TestDebug(HPyTest):
-
-    # these tests are run only with hpy_abi=='debug'. We will probably need to
-    # tweak the approach to make it working with PyPy's apptests
-    @pytest.fixture(params=['debug'])
-    def hpy_abi(self, request):
-        return request.param
-
-    def make_leak_module(self):
-        return self.make_module("""
-            HPyDef_METH(leak, "leak", leak_impl, HPyFunc_O)
-            static HPy leak_impl(HPyContext ctx, HPy self, HPy arg)
-            {
-                HPy_Dup(ctx, arg); // leak!
-                return HPy_Dup(ctx, ctx->h_None);
-            }
-            @EXPORT(leak)
-            @INIT
-        """)
+class TestHandles(HPyDebugTest):
 
     def test_get_open_handles(self):
         from hpy.universal import _debug

--- a/test/debug/test_handles.py
+++ b/test/debug/test_handles.py
@@ -1,7 +1,5 @@
 from test.support import HPyDebugTest
 
-from hpy.debug.pytest import hpy_debug
-
 class TestHandles(HPyDebugTest):
 
     def test_get_open_handles(self):

--- a/test/support.py
+++ b/test/support.py
@@ -295,6 +295,29 @@ class HPyTest:
         return bool(getattr(sys, "executable", None))
 
 
+
+class HPyDebugTest(HPyTest):
+    """
+    Like HPyTest, but force hpy_abi=='debug' and thus run only [debug] tests
+    """
+
+    @pytest.fixture(params=['debug'])
+    def hpy_abi(self, request):
+        return request.param
+
+    def make_leak_module(self):
+        # for convenience
+        return self.make_module("""
+            HPyDef_METH(leak, "leak", leak_impl, HPyFunc_O)
+            static HPy leak_impl(HPyContext ctx, HPy self, HPy arg)
+            {
+                HPy_Dup(ctx, arg); // leak!
+                return HPy_Dup(ctx, ctx->h_None);
+            }
+            @EXPORT(leak)
+            @INIT
+        """)
+
 # the few functions below are copied and adapted from cffi/ffiplatform.py
 
 def c_compile(tmpdir, ext, hpy_devel, hpy_abi, compiler_verbose=0, debug=None):

--- a/test/support.py
+++ b/test/support.py
@@ -256,8 +256,9 @@ class HPyTest:
     ExtensionTemplate = DefaultExtensionTemplate
 
     @pytest.fixture()
-    def initargs(self, compiler):
-        # compiler is a fixture defined in conftest
+    def initargs(self, compiler, hpy_debug):
+        # compiler and hpy_debug are fixtures defined/imported by conftest.py.
+        # By using hpy_debug we enable leak detection in debug mode
         self.compiler = compiler
 
     def make_module(self, main_src, name='mytest', extra_sources=()):
@@ -300,6 +301,12 @@ class HPyDebugTest(HPyTest):
     """
     Like HPyTest, but force hpy_abi=='debug' and thus run only [debug] tests
     """
+
+    # override initargs to avoid using hpy_debug (we don't want to detect
+    # leaks here, we make them on purpose!
+    @pytest.fixture()
+    def initargs(self, compiler):
+        self.compiler = compiler
 
     @pytest.fixture(params=['debug'])
     def hpy_abi(self, request):

--- a/test/test_hpydict.py
+++ b/test/test_hpydict.py
@@ -44,6 +44,7 @@ class TestDict(HPyTest):
                 HPy val = HPyLong_FromLong(ctx, 1234);
                 if (HPy_SetItem(ctx, dict, arg, val) == -1)
                     return HPy_NULL;
+                HPy_Close(ctx, val);
                 return dict;
             }
             @EXPORT(f)

--- a/test/test_hpytuple.py
+++ b/test/test_hpytuple.py
@@ -47,7 +47,9 @@ class TestTuple(HPyTest):
                 HPy x = HPyLong_FromLong(ctx, 42);
                 if (HPy_IsNull(x))
                      return HPy_NULL;
-                return HPyTuple_Pack(ctx, 3, self, arg, x);
+                HPy result = HPyTuple_Pack(ctx, 3, self, arg, x);
+                HPy_Close(ctx, x);
+                return result;
             }
             @EXPORT(f)
             @INIT

--- a/test/test_slots.py
+++ b/test/test_slots.py
@@ -401,6 +401,7 @@ class TestSqSlots(HPyTest):
                 HPy s = HPyUnicode_FromString(ctx, "sq_repeat");
                 HPy other = HPyLong_FromLong(ctx, t);
                 HPy res = HPyTuple_Pack(ctx, 3, self, s, other);
+                HPy_Close(ctx, other);
                 HPy_Close(ctx, s);
                 return res;
             }
@@ -412,6 +413,7 @@ class TestSqSlots(HPyTest):
                 HPy s = HPyUnicode_FromString(ctx, "sq_inplace_repeat");
                 HPy other = HPyLong_FromLong(ctx, t);
                 HPy res = HPyTuple_Pack(ctx, 3, self, s, other);
+                HPy_Close(ctx, other);
                 HPy_Close(ctx, s);
                 return res;
             }


### PR DESCRIPTION
The main feature of this PR is the `hpy_debug` pytest fixture, which checks that you don't have memory leaks in your hpy tests (when you run in debug mode). This fixture is automatically used by our tests so now we get leak detection out of the box.

Among the other things:
1. improve the formatting of `HPyLeakError`
2. add support for HPyTracker to the debug mode: before this PR, it was simply wrong and handles closed through HPyTracker_Close were reported as leaks
3. fix some actual memory leaks which were found when running the tests
