### PR TITLE
Always define HPY macro when building HPy extensions

### DIFF
--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -217,6 +217,7 @@ class build_hpy_ext_mixin:
         ext.hpy_abi = self.distribution.hpy_abi
         ext.include_dirs += self.hpydevel.get_extra_include_dirs()
         ext.sources += self.hpydevel.get_extra_sources()
+        ext.define_macros.append(('HPY', None))
         if ext.hpy_abi == 'cpython':
             ext.sources += self.hpydevel.get_ctx_sources()
             ext._hpy_needs_stub = False


### PR DESCRIPTION
This macro would, for example, allow to share code between HPy extensions and CPython extensions that have not been ported to HPy yet. In general I think it may be useful to detect if the code is being compiled for HPy or not.