### PR TITLE
Implement HPyDef_DOCSTRING

### DIFF
--- a/hpy/devel/include/common/autogen_hpyslot.h
+++ b/hpy/devel/include/common/autogen_hpyslot.h
@@ -52,6 +52,7 @@ typedef enum {
     HPy_sq_item = 44,
     HPy_sq_length = 45,
     HPy_sq_repeat = 46,
+    HPy_tp_doc = 56,
     HPy_tp_init = 60,
     HPy_tp_new = 65,
     HPy_tp_repr = 66,
@@ -102,6 +103,7 @@ typedef enum {
 #define _HPySlot_SIG__HPy_sq_item HPyFunc_SSIZEARGFUNC
 #define _HPySlot_SIG__HPy_sq_length HPyFunc_LENFUNC
 #define _HPySlot_SIG__HPy_sq_repeat HPyFunc_SSIZEARGFUNC
+#define _HPySlot_SIG__HPy_tp_doc HPyFunc_DOCSTRING
 #define _HPySlot_SIG__HPy_tp_init HPyFunc_INITPROC
 #define _HPySlot_SIG__HPy_tp_new HPyFunc_KEYWORDS
 #define _HPySlot_SIG__HPy_tp_repr HPyFunc_REPRFUNC

--- a/hpy/devel/include/common/hpydef.h
+++ b/hpy/devel/include/common/hpydef.h
@@ -70,11 +70,16 @@ typedef struct {
     void *closure;
 } HPyGetSet;
 
+typedef struct {
+    const char *docstring;  // the null-terminated UTF-8 docstring
+} HPyDocString;
+
 typedef enum {
     HPyDef_Kind_Slot = 1,
     HPyDef_Kind_Meth = 2,
     HPyDef_Kind_Member = 3,
     HPyDef_Kind_GetSet = 4,
+    HPyDef_Kind_DocString = 5,
 } HPyDef_Kind;
 
 typedef struct {
@@ -84,6 +89,7 @@ typedef struct {
         HPyMeth meth;
         HPyMember member;
         HPyGetSet getset;
+        HPyDocString docstring;
     };
 } HPyDef;
 
@@ -191,6 +197,14 @@ typedef struct {
             .getter_cpy_trampoline = SYM##_get_trampoline,                  \
             .setter_cpy_trampoline = SYM##_set_trampoline,                  \
             __VA_ARGS__                                                     \
+        }                                                                   \
+    };
+
+#define HPyDef_DOCSTRING(SYM, DOCSTRING)                                    \
+    HPyDef SYM = {                                                          \
+        .kind = HPyDef_Kind_DocString,                                      \
+        .docstring = {                                                      \
+            .docstring = DOCSTRING,                                         \
         }                                                                   \
     };
 

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -241,6 +241,7 @@ create_docstring(HPyDef *hpydefs[])
     return docstring;
 }
 
+
 static PyType_Slot *
 create_slot_defs(HPyType_Spec *hpyspec)
 {
@@ -254,8 +255,15 @@ create_slot_defs(HPyType_Spec *hpyspec)
                        &legacy_method_defs, &legacy_member_defs,
                        &legacy_getset_defs);
 
+    // check for a docstring
+    const char * docstring = create_docstring(hpyspec->defines);
+
     // add slots to hold Py_tp_methods, Py_tp_members, Py_tp_getset
+    // and optionally Py_tp_doc
     hpyslot_count += 3;
+    if (docstring != NULL) {
+        hpyslot_count++;
+    }
 
     // allocate the result PyType_Slot array
     HPy_ssize_t total_slot_count = hpyslot_count + legacy_slot_count;
@@ -318,9 +326,8 @@ create_slot_defs(HPyType_Spec *hpyspec)
     }
     result[dst_idx++] = (PyType_Slot){Py_tp_getset, pygetsets};
 
-    const char * docstring = create_docstring(hpyspec->defines);
+    // add the docstring
     if (docstring != NULL) {
-        total_slot_count++;
         result[dst_idx++] = (PyType_Slot){Py_tp_doc, (char *) docstring};
     }
 

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -226,6 +226,21 @@ create_getset_defs(HPyDef *hpydefs[], PyGetSetDef *legacy_getsets)
 }
 
 
+static const char *
+create_docstring(HPyDef *hpydefs[])
+{
+    const char *docstring = NULL;
+    if (hpydefs != NULL) {
+        for(int i=0; hpydefs[i] != NULL; i++) {
+          HPyDef *src = hpydefs[i];
+          if (src->kind != HPyDef_Kind_DocString)
+              continue;
+          docstring = src->docstring.docstring;
+        }
+    }
+    return docstring;
+}
+
 static PyType_Slot *
 create_slot_defs(HPyType_Spec *hpyspec)
 {
@@ -302,6 +317,12 @@ create_slot_defs(HPyType_Spec *hpyspec)
         return NULL;
     }
     result[dst_idx++] = (PyType_Slot){Py_tp_getset, pygetsets};
+
+    const char * docstring = create_docstring(hpyspec->defines);
+    if (docstring != NULL) {
+        total_slot_count++;
+        result[dst_idx++] = (PyType_Slot){Py_tp_doc, (char *) docstring};
+    }
 
     // add the NULL sentinel at the end
     result[dst_idx++] = (PyType_Slot){0, NULL};

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -403,7 +403,7 @@ typedef enum {
     //HPy_tp_del = SLOT(53, HPyFunc_X),
     //HPy_tp_descr_get = SLOT(54, HPyFunc_X),
     //HPy_tp_descr_set = SLOT(55, HPyFunc_X),
-    //HPy_tp_doc = SLOT(56, HPyFunc_X),
+    HPy_tp_doc = SLOT(56, HPyFunc_DOCSTRING),
     //HPy_tp_getattr = SLOT(57, HPyFunc_X),
     //HPy_tp_getattro = SLOT(58, HPyFunc_X),
     //HPy_tp_hash = SLOT(59, HPyFunc_X),

--- a/test/test_slots.py
+++ b/test/test_slots.py
@@ -65,6 +65,17 @@ class TestSlots(HPyTest):
         gc.collect()
         assert mod.get_destroyed_x() == 7
 
+    def test_tp_doc(self):
+        mod = self.make_module(r"""
+            @DEFINE_PointObject
+
+            HPyDef_DOCSTRING(point_doc, "A succinct docstring")
+
+            @EXPORT_POINT_TYPE(&point_doc)
+            @INIT
+        """)
+        assert mod.Point.__doc__ == "A succinct docstring"
+
     def test_nb_ops_binary(self):
         import operator
         mod = self.make_module(r"""


### PR DESCRIPTION
So that we can add docstrings to types.

Note: Because of how we implement defines with `HPyDef`, some of the `HPy_tp_XXX` like `HPy_tp_doc` are not actually used anywhere. I'm not sure if we should keep the definitions or mark them as unused somehow.