### PR TITLE
Add HPyUnicode_AsUTF8AndSize, HPyUnicode_DecodeFSDefault and "s" support in HPyArg_Parse

### DIFF
--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -114,6 +114,7 @@ DHPy debug_ctx_Bytes_FromStringAndSize(HPyContext *dctx, const char *v, HPy_ssiz
 DHPy debug_ctx_Unicode_FromString(HPyContext *dctx, const char *utf8);
 int debug_ctx_Unicode_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Unicode_AsUTF8String(HPyContext *dctx, DHPy h);
+const char *debug_ctx_Unicode_AsUTF8AndSize(HPyContext *dctx, DHPy h, HPy_ssize_t *size);
 DHPy debug_ctx_Unicode_FromWideChar(HPyContext *dctx, const wchar_t *w, HPy_ssize_t size);
 int debug_ctx_List_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_List_New(HPyContext *dctx, HPy_ssize_t len);
@@ -322,6 +323,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_Unicode_FromString = &debug_ctx_Unicode_FromString;
     dctx->ctx_Unicode_Check = &debug_ctx_Unicode_Check;
     dctx->ctx_Unicode_AsUTF8String = &debug_ctx_Unicode_AsUTF8String;
+    dctx->ctx_Unicode_AsUTF8AndSize = &debug_ctx_Unicode_AsUTF8AndSize;
     dctx->ctx_Unicode_FromWideChar = &debug_ctx_Unicode_FromWideChar;
     dctx->ctx_List_Check = &debug_ctx_List_Check;
     dctx->ctx_List_New = &debug_ctx_List_New;

--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -116,6 +116,7 @@ int debug_ctx_Unicode_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Unicode_AsUTF8String(HPyContext *dctx, DHPy h);
 const char *debug_ctx_Unicode_AsUTF8AndSize(HPyContext *dctx, DHPy h, HPy_ssize_t *size);
 DHPy debug_ctx_Unicode_FromWideChar(HPyContext *dctx, const wchar_t *w, HPy_ssize_t size);
+DHPy debug_ctx_Unicode_DecodeFSDefault(HPyContext *dctx, const char *v);
 int debug_ctx_List_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_List_New(HPyContext *dctx, HPy_ssize_t len);
 int debug_ctx_List_Append(HPyContext *dctx, DHPy h_list, DHPy h_item);
@@ -325,6 +326,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_Unicode_AsUTF8String = &debug_ctx_Unicode_AsUTF8String;
     dctx->ctx_Unicode_AsUTF8AndSize = &debug_ctx_Unicode_AsUTF8AndSize;
     dctx->ctx_Unicode_FromWideChar = &debug_ctx_Unicode_FromWideChar;
+    dctx->ctx_Unicode_DecodeFSDefault = &debug_ctx_Unicode_DecodeFSDefault;
     dctx->ctx_List_Check = &debug_ctx_List_Check;
     dctx->ctx_List_New = &debug_ctx_List_New;
     dctx->ctx_List_Append = &debug_ctx_List_Append;

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -517,6 +517,11 @@ DHPy debug_ctx_Unicode_AsUTF8String(HPyContext *dctx, DHPy h)
     return DHPy_open(dctx, HPyUnicode_AsUTF8String(get_info(dctx)->uctx, DHPy_unwrap(dctx, h)));
 }
 
+const char *debug_ctx_Unicode_AsUTF8AndSize(HPyContext *dctx, DHPy h, HPy_ssize_t *size)
+{
+    return HPyUnicode_AsUTF8AndSize(get_info(dctx)->uctx, DHPy_unwrap(dctx, h), size);
+}
+
 DHPy debug_ctx_Unicode_FromWideChar(HPyContext *dctx, const wchar_t *w, HPy_ssize_t size)
 {
     return DHPy_open(dctx, HPyUnicode_FromWideChar(get_info(dctx)->uctx, w, size));

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -527,6 +527,11 @@ DHPy debug_ctx_Unicode_FromWideChar(HPyContext *dctx, const wchar_t *w, HPy_ssiz
     return DHPy_open(dctx, HPyUnicode_FromWideChar(get_info(dctx)->uctx, w, size));
 }
 
+DHPy debug_ctx_Unicode_DecodeFSDefault(HPyContext *dctx, const char *v)
+{
+    return DHPy_open(dctx, HPyUnicode_DecodeFSDefault(get_info(dctx)->uctx, v));
+}
+
 int debug_ctx_List_Check(HPyContext *dctx, DHPy h)
 {
     return HPyList_Check(get_info(dctx)->uctx, DHPy_unwrap(dctx, h));

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -440,6 +440,11 @@ HPyAPI_FUNC HPy HPyUnicode_AsUTF8String(HPyContext *ctx, HPy h)
     return _py2h(PyUnicode_AsUTF8String(_h2py(h)));
 }
 
+HPyAPI_FUNC const char *HPyUnicode_AsUTF8AndSize(HPyContext *ctx, HPy h, HPy_ssize_t *size)
+{
+    return PyUnicode_AsUTF8AndSize(_h2py(h), size);
+}
+
 HPyAPI_FUNC HPy HPyUnicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_ssize_t size)
 {
     return _py2h(PyUnicode_FromWideChar(w, size));

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -450,6 +450,11 @@ HPyAPI_FUNC HPy HPyUnicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_s
     return _py2h(PyUnicode_FromWideChar(w, size));
 }
 
+HPyAPI_FUNC HPy HPyUnicode_DecodeFSDefault(HPyContext *ctx, const char *v)
+{
+    return _py2h(PyUnicode_DecodeFSDefault(v));
+}
+
 HPyAPI_FUNC int HPyList_Check(HPyContext *ctx, HPy h)
 {
     return PyList_Check(_h2py(h));

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -193,6 +193,7 @@ struct _HPyContext_s {
     HPy (*ctx_Unicode_FromString)(HPyContext *ctx, const char *utf8);
     int (*ctx_Unicode_Check)(HPyContext *ctx, HPy h);
     HPy (*ctx_Unicode_AsUTF8String)(HPyContext *ctx, HPy h);
+    const char *(*ctx_Unicode_AsUTF8AndSize)(HPyContext *ctx, HPy h, HPy_ssize_t *size);
     HPy (*ctx_Unicode_FromWideChar)(HPyContext *ctx, const wchar_t *w, HPy_ssize_t size);
     int (*ctx_List_Check)(HPyContext *ctx, HPy h);
     HPy (*ctx_List_New)(HPyContext *ctx, HPy_ssize_t len);

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -195,6 +195,7 @@ struct _HPyContext_s {
     HPy (*ctx_Unicode_AsUTF8String)(HPyContext *ctx, HPy h);
     const char *(*ctx_Unicode_AsUTF8AndSize)(HPyContext *ctx, HPy h, HPy_ssize_t *size);
     HPy (*ctx_Unicode_FromWideChar)(HPyContext *ctx, const wchar_t *w, HPy_ssize_t size);
+    HPy (*ctx_Unicode_DecodeFSDefault)(HPyContext *ctx, const char *v);
     int (*ctx_List_Check)(HPyContext *ctx, HPy h);
     HPy (*ctx_List_New)(HPyContext *ctx, HPy_ssize_t len);
     int (*ctx_List_Append)(HPyContext *ctx, HPy h_list, HPy h_item);

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -426,6 +426,10 @@ HPyAPI_FUNC HPy HPyUnicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_s
      return ctx->ctx_Unicode_FromWideChar ( ctx, w, size ); 
 }
 
+HPyAPI_FUNC HPy HPyUnicode_DecodeFSDefault(HPyContext *ctx, const char *v) {
+     return ctx->ctx_Unicode_DecodeFSDefault ( ctx, v ); 
+}
+
 HPyAPI_FUNC int HPyList_Check(HPyContext *ctx, HPy h) {
      return ctx->ctx_List_Check ( ctx, h ); 
 }

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -418,6 +418,10 @@ HPyAPI_FUNC HPy HPyUnicode_AsUTF8String(HPyContext *ctx, HPy h) {
      return ctx->ctx_Unicode_AsUTF8String ( ctx, h ); 
 }
 
+HPyAPI_FUNC const char *HPyUnicode_AsUTF8AndSize(HPyContext *ctx, HPy h, HPy_ssize_t *size) {
+     return ctx->ctx_Unicode_AsUTF8AndSize ( ctx, h, size ); 
+}
+
 HPyAPI_FUNC HPy HPyUnicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_ssize_t size) {
      return ctx->ctx_Unicode_FromWideChar ( ctx, w, size ); 
 }

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -241,6 +241,7 @@ HPy HPyBytes_FromStringAndSize(HPyContext *ctx, const char *v, HPy_ssize_t len);
 HPy HPyUnicode_FromString(HPyContext *ctx, const char *utf8);
 int HPyUnicode_Check(HPyContext *ctx, HPy h);
 HPy HPyUnicode_AsUTF8String(HPyContext *ctx, HPy h);
+const char* HPyUnicode_AsUTF8AndSize(HPyContext *ctx, HPy h, HPy_ssize_t *size);
 HPy HPyUnicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_ssize_t size);
 
 /* listobject.h */

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -243,6 +243,7 @@ int HPyUnicode_Check(HPyContext *ctx, HPy h);
 HPy HPyUnicode_AsUTF8String(HPyContext *ctx, HPy h);
 const char* HPyUnicode_AsUTF8AndSize(HPyContext *ctx, HPy h, HPy_ssize_t *size);
 HPy HPyUnicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_ssize_t size);
+HPy HPyUnicode_DecodeFSDefault(HPyContext *ctx, const char* v);
 
 /* listobject.h */
 int HPyList_Check(HPyContext *ctx, HPy h);

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -119,6 +119,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_Unicode_FromString = &ctx_Unicode_FromString,
     .ctx_Unicode_Check = &ctx_Unicode_Check,
     .ctx_Unicode_AsUTF8String = &ctx_Unicode_AsUTF8String,
+    .ctx_Unicode_AsUTF8AndSize = &ctx_Unicode_AsUTF8AndSize,
     .ctx_Unicode_FromWideChar = &ctx_Unicode_FromWideChar,
     .ctx_List_Check = &ctx_List_Check,
     .ctx_List_New = &ctx_List_New,

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -121,6 +121,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_Unicode_AsUTF8String = &ctx_Unicode_AsUTF8String,
     .ctx_Unicode_AsUTF8AndSize = &ctx_Unicode_AsUTF8AndSize,
     .ctx_Unicode_FromWideChar = &ctx_Unicode_FromWideChar,
+    .ctx_Unicode_DecodeFSDefault = &ctx_Unicode_DecodeFSDefault,
     .ctx_List_Check = &ctx_List_Check,
     .ctx_List_New = &ctx_List_New,
     .ctx_List_Append = &ctx_List_Append,

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -450,6 +450,11 @@ HPyAPI_IMPL HPy ctx_Unicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_
     return _py2h(PyUnicode_FromWideChar(w, size));
 }
 
+HPyAPI_IMPL HPy ctx_Unicode_DecodeFSDefault(HPyContext *ctx, const char *v)
+{
+    return _py2h(PyUnicode_DecodeFSDefault(v));
+}
+
 HPyAPI_IMPL int ctx_List_Check(HPyContext *ctx, HPy h)
 {
     return PyList_Check(_h2py(h));

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -440,6 +440,11 @@ HPyAPI_IMPL HPy ctx_Unicode_AsUTF8String(HPyContext *ctx, HPy h)
     return _py2h(PyUnicode_AsUTF8String(_h2py(h)));
 }
 
+HPyAPI_IMPL const char *ctx_Unicode_AsUTF8AndSize(HPyContext *ctx, HPy h, HPy_ssize_t *size)
+{
+    return PyUnicode_AsUTF8AndSize(_h2py(h), size);
+}
+
 HPyAPI_IMPL HPy ctx_Unicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_ssize_t size)
 {
     return _py2h(PyUnicode_FromWideChar(w, size));

--- a/test/support.py
+++ b/test/support.py
@@ -225,7 +225,7 @@ class ExtensionCompiler:
         We don't want to unnecessarily modify the global state inside tests:
         if you are writing a test which needs a proper import, you should not
         use make_module but explicitly use compile_module and import it
-        manually as requied by your test.
+        manually as required by your test.
         """
         so_filename = self.compile_module(
             ExtensionTemplate, main_src, name, extra_sources)

--- a/test/test_argparse.py
+++ b/test/test_argparse.py
@@ -67,8 +67,9 @@ class TestParseItem(HPyTest):
         )
         with pytest.raises(TypeError) as err:
             mod.f(b"hello HPy")
-        # No assertion of the message for now
-        # CPython's message reads: argument {N} must be str, not int
+        assert str(err.value) == (
+            "function a str is required"
+        )
 
     def test_B(self):
         mod = self.make_parse_item("B", "char", "char_to_hpybytes")

--- a/test/test_argparse.py
+++ b/test/test_argparse.py
@@ -56,6 +56,20 @@ class TestParseItem(HPyTest):
             "function unsigned byte integer is less than minimum"
         )
 
+    def test_s(self):
+        import pytest
+        mod = self.make_parse_item("s", "const char*", "HPyUnicode_FromString")
+        assert mod.f("hello HPy") == "hello HPy"
+        with pytest.raises(ValueError) as err:
+            mod.f(b"hello\0HPy".decode('utf-8'))
+        assert str(err.value) == (
+            "function embedded null character"
+        )
+        with pytest.raises(TypeError) as err:
+            mod.f(b"hello HPy")
+        # No assertion of the message for now
+        # CPython's message reads: argument {N} must be str, not int
+
     def test_B(self):
         mod = self.make_parse_item("B", "char", "char_to_hpybytes")
         assert mod.f(0) == b"\x00"

--- a/test/test_hpyunicode.py
+++ b/test/test_hpyunicode.py
@@ -86,3 +86,19 @@ class TestUnicode(HPyTest):
         """)
         assert mod.f('ABC') == 100*ord('A') + 10*ord('B') + ord('C')
         assert mod.f(b'A\0C'.decode('utf-8')) == 100*ord('A') + ord('C')
+
+
+    def test_DecodeFSDefault(self):
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", f_impl, HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                HPy_ssize_t n;
+                const char* buf = HPyUnicode_AsUTF8AndSize(ctx, arg, &n);
+                return HPyUnicode_DecodeFSDefault(ctx, buf);
+                return HPy_Dup(ctx, ctx->h_None);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f('ABC') == "ABC"

--- a/test/test_hpyunicode.py
+++ b/test/test_hpyunicode.py
@@ -67,3 +67,22 @@ class TestUnicode(HPyTest):
         b = mod.f(s)
         assert type(b) is bytes
         assert b == s.encode('utf-8')
+
+
+    def test_AsUTF8AndSize(self):
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", f_impl, HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                HPy_ssize_t n;
+                const char* buf = HPyUnicode_AsUTF8AndSize(ctx, arg, &n);
+                long res = 0;
+                for(int i=0; i<n; i++)
+                    res = (res * 10) + buf[i];
+                return HPyLong_FromLong(ctx, res);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f('ABC') == 100*ord('A') + 10*ord('B') + ord('C')
+        assert mod.f(b'A\0C'.decode('utf-8')) == 100*ord('A') + ord('C')


### PR DESCRIPTION
APIs needed to port `psutils`