### PR TITLE
Add .doc to HPyType_Spec.

### DIFF
--- a/hpy/devel/include/common/hpytype.h
+++ b/hpy/devel/include/common/hpytype.h
@@ -29,6 +29,7 @@ typedef struct {
     unsigned int flags;
     void *legacy_slots; // PyType_Slot *
     HPyDef **defines;   /* points to an array of 'HPyDef *' */
+    const char* doc;    /* UTF-8 doc string or NULL */
 } HPyType_Spec;
 
 typedef enum {

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -239,8 +239,9 @@ create_slot_defs(HPyType_Spec *hpyspec)
                        &legacy_method_defs, &legacy_member_defs,
                        &legacy_getset_defs);
 
-    // add slots to hold Py_tp_methods, Py_tp_members, Py_tp_getset
+    // add slots to hold Py_tp_doc, Py_tp_methods, Py_tp_members, Py_tp_getset
     hpyslot_count += 3;
+    if (hpyspec->doc != NULL) hpyslot_count++;
 
     // allocate the result PyType_Slot array
     HPy_ssize_t total_slot_count = hpyslot_count + legacy_slot_count;
@@ -261,6 +262,11 @@ create_slot_defs(HPyType_Spec *hpyspec)
             dst->slot = hpy_slot_to_cpy_slot(src->slot.slot);
             dst->pfunc = src->slot.cpy_trampoline;
         }
+    }
+
+    // add a slot for the doc string if present
+    if (hpyspec->doc != NULL) {
+        result[dst_idx++] = (PyType_Slot){Py_tp_doc, (void *) hpyspec->doc};
     }
 
     // add the legacy slots (non-methods, non-members, non-getsets)

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -90,6 +90,20 @@ class TestType(HPyTest):
             pass
         assert isinstance(Sub(), mod.Dummy)
 
+    def test_doc_string(self):
+        mod = self.make_module("""
+            static HPyType_Spec Dummy_spec = {
+                .name = "mytest.Dummy",
+                .doc = "A succinct description.",
+                .itemsize = 0,
+                .flags = HPy_TPFLAGS_DEFAULT | HPy_TPFLAGS_BASETYPE,
+            };
+
+            @EXPORT_TYPE("Dummy", Dummy_spec)
+            @INIT
+        """)
+        assert mod.Dummy.__doc__ == "A succinct description."
+
     def test_HPyDef_SLOT(self):
         mod = self.make_module("""
             HPyDef_SLOT(Dummy_repr, Dummy_repr_impl, HPy_tp_repr);


### PR DESCRIPTION
This allows docstrings to be specified for types.

It replaces #166 and is a much simpler implementation (and nicer for people writing C extensions using HPy too).