### PR TITLE
Resolve unused function warning

### DIFF
--- a/hpy/debug/src/dhqueue.c
+++ b/hpy/debug/src/dhqueue.c
@@ -82,6 +82,7 @@ void DHQueue_remove(DHQueue *q, DebugHandle *h)
 }
 
 
+#ifndef NDEBUG
 static void linked_item_sanity_check(DebugHandle *h)
 {
     if (h == NULL)
@@ -91,6 +92,7 @@ static void linked_item_sanity_check(DebugHandle *h)
     if (h->prev != NULL)
         assert(h->prev->next == h);
 }
+#endif
 
 void DHQueue_sanity_check(DHQueue *q)
 {


### PR DESCRIPTION
It adds a cpp conditional to not include the function `linked_item_sanity_check` when `NDEBUG` is not set.
The function is only used when `NDEBUG` is set and therefore causes a compiler warning for non-debug builds.