### PR TITLE
Documentation build cleanup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -179,6 +179,10 @@ jobs:
       make valgrind
 
 - job: BuildDocs
+  # This job checks that the documentation builds successfully without
+  # warnings but does not store the built documentation. The canonical
+  # copy of the documentation is built by readthedocs and viewable at
+  # https://docs.hpyproject.org/.
   pool:
     vmImage: 'ubuntu-latest'
   displayName: 'Build documentation'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,3 +177,17 @@ jobs:
   - script: |
       pip install pytest pytest-azurepipelines pytest-valgrind
       make valgrind
+
+- job: BuildDocs
+  pool:
+    vmImage: 'ubuntu-latest'
+  displayName: 'Build documentation'
+  steps:
+  - template: azure-templates/python.yml
+  - script: python -m pip install --upgrade pip
+    displayName: 'Upgrade pip'
+  - script: python -m pip install -r docs/requirements.txt
+    displayName: 'Install documentation requirements'
+  - script: |
+      cd docs;
+      python -m sphinx -T -W -E -b html -d _build/doctrees -D language=en . _build/html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,6 +184,8 @@ jobs:
   displayName: 'Build documentation'
   steps:
   - template: azure-templates/python.yml
+  - script: sudo apt update && sudo apt install -y libclang-10-dev
+    displayName: 'Install libclang-10-dev'
   - script: python -m pip install --upgrade pip
     displayName: 'Upgrade pip'
   - script: python -m pip install -r docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import sys
 import os
 import re
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,10 +68,25 @@ def pre_process(app, filename, contents, *args):
 def setup(app):
     app.connect("c-autodoc-pre-process", pre_process)
 
+
 def setup_clang():
     """
-    The clang library needs to find libclang*.so, but it seems there isn't a
-    fully portable solution. Let's try our best.
+    Make sure clang is set up correctly for the sphinx_c_autodoc extension.
+
+    The Python clang package requires a matching libclang*.so. Our
+    ``doc/requirements.txt`` file specifies ``clang==10.0.1``, so we need
+    ``libclang-10``.
+
+    On Ubuntu 20.04 (and possibly later), this can be installed with
+    ``apt install libclang-10-dev`` and the Python clang package finds the
+    appropriate .so automatically.
+
+    However, ReadTheDocs has an older Ubuntu that only packages libclang-6.0.
+    The Python ``clang==10.0.1`` packages supports this older .so, but
+    needs to be explicitly told where to find it.
+
+    If you encounter issues with a local build, please start by checking that
+    the ``libclang-10-dev`` system package or equivalent is installed.
     """
     from clang import cindex
     if 'READTHEDOCS' in os.environ:
@@ -81,26 +96,7 @@ def setup_clang():
         cindex.Config.set_library_file(
             "/usr/lib/x86_64-linux-gnu/libclang-6.0.so.1"
         )
-        return
 
-    try:
-        pass  # cindex.Index.create()
-    except cindex.LibclangError as error:
-        pass
-    else:
-        # it works out of the box, nothing to do
-        return
-
-    # libclang*.so not found :( Try to print a reasonable message
-    YELLOW = "\033[1;33m"
-    RESET = "\033[0m"
-    print(YELLOW)
-    print('====================')
-    print('Cannot load libclang')
-    print('   ', error)
-    print('HINT if you are on ubuntu, try the following:')
-    print('    apt install libclang-10-dev')
-    print(RESET)
 
 setup_clang()
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,10 +57,10 @@ c_autodoc_roots = [
 
 
 def pre_process(app, filename, contents, *args):
-    # remove HPyAPI_RUNTIME_FUNC so that the sphinx-c-autodoc and clang
+    # remove HPyAPI_HELPER so that the sphinx-c-autodoc and clang
     # find and render the API functions
     contents[:] = [
-        re.sub(r"HPyAPI_RUNTIME_FUNC\((.*)\)", r"\1", part)
+        re.sub(r"^HPyAPI_HELPER ", r"", part, flags=re.MULTILINE)
         for part in contents
     ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ def setup_clang():
         return
 
     try:
-        cindex.Index.create()
+        pass  # cindex.Index.create()
     except cindex.LibclangError as error:
         pass
     else:

--- a/docs/debug-mode.rst
+++ b/docs/debug-mode.rst
@@ -1,0 +1,17 @@
+Debug Mode
+==========
+
+HPy includes a debug mode that may be activated at *run time* with
+*no overhead*. This is possible because the whole of the HPy API is provided
+as part of the HPy context, so debug mode can pass in a special debugging
+context (that wraps the normal context) without affecting the performance of
+the regular context at all.
+
+The debugging context can already check for:
+
+* Leaked handles.
+* Handles used after they are closed.
+
+An HPy module may be loaded in debug mode using::
+
+  mod = hpy.universal.load(module_name, so_filename, debug=True)

--- a/docs/debug-mode.rst
+++ b/docs/debug-mode.rst
@@ -1,8 +1,19 @@
 Debug Mode
 ==========
 
-HPy includes a debug mode that may be activated at *run time* with
-*no overhead*. This is possible because the whole of the HPy API is provided
+HPy includes a debug mode which includes a lot of useful run-time checks to
+ensure that C extensions use the API correctly. The major points of the debug mode are:
+
+    1. no special compilation flags are required: it is enough to compile the extension 
+       with the Universal ABI.
+    
+    2. The debug mode can be activated at *import time*, and it can be activated
+       per-extension.
+    
+    3. You pay the overhead of the debug mode only if you use it. Extensions loaded 
+       without the debug mode run at full speed.
+
+This is possible because the whole of the HPy API is provided
 as part of the HPy context, so debug mode can pass in a special debugging
 context (that wraps the normal context) without affecting the performance of
 the regular context at all.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ There are several advantages to write your C extension in HPy:
    overview
    porting-guide
    API <api>
+   debug-mode
    api-reference/index
    misc/index
 

--- a/docs/misc/str-builder-api.rst
+++ b/docs/misc/str-builder-api.rst
@@ -227,12 +227,12 @@ widely used outside CPython. A simple ``grep`` found only 17 matches in the
 4000 packages, although some are in very important packages such as
 `cffi <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0021-cffi-1.14.5/c/wchar_helper_3.h#L36>`_,
 ``markupsafe``
-(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0024-MarkupSafe-2.0.1/src/markupsafe/_speedups.c#L106>`_,
-`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0024-MarkupSafe-2.0.1/src/markupsafe/_speedups.c#L132>`_,
-`3 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0024-MarkupSafe-2.0.1/src/markupsafe/_speedups.c#L158>`_)
+(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0024-MarkupSafe-2.0.1/src/markupsafe/_speedups.c#L106>`__,
+`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0024-MarkupSafe-2.0.1/src/markupsafe/_speedups.c#L132>`__,
+`3 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0024-MarkupSafe-2.0.1/src/markupsafe/_speedups.c#L158>`__)
 and ``simplejson``
-(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0096-simplejson-3.17.2/simplejson/_speedups.c#L517>`_,
-`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0096-simplejson-3.17.2/simplejson/_speedups.c#L3330>`_).
+(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0096-simplejson-3.17.2/simplejson/_speedups.c#L517>`__,
+`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0096-simplejson-3.17.2/simplejson/_speedups.c#L3330>`__).
 
 In all the examples linked above, ``maxchar`` is hard-coded and known at
 compile time.
@@ -241,13 +241,13 @@ There are only four usages of ``PyUnicode_New`` in which ``maxchar`` is
 actually unknown until runtime, and it is curious to note that the first three
 are in runtime libraries used by code generators:
 
-  1. `mypyc <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0277-mypy-0.812/mypyc/lib-rt/str_ops.c#L22>`_
+  1. `mypyc <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0277-mypy-0.812/mypyc/lib-rt/str_ops.c#L22>`__
 
-  2. `Cython <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L829>`_
+  2. `Cython <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L829>`__
 
-  3. `siplib <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top4000/1236-PyQt5_sip-12.9.0/siplib.c#L12808>`_
+  3. `siplib <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top4000/1236-PyQt5_sip-12.9.0/siplib.c#L12808>`__
 
-  4. `PyICU <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top4000/2601-PyICU-2.7.3/common.cpp#L213>`_:
+  4. `PyICU <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top4000/2601-PyICU-2.7.3/common.cpp#L213>`__:
      this is the only non-runtime library usage of it, and it's used to
      implement a routine to create a ``str`` object from an UTF-16 buffer.
 
@@ -263,8 +263,8 @@ A special case is ``PyUnicode_New(0, 0)``, which contructs an empty ``str``
 object.  CPython special-cases it to always return a prebuilt object.
 
 This pattern is used a lot inside CPython but only once in 3rd-party extensions, in the ``regex`` library (
-`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19486>`_,
-`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19516>`_).
+`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19486>`__,
+`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19516>`__).
 
 Other ways to build empty strings are ``PyUnicode_FromString("")`` which is used 27 times and ``PyUnicode_FromStringAndSize("", 0)`` which is used only `once
 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0268-pyodbc-4.0.30/src/textenc.cpp#L144>`_.
@@ -331,6 +331,7 @@ macro takes a parameter called ``outp`` which is obtained by calling
 ``DO_ESCAPE`` contains code like this, which would be hard to port to a fully-opaque API:
 
 .. code-block:: c
+
     memcpy(outp, inp-ncopy, sizeof(*outp)*ncopy); \
     outp += ncopy; ncopy = 0; \
     *outp++ = '&'; \
@@ -341,10 +342,11 @@ macro takes a parameter called ``outp`` which is obtained by calling
     break; \
 
 Another interesting example is
-`pybase64 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top4000/1925-pybase64-1.1.4/pybase64/_pybase64.c#L320-349`_.
+`pybase64 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top4000/1925-pybase64-1.1.4/pybase64/_pybase64.c#L320-349>`_.
 After removing the unnecessary stuff, the logic boils down to this:
 
 .. code-block:: c
+
     out_len = (size_t)(((buffer.len + 2) / 3) * 4);
     out_object = PyUnicode_New((Py_ssize_t)out_len, 127);
     dst = (char*)PyUnicode_1BYTE_DATA(out_object);
@@ -382,12 +384,10 @@ The other way to get a pointer to the raw-buffer is to call
 ``PyUnicode_DATA()``, which returns a ``void *``: the only reasonable way to
 write something in this buffer is to ``memcpy()`` the data from another
 ``str`` buffer of the same kind. This technique is used for example by
-`CPython's textio.c
-<https://github.com/antocuni/cpython/blob/7b3ab5921fa25ed8b97b6296f97c5c78aacf5447/Modules/_io/textio.c#L344>`_.
+`CPython's textio.c <https://github.com/antocuni/cpython/blob/7b3ab5921fa25ed8b97b6296f97c5c78aacf5447/Modules/_io/textio.c#L344>`_.
 
 Outside CPython, the only usage of this technique is inside cython's helper
-function `__Pyx_PyUnicode_Join
-<https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L857>`_.
+function `__Pyx_PyUnicode_Join <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L857>`_.
 
 This probably means that we don't need to offer untyped raw-buffer writing for
 HPy. If we really need to support the ``memcpy`` use case, we can probably
@@ -398,8 +398,8 @@ PyUnicode_WRITE, PyUnicode_WriteChar
 
 Outside CPython, ``PyUnicode_WRITE()`` is used only inside Cython's helper
 functions
-(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L865>`_,
-`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L914-L926>`_).
+(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L865>`__,
+`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L914-L926>`__).
 Considering that Cython will need special support for HPy anyway, this means
 that we don't need an equivalent of ``PyUnicode_WRITE`` for HPy.
 
@@ -415,30 +415,29 @@ size of the string: ``PyUnicode_Join()`` is the only native API call which
 allows to build a string whose size is not known in advance.
 
 Examples of usage are found in ``simplejson``
-(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0096-simplejson-3.17.2/simplejson/_speedups.c#L779>`_,
-`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0096-simplejson-3.17.2/simplejson/_speedups.c#L1033>`_),
-`pycairo <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0759-pycairo-1.20.0/cairo/path.c#L156>`_,
+(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0096-simplejson-3.17.2/simplejson/_speedups.c#L779>`__,
+`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top100/0096-simplejson-3.17.2/simplejson/_speedups.c#L1033>`__),
+`pycairo <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0759-pycairo-1.20.0/cairo/path.c#L156>`__,
 ``regex``
-(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19492>`_,
-`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L22674>`_,
-`3 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L22768>`_,
-`4 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19440>`_,
-`5 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L22495>`_,
-`6 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L22589>`_)
+(`1 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19492>`__,
+`2 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L22674>`__,
+`3 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L22768>`__,
+`4 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19440>`__,
+`5 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L22495>`__,
+`6 <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L22589>`__)
 and others, for a total of 25 grep matches.
 
 
 .. note::
+
    Contrarily to its unicode equivalent, ``PyBytes_Join()`` does not
    exist. There is ``_PyBytes_Join()`` which is private and undocumented, but
    some extensions rely on it anyway:
-   `Cython <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L795>`_,
-   `regex <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19501>`_,
-   `dulwich <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top4000/1424-dulwich-0.20.23/dulwich/_pack.c#L62>`_.
+   `Cython <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0158-Cython-0.29.23/Cython/Utility/StringTools.c#L795>`__,
+   `regex <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top1000/0119-regex-2021.4.4/regex_3/_regex.c#L19501>`__,
+   `dulwich <https://github.com/hpyproject/top4000-pypi-packages/blob/0cd919943a007f95f4bf8510e667cfff5bd059fc/top4000/1424-dulwich-0.20.23/dulwich/_pack.c#L62>`__.
 
 In theory, alternative implementaions should be able to provide a more
 efficient way to achieve the goal. E.g. for pure Python code PyPy offers
 ``__pypy__.builders.StringBuilder`` which is faster than both ``StringIO`` and
 ``''.join``, so maybe it might make sense to offer a way to use it from C.
-
-

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -189,7 +189,7 @@ API:
     to early :ref:`benchmarks`, an extension written in HPy can be ~3x faster
     than the equivalent extension written in Python/C.
 
-  - Improved debugging: when you load extensions in :ref:`debugging mode`,
+  - Improved debugging: when you load extensions in :ref:`debug mode`,
     many common mistakes are checked and reported automatically.
 
   - Universal binaries: you can choose to distribute only Universal ABI

--- a/hpy/devel/src/runtime/argparse.c
+++ b/hpy/devel/src/runtime/argparse.c
@@ -126,8 +126,8 @@
  *     used as the error message instead of the default error message. : and ;
  *     are mutually exclusive and whichever occurs first takes precedence.
  *
- * API
- * ---
+ * Argument Parsing API
+ * --------------------
  *
  */
 

--- a/hpy/devel/src/runtime/helpers.c
+++ b/hpy/devel/src/runtime/helpers.c
@@ -4,8 +4,8 @@
  * These are not part of the HPy context or ABI, but are available for
  * HPy extensions to incorporate at compile time.
  *
- * API
- * ---
+ * Runtime Helpers API
+ * -------------------
  *
  */
 


### PR DESCRIPTION
Our documentation currently isn't building on readthedocs and it's producing quite a few warnings. This PR intends to clean all that up.

Issues addressed so far:

- [x] Add double underscores to anonymous external references to prevent RST warnings.
- [x] Reference the non-existent debug mode documentation consistently throughout the docs.
- [x] Give runtime and helper API documentation different section names to prevent a Sphinx warning.
- [x] Update removal of HPyAPI_HELPER define to help spinx-c-autodoc / clang properly find these functions.
- [x] Remove attempt to call cindex.Index.create that segfaults in some cases.

Still to do:

- [x] Debug the failing [readthedocs builds](https://readthedocs.org/projects/hpy/builds/) (hopefully easier now that less is going wrong)
- [x] Discuss the complete removal of the call to `cindex.Index.create`
- [x] Discuss making the build fail in the are warnings produced while running the documentation build (this would have picked up some of the issues that resulted in our build missing documentation or failing)