### PR TITLE
Remove Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,3 @@
 language: python
 
 script : true
-
-notifications:
-    irc: 
-        channels: "chat.freenode.net#hpy"
-        template:
-        - "[%{repository_slug}@%{branch}]: %{author} pushed %{commit}"
-        - "Changes: %{compare_url}"
-        - "%{commit_message}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: python
-
-script : true


### PR DESCRIPTION
The Travis CI completely:

* The IRC notifications are noisy and don't contain particularly interesting information, so let's turn them off.
* The Travis CI runs are uninteresting, because all our tests happen in Azure Pipelines.
* Travis seems to be slowly dropping support for its free tier, so we're unlikely to add more to it in the foreseeable future.