### PR TITLE
Add function macro API docs

### DIFF
--- a/docs/api-reference/hpy-h.rst
+++ b/docs/api-reference/hpy-h.rst
@@ -1,0 +1,8 @@
+HPy.h
+=====
+
+Function marcos
+---------------
+
+.. autocmodule:: hpy.h
+   :members: HPyAPI_FUNC, HPyAPI_IMPL, HPyAPI_HELPER

--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -5,4 +5,5 @@ API Reference
    :maxdepth: 2
 
    argument-parsing
-   module-helpers
+   helpers
+   hpy-h

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx_c_autodoc",
     "sphinx_c_autodoc.viewcode",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # -- sphinx_c_autodoc --------------------------------------------------------
 
 c_autodoc_roots = [
-    "../hpy/devel/include/common",
+    "../hpy/devel/include",
     "../hpy/devel/src",
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx-rtd-theme==0.5.0
 sphinx-autobuild==0.7.1
 sphinx-c-autodoc==0.3.1
 clang==10.0.1
+docutils==0.16  # docutils >= 0.17 fails to render bullet lists :/

--- a/hpy/devel/include/hpy.h
+++ b/hpy/devel/include/hpy.h
@@ -28,42 +28,42 @@
 
 /* ~~~~~~~~~~~~~~~~ HPyAPI declaration ~~~~~~~~~~~~~~~~ */
 
-/* We have three different kind of API functions:
+/* We have three different kind of API functions: */
 
-   HPyAPI_FUNC
-
-       Public API functions which are exposed to the user, e.g. HPy_Add or
-       HPyType_FromSpec. Generally speaking they are thiny shims dispatching
-       to the actual implementation:
-
-           - In CPython-ABI mode they directly call the corresponding Py* or
-             HPyAPI_IMPL equivalent, e.g. PyObject_Add or ctx_Type_FromSpec.
-
-           - In Universal-ABI mode, they always resolve to an indirect call
-             through HPyContext*, i.e. ctx->ctx_Add(...), which on CPython
-             dispaches to ctx_Add
-
-   HPyAPI_IMPL
-
-       CPython implementation for HPyAPI_FUNC functions. Generally speaking,
-       they are put in ctx_*.c files and they are prefixed by ctx_.
-
-       Some of these functions are needed by the CPython ABI mode, and by
-       CPython's implementation of hpy.universal: these can be found in
-       hpy/devel/src/runtime/ctx_*.c, e.g. ctx_Type_FromSpec and
-       ctx_Tuple_FromArray.
-
-       Some other are used ONLY by hpy.universal and can be found in
-       hpy/universal/src/ctx_*.c.
-
-    HPyAPI_HELPER
-
-       These functions are part of the public API but **not** of the ABI. They
-       are helpers which are meant to be compiled togeher with every
-       extension. E.g. HPyArg_Parse and HPyHelpers_AddType.
-*/
-#define HPyAPI_IMPL   _HPy_HIDDEN
+/**
+ * Public API functions which are exposed to the user, e.g.
+ * HPy_Add or HPyType_FromSpec. Generally speaking they are thin shims
+ * dispatching to the actual implementation:
+ *
+ * - In CPython-ABI mode they directly call the corresponding Py* or
+ *   HPyAPI_IMPL equivalent, e.g. PyObject_Add or ctx_Type_FromSpec.
+ *
+ * - In Universal-ABI mode, they always resolve to an indirect call
+ *   through HPyContext*, i.e. ctx->ctx_Add(...), which on CPython
+ *   dispaches to ctx_Add
+ */
 #define HPyAPI_FUNC   _HPy_UNUSED static inline
+
+/**
+ * CPython implementations for HPyAPI_FUNC
+ * functions. Generally speaking, they are put in ctx_*.c files and they are
+ * prefixed by ctx\_.
+ *
+ * Some of these functions are needed by the CPython ABI mode, and by
+ * CPython's implementation of hpy.universal: these can be found in
+ * hpy/devel/src/runtime/ctx_*.c, e.g. ctx_Type_FromSpec and
+ * ctx_Tuple_FromArray.
+ *
+ * Some other are used ONLY by hpy.universal and can be found in
+ * hpy/universal/src/ctx_*.c.
+ */
+#define HPyAPI_IMPL   _HPy_HIDDEN
+
+/**
+ * These functions are part of the public API but **not** of
+ * the ABI. They are helpers which are meant to be compiled togeher with every
+ * extension. E.g. HPyArg_Parse and HPyHelpers_AddType.
+ */
 #define HPyAPI_HELPER _HPy_HIDDEN
 
 

--- a/hpy/devel/include/hpy.h
+++ b/hpy/devel/include/hpy.h
@@ -32,29 +32,30 @@
 
 /**
  * Public API functions which are exposed to the user, e.g.
- * HPy_Add or HPyType_FromSpec. Generally speaking they are thin shims
- * dispatching to the actual implementation:
+ * ``HPy_Add`` or ``HPyType_FromSpec``. Generally speaking they are
+ * thin shims dispatching to the actual implementation:
  *
- * - In CPython-ABI mode they directly call the corresponding Py* or
- *   HPyAPI_IMPL equivalent, e.g. PyObject_Add or ctx_Type_FromSpec.
+ * * In CPython-ABI mode they directly call the corresponding Py* or
+ *   ``HPyAPI_IMPL`` equivalent, e.g. ``PyObject_Add`` or
+ *   ``ctx_Type_FromSpec``.
  *
- * - In Universal-ABI mode, they always resolve to an indirect call
- *   through HPyContext*, i.e. ctx->ctx_Add(...), which on CPython
- *   dispaches to ctx_Add
+ * * In Universal-ABI mode, they always resolve to an indirect call
+ *   through ``HPyContext *``, i.e. ``ctx->ctx_Add(...)``, which on CPython
+ *   dispaches to ``ctx_Add``.
  */
 #define HPyAPI_FUNC   _HPy_UNUSED static inline
 
 /**
- * CPython implementations for HPyAPI_FUNC
+ * CPython implementations for ``HPyAPI_FUNC``
  * functions. Generally speaking, they are put in ctx_*.c files and they are
  * prefixed by ctx\_.
  *
  * Some of these functions are needed by the CPython ABI mode, and by
  * CPython's implementation of hpy.universal: these can be found in
- * hpy/devel/src/runtime/ctx_*.c, e.g. ctx_Type_FromSpec and
- * ctx_Tuple_FromArray.
+ * hpy/devel/src/runtime/ctx_*.c, e.g. ``ctx_Type_FromSpec`` and
+ * ``ctx_Tuple_FromArray``.
  *
- * Some other are used ONLY by hpy.universal and can be found in
+ * Some other are used ONLY by ``hpy.universal`` and can be found in
  * hpy/universal/src/ctx_*.c.
  */
 #define HPyAPI_IMPL   _HPy_HIDDEN
@@ -62,7 +63,7 @@
 /**
  * These functions are part of the public API but **not** of
  * the ABI. They are helpers which are meant to be compiled togeher with every
- * extension. E.g. HPyArg_Parse and HPyHelpers_AddType.
+ * extension. E.g. ``HPyArg_Parse`` and ``HPyHelpers_AddType``.
  */
 #define HPyAPI_HELPER _HPy_HIDDEN
 


### PR DESCRIPTION
This is a small experiment to document parts of HPy.h with the `sphinx-c-autodoc` extension (as we are already doing for argument parsing and helpers).

It's built on top of #225 (since that is likely to be merged soon).

What the documentation looks like:

![image](https://user-images.githubusercontent.com/165551/126180102-45defb75-d11d-453d-9ed1-1e07a2adb45b.png)