### PR TITLE
Changing spec.origin to name of shared library

### DIFF
--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -121,6 +121,7 @@ def __bootstrap__():
     m.__name__ = __name__
     m.__package__ = __package__
     m.__spec__ = __spec__
+    m.__spec__.origin = ext_filepath
     sys.modules[__name__] = m
 
 __bootstrap__()

--- a/test/test_importing.py
+++ b/test/test_importing.py
@@ -25,7 +25,7 @@ class TestImporting(HPyTest):
                 del sys.modules[name]
         return module
 
-    def test_importing_attributes(self):
+    def test_importing_attributes(self, hpy_abi, tmpdir):
         import pytest
         if not self.supports_ordinary_make_module_imports():
             pytest.skip()
@@ -40,3 +40,11 @@ class TestImporting(HPyTest):
         assert mod.__spec__.loader is mod.__loader__
         assert mod.__spec__.name == 'mytest'
         assert mod.__file__
+
+        if hpy_abi == 'cpython':
+            from sysconfig import get_config_var
+            ext = get_config_var('EXT_SUFFIX')
+        else:
+            ext ='.hpy.so'
+
+        assert repr(mod) == '<module \'mytest\' from \'{}\'>'.format(tmpdir.join('mytest' + ext))


### PR DESCRIPTION
This makes `repr(mod)` show the name of the shared library
instead of the python bootstrap module for universal ABI

This addresses https://github.com/hpyproject/hpy/issues/191