### PR TITLE
Implementation for comparing object identity.

### DIFF
--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -93,6 +93,7 @@ int debug_ctx_SetItem_i(HPyContext *dctx, DHPy obj, HPy_ssize_t idx, DHPy value)
 int debug_ctx_SetItem_s(HPyContext *dctx, DHPy obj, const char *key, DHPy value);
 DHPy debug_ctx_Type(HPyContext *dctx, DHPy obj);
 int debug_ctx_TypeCheck(HPyContext *dctx, DHPy obj, DHPy type);
+int debug_ctx_Is(HPyContext *dctx, DHPy obj, DHPy other);
 void *debug_ctx_AsStruct(HPyContext *dctx, DHPy h);
 void *debug_ctx_AsStructLegacy(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_New(HPyContext *dctx, DHPy h_type, void **data);
@@ -300,6 +301,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_SetItem_s = &debug_ctx_SetItem_s;
     dctx->ctx_Type = &debug_ctx_Type;
     dctx->ctx_TypeCheck = &debug_ctx_TypeCheck;
+    dctx->ctx_Is = &debug_ctx_Is;
     dctx->ctx_AsStruct = &debug_ctx_AsStruct;
     dctx->ctx_AsStructLegacy = &debug_ctx_AsStructLegacy;
     dctx->ctx_New = &debug_ctx_New;

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -412,6 +412,11 @@ int debug_ctx_TypeCheck(HPyContext *dctx, DHPy obj, DHPy type)
     return HPy_TypeCheck(get_info(dctx)->uctx, DHPy_unwrap(dctx, obj), DHPy_unwrap(dctx, type));
 }
 
+int debug_ctx_Is(HPyContext *dctx, DHPy obj, DHPy other)
+{
+    return HPy_Is(get_info(dctx)->uctx, DHPy_unwrap(dctx, obj), DHPy_unwrap(dctx, other));
+}
+
 void *debug_ctx_AsStruct(HPyContext *dctx, DHPy h)
 {
     return HPy_AsStruct(get_info(dctx)->uctx, DHPy_unwrap(dctx, h));

--- a/hpy/devel/include/common/runtime/ctx_object.h
+++ b/hpy/devel/include/common/runtime/ctx_object.h
@@ -6,5 +6,6 @@
 
 _HPy_HIDDEN void ctx_Dump(HPyContext *ctx, HPy h);
 _HPy_HIDDEN int ctx_TypeCheck(HPyContext *ctx, HPy h_obj, HPy h_type);
+_HPy_HIDDEN int ctx_Is(HPyContext *ctx, HPy h_obj, HPy h_other);
 
 #endif /* HPY_COMMON_RUNTIME_CTX_OBJECT_H */

--- a/hpy/devel/include/cpython/hpy.h
+++ b/hpy/devel/include/cpython/hpy.h
@@ -347,6 +347,12 @@ HPy_TypeCheck(HPyContext *ctx, HPy h_obj, HPy h_type)
     return ctx_TypeCheck(ctx, h_obj, h_type);
 }
 
+HPyAPI_FUNC(int)
+HPy_Is(HPyContext *ctx, HPy h_obj, HPy h_other)
+{
+    return ctx_Is(ctx, h_obj, h_other);
+}
+
 HPyAPI_FUNC(HPyListBuilder)
 HPyListBuilder_New(HPyContext *ctx, HPy_ssize_t initial_size)
 {

--- a/hpy/devel/include/universal/autogen_ctx.h
+++ b/hpy/devel/include/universal/autogen_ctx.h
@@ -172,6 +172,7 @@ struct _HPyContext_s {
     int (*ctx_SetItem_s)(HPyContext *ctx, HPy obj, const char *key, HPy value);
     HPy (*ctx_Type)(HPyContext *ctx, HPy obj);
     int (*ctx_TypeCheck)(HPyContext *ctx, HPy obj, HPy type);
+    int (*ctx_Is)(HPyContext *ctx, HPy obj, HPy other);
     void *(*ctx_AsStruct)(HPyContext *ctx, HPy h);
     void *(*ctx_AsStructLegacy)(HPyContext *ctx, HPy h);
     HPy (*ctx_New)(HPyContext *ctx, HPy h_type, void **data);

--- a/hpy/devel/include/universal/autogen_trampolines.h
+++ b/hpy/devel/include/universal/autogen_trampolines.h
@@ -338,6 +338,10 @@ static inline int HPy_TypeCheck(HPyContext *ctx, HPy obj, HPy type) {
      return ctx->ctx_TypeCheck ( ctx, obj, type ); 
 }
 
+static inline int HPy_Is(HPyContext *ctx, HPy obj, HPy other) {
+     return ctx->ctx_Is ( ctx, obj, other ); 
+}
+
 static inline void *HPy_AsStruct(HPyContext *ctx, HPy h) {
      return ctx->ctx_AsStruct ( ctx, h ); 
 }

--- a/hpy/devel/src/runtime/ctx_object.c
+++ b/hpy/devel/src/runtime/ctx_object.c
@@ -38,3 +38,9 @@ ctx_TypeCheck(HPyContext *ctx, HPy h_obj, HPy h_type)
     }
     return PyObject_TypeCheck(_h2py(h_obj), (PyTypeObject*)type);
 }
+
+_HPy_HIDDEN int
+ctx_Is(HPyContext *ctx, HPy h_obj, HPy h_other)
+{
+    return _h2py(h_obj) == _h2py(h_other);
+}

--- a/hpy/tools/autogen/parse.py
+++ b/hpy/tools/autogen/parse.py
@@ -222,6 +222,7 @@ SPECIAL_CASES = {
     '_HPy_Dump': None,
     'HPy_Type': 'PyObject_Type',
     'HPy_TypeCheck': None,
+    'HPy_Is': None,
     'HPyBytes_FromStringAndSize': None,
 }
 

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -211,6 +211,8 @@ HPy HPy_Type(HPyContext *ctx, HPy obj);
 // WARNING: HPy_TypeCheck could be tweaked/removed in the future, see issue #160
 int HPy_TypeCheck(HPyContext *ctx, HPy obj, HPy type);
 
+int HPy_Is(HPyContext *ctx, HPy obj, HPy other);
+
 void* HPy_AsStruct(HPyContext *ctx, HPy h);
 void* HPy_AsStructLegacy(HPyContext *ctx, HPy h);
 

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -98,6 +98,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_SetItem_s = &ctx_SetItem_s,
     .ctx_Type = &ctx_Type,
     .ctx_TypeCheck = &ctx_TypeCheck,
+    .ctx_Is = &ctx_Is,
     .ctx_AsStruct = &ctx_AsStruct,
     .ctx_AsStructLegacy = &ctx_AsStructLegacy,
     .ctx_New = &ctx_New,

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -510,3 +510,22 @@ class TestObject(HPyTest):
         assert mod.f('hello', str)
         assert not mod.f('hello', int)
         assert mod.f(MyStr('hello'), str)
+
+    def test_is(self):
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", f_impl, HPyFunc_VARARGS)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy *args, HPy_ssize_t nargs)
+            {
+                HPy obj, other;
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "OO", &obj, &other))
+                    return HPy_NULL;
+                int res = HPy_Is(ctx, obj, other);
+                return HPyBool_FromLong(ctx, res);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f(None, None)
+        a = object()
+        assert mod.f(a, a)
+        assert not mod.f(a, None)


### PR DESCRIPTION
This allows comparing two objects for equality, e.g. `HPy_Is(h_obj, ctx->h_None)`.
I ran into this issue when trying to remove the duplicated code in https://github.com/hpyproject/hpy/pull/193.
Comparing objects for equality is documented in https://github.com/hpyproject/hpy/blob/master/docs/api.rst but I could not find the implementation, also not in the history.
