### PR TITLE
Add macros for parsing and converting pid_t values

### DIFF
--- a/hpy/devel/include/hpy/macros.h
+++ b/hpy/devel/include/hpy/macros.h
@@ -52,3 +52,20 @@ typedef enum {
             return HPy_Dup(ctx, ctx->h_True);                           \
         return HPy_Dup(ctx, ctx->h_False);                              \
     } while (0)
+
+
+#if !defined(SIZEOF_PID_T) || SIZEOF_PID_T == SIZEOF_INT
+    #define _HPy_PARSE_PID "i"
+    #define HPyLong_FromPid HPyLong_FromLong
+    #define HPyLong_AsPid HPyLong_AsLong
+#elif SIZEOF_PID_T == SIZEOF_LONG
+    #define _HPy_PARSE_PID "l"
+    #define HPyLong_FromPid HPyLong_FromLong
+    #define HPyLong_AsPid HPyLong_AsLong
+#elif defined(SIZEOF_LONG_LONG) && SIZEOF_PID_T == SIZEOF_LONG_LONG
+    #define _HPy_PARSE_PID "L"
+    #define HPyLong_FromPid HPyLong_FromLongLong
+    #define HPyLong_AsPid HPyLong_AsLongLong
+#else
+#error "sizeof(pid_t) is neither sizeof(int), sizeof(long) or sizeof(long long)"
+#endif /* SIZEOF_PID_T */


### PR DESCRIPTION
Defined the same set of macros as CPython. The reasoning is that `pid_t` may be a different type on different systems and one may want to convert to/from it or parse it in `HPyArg_Parse`. Without these macros one cannot avoid including `Python.h`. Alternative would be to let the packages define those macros for themselves.