### PR TITLE
Empty initializers and zero size arrays are not ISO C compatible

### DIFF
--- a/hpy/devel/src/runtime/ctx_call.c
+++ b/hpy/devel/src/runtime/ctx_call.c
@@ -29,7 +29,7 @@ ctx_CallTupleDict(HPyContext *ctx, HPy callable, HPy args, HPy kw)
     else {
         // args is null, but kw is not, so we need to create an empty args tuple
         // for CPython's PyObject_Call
-        HPy items[] = {};
+        HPy *items = NULL;
         HPy empty_tuple = HPyTuple_FromArray(ctx, items, 0);
         obj = PyObject_Call(_h2py(callable), _h2py(empty_tuple), _h2py(kw));
         HPy_Close(ctx, empty_tuple);


### PR DESCRIPTION
If compiled with all warnings turned on, this produced the following warnings:

```
hpy/devel/src/runtime/ctx_call.c:32:23: warning: use of GNU empty initializer extension [-Wgnu-empty-initializer]
        HPy items[] = {};
                      ^
hpy/devel/src/runtime/ctx_call.c:32:23: warning: zero size arrays are an extension [-Wzero-length-array]
2 warnings generated.
```

It seems to work fine with gcc and clang but might cause trouble on other platforms in the future.
There's another way to create an empty tuple using the TupleBuilder.