### PR TITLE
Remove unnecessary include of Python.h

### DIFF
--- a/hpy/devel/include/hpy/runtime/ctx_funcs.h
+++ b/hpy/devel/include/hpy/runtime/ctx_funcs.h
@@ -4,7 +4,6 @@
 // This file contains the prototypes for all the functions defined in
 // hpy/devel/src/runtime/ctx_*.c
 
-#include <Python.h>
 #include "hpy.h"
 
 // ctx_bytes.c


### PR DESCRIPTION
This include was causing issues e.g. in pypy tests.