### PR TITLE
Introduce helper HPy_BuildValue

### DIFF
--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -40,6 +40,7 @@ class HPyDevel:
         """
         return list(map(str, [
             self.src_dir.joinpath('argparse.c'),
+            self.src_dir.joinpath('buildvalue.c'),
             self.src_dir.joinpath('helpers.c'),
         ]))
 

--- a/hpy/devel/include/hpy.h
+++ b/hpy/devel/include/hpy.h
@@ -135,6 +135,7 @@ typedef struct _HPyContext_s HPyContext;
 #include "hpy/hpytype.h"
 #include "hpy/hpymodule.h"
 #include "hpy/runtime/argparse.h"
+#include "hpy/runtime/buildvalue.h"
 #include "hpy/runtime/helpers.h"
 
 #ifdef HPY_UNIVERSAL_ABI

--- a/hpy/devel/include/hpy/runtime/buildvalue.h
+++ b/hpy/devel/include/hpy/runtime/buildvalue.h
@@ -1,0 +1,9 @@
+#ifndef HPY_COMMON_RUNTIME_BUILDVALUE_H
+#define HPY_COMMON_RUNTIME_BUILDVALUE_H
+
+#include "hpy.h"
+
+HPyAPI_HELPER HPy
+HPy_BuildValue(HPyContext *ctx, const char *fmt, ...);
+
+#endif /* HPY_COMMON_RUNTIME_BUILDVALUE_H */

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -45,7 +45,7 @@ static HPy_ssize_t count_items(HPyContext *ctx, const char *fmt, char end);
 static HPy build_tuple(HPyContext *ctx, const char **fmt, va_list *values, HPy_ssize_t size, char expected_end);
 static HPy build_single(HPyContext *ctx, const char **fmt, va_list *values);
 
-// HPyAPI_HELPER
+HPyAPI_HELPER
 HPy HPy_BuildValue(HPyContext *ctx, const char *fmt, ...)
 {
     va_list values;
@@ -102,6 +102,9 @@ static HPy build_single(HPyContext *ctx, const char **fmt, va_list *values)
     switch (*(*fmt)++) {
         case '(': {
             HPy_ssize_t size = count_items(ctx, *fmt, ')');
+            if (size < 0) {
+                return HPy_NULL;
+            }
             return build_tuple(ctx, fmt, values, size, ')');
         }
 

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -1,0 +1,142 @@
+/**
+ * Implementation of HPy_BuildValue.
+ *
+ * HPy_BuildValue creates a new value based on a format string from the values
+ * passed in an array. Returns HPy_NULL in case of an error and raises an exception.
+ *
+ * HPy_BuildValue does not always build a tuple. It builds a tuple only if its format
+ * string contains two or more format units. If the format string is empty, it returns
+ * None; if it contains exactly one format unit, it returns whatever object is described
+ * by that format unit. To force it to return a tuple of size 0 or one, parenthesize the
+ * format string.
+ *
+ * Building complex values with HPy_BuildValue is more convenient than the equivalent
+ * code that uses more granular APIs with proper error handling and cleanup. Moreover,
+ * HPy_BuildValue provides straightforward way to port existing code that uses
+ * Py_BuildValue.
+ *
+ * Supported Formatting Strings
+ * ----------------------------
+ *
+ * Numbers
+ * ~~~~~~~
+ *
+ * ``i (int) [int]``
+ *     Convert a plain C int to a Python integer object.
+ *
+ * ``f (float) [float]``
+ *     Convert a C float to a Python floating point number.
+ *
+ * Collections
+ * ~~~~~~~
+ *
+ * ``(items) (tuple) [matching-items]``
+ *     Convert a sequence of C values to a Python tuple with the same number of items.
+ *
+ * API
+ * ---
+ *
+ */
+
+#include "hpy.h"
+#include <stdarg.h>
+
+static HPy_ssize_t count_items(HPyContext *ctx, const char *fmt, char end);
+static HPy build_tuple(HPyContext *ctx, const char **fmt, va_list *values, HPy_ssize_t size, char expected_end);
+static HPy build_single(HPyContext *ctx, const char **fmt, va_list *values);
+
+// HPyAPI_HELPER
+HPy HPy_BuildValue(HPyContext *ctx, const char *fmt, ...)
+{
+    va_list values;
+    va_start(values, fmt);
+    HPy_ssize_t size = count_items(ctx, fmt, '\0');
+    if (size < 0) {
+        return HPy_NULL;
+    } else if (size == 1) {
+        return build_single(ctx, &fmt, &values);
+    } else {
+        return build_tuple(ctx, &fmt, &values, size, '\0');
+    }
+}
+
+static HPy_ssize_t count_items(HPyContext *ctx, const char *fmt, char end)
+{
+    HPy_ssize_t level = 0, result = 0;
+    while (*fmt != end) {
+        switch (*fmt++) {
+            case '\0':
+                // Premature end
+                HPyErr_SetString(ctx, ctx->h_SystemError, "unmatched paren in format");
+                return -1;
+
+            case '[':
+            case '(':
+            case '{':
+                if (level == 0) {
+                    result++;
+                }
+                level++;
+                break;
+
+            case ']':
+            case ')':
+            case '}':
+                level--;
+                break;
+
+            case ' ':
+                break;
+
+            default:
+                if (level == 0) {
+                    result++;
+                }
+        }
+    }
+    return result;
+}
+
+static HPy build_single(HPyContext *ctx, const char **fmt, va_list *values)
+{
+    switch (*(*fmt)++) {
+        case '(': {
+            HPy_ssize_t size = count_items(ctx, *fmt, ')');
+            return build_tuple(ctx, fmt, values, size, ')');
+        }
+
+        case 'i':
+            return HPyLong_FromLong(ctx, (long)va_arg(*values, int));
+
+        case 'f':
+            return HPyFloat_FromDouble(ctx, (double)va_arg(*values, double));
+
+        default: {
+            HPyErr_SetString(ctx, ctx->h_SystemError, "NULL object passed to Py_BuildValue");
+            return HPy_NULL;
+        }
+    } // switch
+}
+
+static HPy build_tuple(HPyContext *ctx, const char **fmt, va_list *values, HPy_ssize_t size, char expected_end)
+{
+    HPyTupleBuilder builder = HPyTupleBuilder_New(ctx, size);
+    for (HPy_ssize_t i = 0; i < size; ++i) {
+        HPy item = build_single(ctx, fmt, values);
+        if (HPy_IsNull(item)) {
+            HPyTupleBuilder_Cancel(ctx, builder);
+            return HPy_NULL;
+        }
+        HPyTupleBuilder_Set(ctx, builder, i, item);
+        HPy_Close(ctx, item);
+    }
+    if (**fmt != expected_end) {
+        HPyTupleBuilder_Cancel(ctx, builder);
+        HPyErr_SetString(ctx, ctx->h_SystemError, "Unmatched paren in format");
+        return HPy_NULL;
+    }
+    if (expected_end != '\0') {
+        ++*fmt;
+    }
+    return HPyTupleBuilder_Build(ctx, builder);
+}

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -219,7 +219,6 @@ static HPy build_single(HPyContext *ctx, const char **fmt, va_list *values, int 
             return HPyUnicode_FromString(ctx, va_arg(*values, const char*));
 
         case 'O':
-        case 'N':
         case 'S': {
             HPy handle = va_arg(*values, HPy);
             if (HPy_IsNull(handle)) {
@@ -230,6 +229,17 @@ static HPy build_single(HPyContext *ctx, const char **fmt, va_list *values, int 
             }
             *needs_close = 0;
             return handle;
+        }
+
+        case 'N': {
+            HPyErr_SetString(ctx, ctx->h_SystemError,
+                             "HPy_BuildValue does not support the 'N' formatting unit. "
+                             "Instead, use the 'O' formatting unit and manually close "
+                             "the handle in the caller if necessary. HPy API functions "
+                             "never 'steal' handles and always make a duplicate handle if "
+                             "needed, the 'ownership' of the original handle is never "
+                             "'transferred'. ");
+            return HPy_NULL;
         }
 
         case 'f': // Note: floats are promoted to doubles when passed in "..."

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -74,10 +74,6 @@
  *      never closes the handle nor transfers its ownership. If the handle is used, then
  *      HPy_BuildValue creates a duplicate of the handle.
  *
- * ``N (Python object) [HPy]``
- *      For compatibility reasons and ease of porting from CPython API, HPy_BuildValue
- *      also supports 'N', but it is an alias to 'O'.
- *
  * ``S (Python object) [HPy]``
  *      Alias for 'O'.
  *

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -143,7 +143,7 @@ static HPy_ssize_t count_items(HPyContext *ctx, const char *fmt, char end)
                     }
                     par_type = top_level_par;
                 }
-                snprintf(msg, MESSAGE_BUF_SIZE, "unmatched '%c' in the format string passed HPy_BuildValue", par_type);
+                snprintf(msg, MESSAGE_BUF_SIZE, "unmatched '%c' in the format string passed to HPy_BuildValue", par_type);
                 HPyErr_SetString(ctx, ctx->h_SystemError, msg);
                 return -1;
             }
@@ -264,7 +264,7 @@ static HPy build_list(HPyContext *ctx, const char **fmt, va_list *values, HPy_ss
         // count_items does not check the type of the matching paren, that's what we do here
         HPyListBuilder_Cancel(ctx, builder);
         HPyErr_SetString(ctx, ctx->h_SystemError,
-                         "unmatched '[' in the format string passed HPy_BuildValue");
+                         "unmatched '[' in the format string passed to HPy_BuildValue");
         return HPy_NULL;
     }
     ++*fmt;
@@ -294,7 +294,7 @@ static HPy build_tuple(HPyContext *ctx, const char **fmt, va_list *values, HPy_s
             HPyErr_SetString(ctx, ctx->h_SystemError, "internal error in HPy_BuildValue");
         } else {
             HPyErr_SetString(ctx, ctx->h_SystemError,
-                             "unmatched '[' in the format string passed HPy_BuildValue");
+                             "unmatched '[' in the format string passed to HPy_BuildValue");
         }
         return HPy_NULL;
     }

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -131,7 +131,7 @@ static HPy_ssize_t count_items(HPyContext *ctx, const char *fmt, char end)
                 // Premature end
                 // We try to provide slightly better diagnostics than CPython
                 char msg[MESSAGE_BUF_SIZE];
-                char par_type = 'X';
+                char par_type;
                 if (end == ')') {
                     par_type = '(';
                 } else if (end == ']') {

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -105,6 +105,8 @@ HPy HPy_BuildValue(HPyContext *ctx, const char *fmt, ...)
     HPy_ssize_t size = count_items(ctx, fmt, '\0');
     if (size < 0) {
         return HPy_NULL;
+    } else if (size == 0) {
+        return HPy_Dup(ctx, ctx->h_None);
     } else if (size == 1) {
         int needs_close;
         HPy result = build_single(ctx, &fmt, &values, &needs_close);

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -59,16 +59,16 @@
  * ~~~~~~~
  *
  * ``O (Python object) [HPy]``
- *      Pass a untouched Python object represented by the handle. If the object passed
+ *      Pass an untouched Python object represented by the handle. If the object passed
  *      in is a HPy_NULL, it is assumed that this was caused because the call producing
  *      the argument found an error and set an exception. Therefore, HPy_BuildValue will
- *      also immediately stop and return HPy_NULL but will not raise a new exception. If
- *      no exception has been raised yet, SystemError is set.
+ *      also immediately stop and return HPy_NULL but will not raise any new exception.
+ *      If no exception has been raised yet, SystemError is set.
  *
  * ``N (Python object) [HPy]``
- *      For the compatibility reasons and ease of porting from CPython API, HPy_BuildValue
- *      also supports, but it is an alias to 'O'. Any HPy handle passed to HPy_BuildValue is
- *      always owned by the caller.
+ *      For compatibility reasons and ease of porting from CPython API, HPy_BuildValue
+ *      also supports 'N', but it is an alias to 'O'. Any HPy handle passed to HPy_BuildValue
+ *      is always owned by the caller.
  *
  * ``S (Python object) [HPy]``
  *      Alias for 'O'.

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ EXT_MODULES = [
                'hpy/universal/src/ctx_meth.c',
                'hpy/universal/src/ctx_misc.c',
                'hpy/devel/src/runtime/argparse.c',
+               'hpy/devel/src/runtime/buildvalue.c',
                'hpy/devel/src/runtime/helpers.c',
                'hpy/devel/src/runtime/ctx_bytes.c',
                'hpy/devel/src/runtime/ctx_call.c',

--- a/test/test_hpybuildvalue.py
+++ b/test/test_hpybuildvalue.py
@@ -1,0 +1,51 @@
+"""
+NOTE: this tests are also meant to be run as PyPy "applevel" tests.
+
+This means that global imports will NOT be visible inside the test
+functions. In particular, you have to "import pytest" inside the test in order
+to be able to use e.g. pytest.raises (which on PyPy will be implemented by a
+"fake pytest module")
+"""
+from .support import HPyTest
+from .test_hpylong import unsigned_long_bits
+
+
+class TestParseItem(HPyTest):
+
+    def make_build_item(self, fmt, values):
+        mod = self.make_module("""
+            #include <limits.h>
+        
+            HPyDef_METH(f, "f", f_impl, HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {{
+                return HPy_BuildValue(ctx, "{fmt}", {values});
+            }}
+            @EXPORT(f)
+            @INIT
+        """.format(fmt=fmt, values=values))
+        return mod
+
+    def test_f(self):
+        mod = self.make_build_item("f", "HPyFloat_AsDouble(ctx, arg)")
+        assert mod.f(0.25) == 0.25
+
+    def test_i(self):
+        mod = self.make_build_item("i", "HPyLong_AsLong(ctx, arg)")
+        assert mod.f(42) == 42
+        assert mod.f(0) == 0
+        assert mod.f(-1) == -1
+
+    def test_ii(self):
+        mod = self.make_build_item("ii", "-1, 1")
+        assert mod.f(None) == (-1, 1)
+
+    def test_i_pars(self):
+        mod = self.make_build_item("(i)", "-1")
+        assert mod.f(None) == (-1,)
+
+    def test_limits(self):
+        mod = self.make_build_item("(ii)", "INT_MIN, INT_MAX")
+        result = mod.f(None)
+        assert result[0] < 0
+        assert result[1] > 0

--- a/test/test_hpybuildvalue.py
+++ b/test/test_hpybuildvalue.py
@@ -1,51 +1,117 @@
-"""
-NOTE: this tests are also meant to be run as PyPy "applevel" tests.
-
-This means that global imports will NOT be visible inside the test
-functions. In particular, you have to "import pytest" inside the test in order
-to be able to use e.g. pytest.raises (which on PyPy will be implemented by a
-"fake pytest module")
-"""
 from .support import HPyTest
-from .test_hpylong import unsigned_long_bits
+import pytest
 
 
-class TestParseItem(HPyTest):
+class TestBuildValue(HPyTest):
 
-    def make_build_item(self, fmt, values):
+    def make_build_item(self, fmt, values=None):
+        comma_and_values = "" if values is None else ", " + values
         mod = self.make_module("""
             #include <limits.h>
         
             HPyDef_METH(f, "f", f_impl, HPyFunc_O)
             static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
             {{
-                return HPy_BuildValue(ctx, "{fmt}", {values});
+                return HPy_BuildValue(ctx, "{fmt}" {values});
             }}
             @EXPORT(f)
             @INIT
-        """.format(fmt=fmt, values=values))
+        """.format(fmt=fmt, values=comma_and_values))
         return mod
 
-    def test_f(self):
-        mod = self.make_build_item("f", "HPyFloat_AsDouble(ctx, arg)")
-        assert mod.f(0.25) == 0.25
+    @pytest.mark.parametrize("fmt, c_values, expected", [
+        ("i", "42", 42),
+        ("i", "0", 0),
+        ("i", "-1", -1),
+        ("I", "33", 33),
+        ("k", "1", 1),
+        ("K", "6543", 6543),
+        ("l", "345L", 345),
+        ("l", "-876L", -876),
+        ("L", "545LL", 545),
+        ("L", "-344LL", -344),
+        ("f", "0.25f", 0.25),
+        ("d", "0.25", 0.25),
+        ("ii", "-1, 1", (-1, 1)),
+        ("(i)", "-1", (-1,)),
+        ("(ii)", "-1, 1", (-1, 1)),
+        ("s", '"test string"', "test string"),
+        ("[ii]", "4, 2", [4, 2]),
+        ("[is]", '4, "2"', [4, "2"]),
+        ("[]", None, []),
+        ("[(is)((f)[kk])i]", '4, "str", 0.25, 4, 2, 14267', [(4, "str"), ((0.25,), [4, 2]), 14267]),
+    ])
+    def test_formats(self, fmt, c_values, expected):
+        mod = self.make_build_item(fmt, c_values)
+        assert mod.f(None) == expected
 
-    def test_i(self):
-        mod = self.make_build_item("i", "HPyLong_AsLong(ctx, arg)")
-        assert mod.f(42) == 42
-        assert mod.f(0) == 0
-        assert mod.f(-1) == -1
+    @pytest.mark.parametrize("fmt", ["O", "N", "S"])
+    def test_O_and_aliases(self, fmt):
+        class Dummy:
+            pass
+        obj = Dummy()
+        mod = self.make_build_item(fmt, "arg")
+        assert mod.f(obj) == obj
 
-    def test_ii(self):
-        mod = self.make_build_item("ii", "-1, 1")
-        assert mod.f(None) == (-1, 1)
+    def test_OO_pars_with_new_objects(self):
+        mod = self.make_module("""
+            #include <stdio.h>
+            HPyDef_METH(f, "f", f_impl, HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {{
+                HPy o1 = HPyLong_FromLong(ctx, 1);
+                HPy o2 = HPyLong_FromLong(ctx, 2);
+                HPy result = HPy_BuildValue(ctx, "(OO)", o1, o2);
+                HPy_Close(ctx, o1);
+                HPy_Close(ctx, o2);
+                return result;
+            }}
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f(None) == (1, 2)
 
-    def test_i_pars(self):
-        mod = self.make_build_item("(i)", "-1")
-        assert mod.f(None) == (-1,)
-
-    def test_limits(self):
+    def test_int_limits(self):
         mod = self.make_build_item("(ii)", "INT_MIN, INT_MAX")
         result = mod.f(None)
         assert result[0] < 0
         assert result[1] > 0
+
+    def test_long_limit(self):
+        mod = self.make_build_item("(ll)", "LONG_MIN, LONG_MAX")
+        result = mod.f(None)
+        assert result[0] < 0
+        assert result[1] > 0
+
+    def test_longlong_limit(self):
+        mod = self.make_build_item("(LL)", "LLONG_MIN, LLONG_MAX")
+        result = mod.f(None)
+        assert result[0] < 0
+        assert result[1] > 0
+
+    def test_ulong_limit(self):
+        mod = self.make_build_item("k", "ULONG_MAX")
+        assert mod.f(None) > 0
+
+    def test_ulonglong_limit(self):
+        mod = self.make_build_item("k", "ULLONG_MAX")
+        assert mod.f(None) > 0
+
+    def test_uint_limit(self):
+        mod = self.make_build_item("k", "UINT_MAX")
+        assert mod.f(None) > 0
+
+    @pytest.mark.parametrize("fmt, msg", [
+        ("(q)", "bad format char 'q' in the format string passed HPy_BuildValue"),
+        ("(i", "unmatched '(' in the format string passed HPy_BuildValue"),
+        ("[i", "unmatched '[' in the format string passed HPy_BuildValue"),
+        ("([(i)k", "unmatched '(' in the format string passed HPy_BuildValue"),
+        ("(i]", "unmatched '(' in the format string passed HPy_BuildValue"),
+        ("[i)", "unmatched '[' in the format string passed HPy_BuildValue"),
+    ])
+    def test_bad_format(self, fmt, msg):
+        import pytest
+        mod = self.make_build_item(fmt, "42")
+        with pytest.raises(SystemError) as e:
+            mod.f(None)
+        assert msg in str(e)

--- a/test/test_hpybuildvalue.py
+++ b/test/test_hpybuildvalue.py
@@ -20,6 +20,7 @@ class TestBuildValue(HPyTest):
         return mod
 
     @pytest.mark.parametrize("fmt, c_values, expected", [
+        ("", None, None),
         ("i", "42", 42),
         ("i", "0", 0),
         ("i", "-1", -1),

--- a/test/test_hpybuildvalue.py
+++ b/test/test_hpybuildvalue.py
@@ -153,12 +153,12 @@ class TestBuildValue(HPyTest):
         assert mod.f(None) > 0
 
     @pytest.mark.parametrize("fmt, msg", [
-        ("(q)", "bad format char 'q' in the format string passed HPy_BuildValue"),
-        ("(i", "unmatched '(' in the format string passed HPy_BuildValue"),
-        ("[i", "unmatched '[' in the format string passed HPy_BuildValue"),
-        ("([(i)k", "unmatched '(' in the format string passed HPy_BuildValue"),
-        ("(i]", "unmatched '(' in the format string passed HPy_BuildValue"),
-        ("[i)", "unmatched '[' in the format string passed HPy_BuildValue"),
+        ("(q)", "bad format char 'q' in the format string passed to HPy_BuildValue"),
+        ("(i", "unmatched '(' in the format string passed to HPy_BuildValue"),
+        ("[i", "unmatched '[' in the format string passed to HPy_BuildValue"),
+        ("([(i)k", "unmatched '(' in the format string passed to HPy_BuildValue"),
+        ("(i]", "unmatched '(' in the format string passed to HPy_BuildValue"),
+        ("[i)", "unmatched '[' in the format string passed to HPy_BuildValue"),
     ])
     def test_bad_format(self, fmt, msg):
         import pytest

--- a/test/test_hpybuildvalue.py
+++ b/test/test_hpybuildvalue.py
@@ -8,7 +8,7 @@ class TestBuildValue(HPyTest):
         # to execute. Argument test_cases should be a tuple with first item
         # being C code of the test case.
         # Generates, e.g.: case 0: return HPy_BuildValue(...);
-        test_cases_c_code = [f"case {i}: {case[0]}; break;" for i, case in enumerate(test_cases)]
+        test_cases_c_code = ["case {}: {}; break;".format(i, case[0]) for i, case in enumerate(test_cases)]
         return self.make_module("""
             #include <limits.h>
 


### PR DESCRIPTION
In order to make porting to HPy more convenient I believe we need to provide API like `Py_BuildValue`, because otherwise there is too much error checking and handle closing boilerplate code. An alternative or additional API could be to extend the tuple builder with functions like `TupleBuilder_Set_i(ctx, builder, index, int_value)`. We can also have both and have `HPy_BuildValue` be built upon that API.

~This PR is intended as a discussion starter. It provides skeleton of the `HPy_BuildValue` implementation as I see it. Without the `TupleBuilder_Set_i` part for now.~

Update: the PR is now good to merge from my perspective. It provides all the formatting units used in `psutils` and I think it's now easy to add new less frequently used units.