### PR TITLE
Add h_BoolType and h_FloatType

### DIFF
--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -218,7 +218,9 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->h_ResourceWarning = DHPy_open(dctx, uctx->h_ResourceWarning);
     dctx->h_BaseObjectType = DHPy_open(dctx, uctx->h_BaseObjectType);
     dctx->h_TypeType = DHPy_open(dctx, uctx->h_TypeType);
+    dctx->h_BoolType = DHPy_open(dctx, uctx->h_BoolType);
     dctx->h_LongType = DHPy_open(dctx, uctx->h_LongType);
+    dctx->h_FloatType = DHPy_open(dctx, uctx->h_FloatType);
     dctx->h_UnicodeType = DHPy_open(dctx, uctx->h_UnicodeType);
     dctx->h_TupleType = DHPy_open(dctx, uctx->h_TupleType);
     dctx->h_ListType = DHPy_open(dctx, uctx->h_ListType);

--- a/hpy/devel/include/hpy/cpython/misc.h
+++ b/hpy/devel/include/hpy/cpython/misc.h
@@ -95,7 +95,9 @@ struct _HPyContext_s {
     /* Types */
     HPy h_BaseObjectType;
     HPy h_TypeType;
+    HPy h_BoolType;
     HPy h_LongType;
+    HPy h_FloatType;
     HPy h_UnicodeType;
     HPy h_TupleType;
     HPy h_ListType;
@@ -183,7 +185,9 @@ HPyAPI_FUNC HPyContext * _HPyGetContext(void) {
         /* Types */
         ctx->h_BaseObjectType = _py2h((PyObject *)&PyBaseObject_Type);
         ctx->h_TypeType = _py2h((PyObject *)&PyType_Type);
+        ctx->h_BoolType = _py2h((PyObject *)&PyBool_Type);
         ctx->h_LongType = _py2h((PyObject *)&PyLong_Type);
+        ctx->h_FloatType = _py2h((PyObject *)&PyFloat_Type);
         ctx->h_UnicodeType = _py2h((PyObject *)&PyUnicode_Type);
         ctx->h_TupleType = _py2h((PyObject *)&PyTuple_Type);
         ctx->h_ListType = _py2h((PyObject *)&PyList_Type);

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -85,7 +85,9 @@ struct _HPyContext_s {
     HPy h_ResourceWarning;
     HPy h_BaseObjectType;
     HPy h_TypeType;
+    HPy h_BoolType;
     HPy h_LongType;
+    HPy h_FloatType;
     HPy h_UnicodeType;
     HPy h_TupleType;
     HPy h_ListType;

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -101,7 +101,9 @@ HPy h_ResourceWarning;
 /* Types */
 HPy h_BaseObjectType;   /* built-in 'object' */
 HPy h_TypeType;         /* built-in 'type' */
+HPy h_BoolType;         /* built-in 'bool' */
 HPy h_LongType;         /* built-in 'int' */
+HPy h_FloatType;        /* built-in 'float' */
 HPy h_UnicodeType;      /* built-in 'str' */
 HPy h_TupleType;        /* built-in 'tuple' */
 HPy h_ListType;         /* built-in 'list' */

--- a/hpy/universal/src/hpymodule.c
+++ b/hpy/universal/src/hpymodule.c
@@ -272,7 +272,9 @@ static void init_universal_ctx(HPyContext *ctx)
     /* Types */
     ctx->h_BaseObjectType = _py2h((PyObject *)&PyBaseObject_Type);
     ctx->h_TypeType = _py2h((PyObject *)&PyType_Type);
+    ctx->h_BoolType = _py2h((PyObject *)&PyBool_Type);
     ctx->h_LongType = _py2h((PyObject *)&PyLong_Type);
+    ctx->h_FloatType  = _py2h((PyObject *)&PyFloat_Type);
     ctx->h_UnicodeType = _py2h((PyObject *)&PyUnicode_Type);
     ctx->h_TupleType = _py2h((PyObject *)&PyTuple_Type);
     ctx->h_ListType = _py2h((PyObject *)&PyList_Type);

--- a/test/test_00_basic.py
+++ b/test/test_00_basic.py
@@ -196,12 +196,14 @@ class TestBasic(HPyTest):
                     case 7: h = ctx->h_SystemError; break;
                     case 8: h = ctx->h_BaseObjectType; break;
                     case 9: h = ctx->h_TypeType; break;
-                    case 10: h = ctx->h_LongType; break;
-                    case 11: h = ctx->h_UnicodeType; break;
-                    case 12: h = ctx->h_TupleType; break;
-                    case 13: h = ctx->h_ListType; break;
-                    case 14: h = ctx->h_NotImplemented; break;
-                    case 15: h = ctx->h_Ellipsis; break;
+                    case 10: h = ctx->h_BoolType; break;
+                    case 11: h = ctx->h_LongType; break;
+                    case 12: h = ctx->h_FloatType; break;
+                    case 13: h = ctx->h_UnicodeType; break;
+                    case 14: h = ctx->h_TupleType; break;
+                    case 15: h = ctx->h_ListType; break;
+                    case 16: h = ctx->h_NotImplemented; break;
+                    case 17: h = ctx->h_Ellipsis; break;
                     default:
                         HPyErr_SetString(ctx, ctx->h_ValueError, "invalid choice");
                         return HPy_NULL;
@@ -213,7 +215,7 @@ class TestBasic(HPyTest):
         """)
         builtin_objs = (
             '<NULL>', None, False, True, ValueError, TypeError, IndexError,
-            SystemError, object, type, int, str, tuple, list, NotImplemented, Ellipsis,
+            SystemError, object, type, bool, int, float, str, tuple, list, NotImplemented, Ellipsis,
         )
         for i, obj in enumerate(builtin_objs):
             if i == 0:


### PR DESCRIPTION
Just adding handles for bool and float type to the context.
I need that for `ujson_hpy` which currently does this:

```
static inline int _HPyFloat_Check(HPyContext *ctx, HPy h_obj)
{
	HPy h_tmp = HPyFloat_FromDouble(ctx, 1.0);
	HPy h_floatType = HPy_Type(ctx, h_tmp);
	int res = HPy_TypeCheck(ctx, h_obj, h_floatType);
	HPy_Close(ctx, h_tmp);
	HPy_Close(ctx, h_floatType);
	return res;
}
```