### PR TITLE
Upgrade infer to 1.1.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,7 @@ jobs:
   - template: azure-templates/python.yml
   - script: |
       pip install compiledb wheel;
-      VERSION=0.17.0; \
+      VERSION=1.1.0; \
       curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux64-v$VERSION.tar.xz" \
       | sudo tar -C /opt -xJ && \
       echo "##vso[task.prependpath]/opt/infer-linux64-v$VERSION/bin"


### PR DESCRIPTION
infer 1.0 removed their dependency on Python 2 which makes our build environment easier to maintain.
This, on top of various bug fixes, should be reason enough to upgrade.