### PR TITLE
Extend debug tests (rebased)

### DIFF
--- a/hpy/debug/src/_debugmod.c
+++ b/hpy/debug/src/_debugmod.c
@@ -115,11 +115,14 @@ static UHPy set_on_invalid_handle_impl(HPyContext *uctx, UHPy u_self, UHPy u_arg
 {
     HPyContext *dctx = hpy_debug_get_ctx(uctx);
     HPyDebugInfo *info = get_info(dctx);
-    if (!HPyCallable_Check(uctx, u_arg)) {
+    if (HPy_Is(uctx, u_arg, uctx->h_None)) {
+        info->uh_on_invalid_handle = HPy_NULL;
+    } else if (!HPyCallable_Check(uctx, u_arg)) {
         HPyErr_SetString(uctx, uctx->h_TypeError, "Expected a callable object");
         return HPy_NULL;
+    } else {
+        info->uh_on_invalid_handle = HPy_Dup(uctx, u_arg);
     }
-    info->uh_on_invalid_handle = HPy_Dup(uctx, u_arg);
     return HPy_Dup(uctx, uctx->h_None);
 }
 

--- a/test/check_py27_compat.py
+++ b/test/check_py27_compat.py
@@ -18,7 +18,7 @@ ROOT = py.path.local(__file__).join('..', '..')
 TEST_DIRS = [ROOT / 'test', ROOT / 'test' / 'debug']
 
 # PyPy does NOT import these files using py2
-PY3_ONLY = ['test_support.py', 'test_handles.py']
+PY3_ONLY = ['test_support.py', 'test_handles_invalid.py', 'test_handles_leak.py']
 
 def try_import(name):
     try:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
 import pytest
-from .support import ExtensionCompiler, DefaultExtensionTemplate, PythonSubprocessRunner
+from .support import ExtensionCompiler, DefaultExtensionTemplate,\
+    PythonSubprocessRunner, HPyDebugCapture
 from hpy.debug.leakdetector import LeakDetector
 
 def pytest_addoption(parser):
@@ -54,3 +55,10 @@ def fatal_exit_code(request):
 def python_subprocess(request, hpy_abi):
     verbose = request.config.getoption('--subprocess-v')
     yield PythonSubprocessRunner(verbose, hpy_abi)
+
+
+@pytest.fixture()
+def hpy_debug_capture(request, hpy_abi):
+    assert hpy_abi == 'debug'
+    with HPyDebugCapture() as reporter:
+        yield reporter

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,15 @@
 import pytest
-from .support import ExtensionCompiler, DefaultExtensionTemplate
+from .support import ExtensionCompiler, DefaultExtensionTemplate, PythonSubprocessRunner
 from hpy.debug.leakdetector import LeakDetector
 
 def pytest_addoption(parser):
     parser.addoption(
         "--compiler-v", action="store_true",
         help="Print to stdout the commands used to invoke the compiler")
+    parser.addoption(
+        "--subprocess-v", action="store_true",
+        help="Print to stdout the stdout and stderr of Python subprocesses"
+             "executed via run_python_subprocess")
 
 @pytest.fixture(scope='session')
 def hpy_devel(request):
@@ -32,3 +36,21 @@ def compiler(request, tmpdir, hpy_devel, hpy_abi, ExtensionTemplate):
     return ExtensionCompiler(tmpdir, hpy_devel, hpy_abi,
                              compiler_verbose=compiler_verbose,
                              ExtensionTemplate=ExtensionTemplate)
+
+
+@pytest.fixture(scope="session")
+def fatal_exit_code(request):
+    import sys
+    return {
+        "linux": -6,  # SIGABRT
+        # See https://bugs.python.org/issue36116#msg336782 -- the
+        # return code from abort on Windows 8+ is a stack buffer overrun.
+        # :|
+        "win32": 0xC0000409,  # STATUS_STACK_BUFFER_OVERRUN
+    }.get(sys.platform, -6)
+
+
+@pytest.fixture
+def python_subprocess(request, hpy_abi):
+    verbose = request.config.getoption('--subprocess-v')
+    yield PythonSubprocessRunner(verbose, hpy_abi)

--- a/test/debug/test_handles_invalid.py
+++ b/test/debug/test_handles_invalid.py
@@ -8,6 +8,30 @@ def hpy_abi():
         yield "debug"
 
 
+def test_no_invalid_handle(compiler, hpy_debug_capture):
+    # Basic sanity check that valid code does not trigger any error reports
+    mod = compiler.make_module("""
+        HPyDef_METH(f, "f", f_impl, HPyFunc_O)
+        static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+        {
+            HPy x = HPyLong_FromLong(ctx, 42);
+            HPy y = HPyLong_FromLong(ctx, 2);
+            HPy arg_dup = HPy_Dup(ctx, arg);
+            HPy_Close(ctx, y);
+            HPy b = HPy_Dup(ctx, x);
+            HPy_Close(ctx, x);
+            HPy_Close(ctx, arg_dup);
+            return b;
+        }
+
+        @EXPORT(f)
+        @INIT
+    """)
+    assert mod.f("hello") == 42
+    assert mod.f("world") == 42
+    assert hpy_debug_capture.invalid_handles_count == 0
+
+
 def test_cant_use_closed_handle(compiler, hpy_debug_capture):
     mod = compiler.make_module("""
         HPyDef_METH(f, "f", f_impl, HPyFunc_O, .doc="double close")
@@ -35,6 +59,33 @@ def test_cant_use_closed_handle(compiler, hpy_debug_capture):
     assert hpy_debug_capture.invalid_handles_count == 1
     mod.g('bar')   # use-after-close
     assert hpy_debug_capture.invalid_handles_count == 2
+
+
+def test_keeping_and_reusing_argument_handle(compiler, hpy_debug_capture):
+    mod = compiler.make_module("""
+        HPy keep;
+
+        HPyDef_METH(f, "f", f_impl, HPyFunc_O)
+        static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+        {
+            keep = arg;
+            return HPy_Dup(ctx, ctx->h_None);
+        }
+
+        HPyDef_METH(g, "g", g_impl, HPyFunc_NOARGS)
+        static HPy g_impl(HPyContext *ctx, HPy self)
+        {
+            return keep;
+        }
+
+        @EXPORT(f)
+        @EXPORT(g)
+        @INIT
+    """)
+    mod.f("hello leaks!")
+    assert hpy_debug_capture.invalid_handles_count == 0
+    mod.g()
+    assert hpy_debug_capture.invalid_handles_count == 1
 
 
 def test_invalid_handle_crashes_python_if_no_hook(compiler, python_subprocess, fatal_exit_code):

--- a/test/debug/test_handles_invalid.py
+++ b/test/debug/test_handles_invalid.py
@@ -1,5 +1,6 @@
 import pytest
 from hpy.debug.leakdetector import LeakDetector
+from test.support import SUPPORTS_SYS_EXECUTABLE
 
 @pytest.fixture
 def hpy_abi():
@@ -41,3 +42,23 @@ def test_cant_use_closed_handle(compiler):
     mod.g('bar')   # use-after-close
     assert n == 2
 
+
+def test_invalid_handle_crashes_python_if_no_hook(compiler, python_subprocess, fatal_exit_code):
+    if not SUPPORTS_SYS_EXECUTABLE:
+        pytest.skip("no sys.executable")
+
+    mod = compiler.compile_module("""
+        HPyDef_METH(f, "f", f_impl, HPyFunc_O, .doc="double close")
+        static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+        {
+            HPy h = HPy_Dup(ctx, arg);
+            HPy_Close(ctx, h);
+            HPy_Close(ctx, h); // double close
+            return HPy_Dup(ctx, ctx->h_None);
+        }
+
+        @EXPORT(f)
+        @INIT
+    """)
+    result = python_subprocess.run(mod, "mod.f(42);")
+    assert result.returncode == fatal_exit_code

--- a/test/debug/test_handles_invalid.py
+++ b/test/debug/test_handles_invalid.py
@@ -1,0 +1,43 @@
+import pytest
+from hpy.debug.leakdetector import LeakDetector
+
+@pytest.fixture
+def hpy_abi():
+    with LeakDetector():
+        yield "debug"
+
+
+def test_cant_use_closed_handle(compiler):
+    from hpy.universal import _debug
+    mod = compiler.make_module("""
+        HPyDef_METH(f, "f", f_impl, HPyFunc_O, .doc="double close")
+        static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+        {
+            HPy h = HPy_Dup(ctx, arg);
+            HPy_Close(ctx, h);
+            HPy_Close(ctx, h); // double close
+            return HPy_Dup(ctx, ctx->h_None);
+        }
+
+        HPyDef_METH(g, "g", g_impl, HPyFunc_O, .doc="use after close")
+        static HPy g_impl(HPyContext *ctx, HPy self, HPy arg)
+        {
+            HPy h = HPy_Dup(ctx, arg);
+            HPy_Close(ctx, h);
+            return HPy_Repr(ctx, h);
+        }
+
+        @EXPORT(f)
+        @EXPORT(g)
+        @INIT
+    """)
+    n = 0
+    def callback():
+        nonlocal n
+        n += 1
+    _debug.set_on_invalid_handle(callback)
+    mod.f('foo')   # double close
+    assert n == 1
+    mod.g('bar')   # use-after-close
+    assert n == 2
+

--- a/test/debug/test_handles_leak.py
+++ b/test/debug/test_handles_leak.py
@@ -258,38 +258,3 @@ def test_reuse_closed_handles(compiler):
             h._force_close()
     finally:
         _debug.set_closed_handles_queue_max_size(old_size)
-
-def test_cant_use_closed_handle(compiler):
-    from hpy.universal import _debug
-    mod = compiler.make_module("""
-        HPyDef_METH(f, "f", f_impl, HPyFunc_O, .doc="double close")
-        static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
-        {
-            HPy h = HPy_Dup(ctx, arg);
-            HPy_Close(ctx, h);
-            HPy_Close(ctx, h); // double close
-            return HPy_Dup(ctx, ctx->h_None);
-        }
-
-        HPyDef_METH(g, "g", g_impl, HPyFunc_O, .doc="use after close")
-        static HPy g_impl(HPyContext *ctx, HPy self, HPy arg)
-        {
-            HPy h = HPy_Dup(ctx, arg);
-            HPy_Close(ctx, h);
-            return HPy_Repr(ctx, h);
-        }
-
-        @EXPORT(f)
-        @EXPORT(g)
-        @INIT
-    """)
-    n = 0
-    def callback():
-        nonlocal n
-        n += 1
-    _debug.set_on_invalid_handle(callback)
-    mod.f('foo')   # double close
-    assert n == 1
-    mod.g('bar')   # use-after-close
-    assert n == 2
-

--- a/test/support.py
+++ b/test/support.py
@@ -177,10 +177,14 @@ class ExtensionCompiler:
             filename.write(source)
         return name + '.c'
 
-    def compile_module(self, ExtensionTemplate, main_src, name, extra_sources):
+    def _fixup_template(self, ExtensionTemplate):
+        return self.ExtensionTemplate if ExtensionTemplate is None else ExtensionTemplate
+
+    def compile_module(self, main_src, ExtensionTemplate=None, name='mytest', extra_sources=()):
         """
         Create and compile a HPy module from the template
         """
+        ExtensionTemplate = self._fixup_template(ExtensionTemplate)
         from distutils.core import Extension
         filename = self._expand(ExtensionTemplate, name, main_src)
         sources = [str(filename)]
@@ -241,10 +245,9 @@ class ExtensionCompiler:
         use make_module but explicitly use compile_module and import it
         manually as required by your test.
         """
-        if ExtensionTemplate is None:
-            ExtensionTemplate = self.ExtensionTemplate
+        ExtensionTemplate = self._fixup_template(ExtensionTemplate)
         module = self.compile_module(
-            ExtensionTemplate, main_src, name, extra_sources)
+            main_src, ExtensionTemplate, name, extra_sources)
         so_filename = module.so_filename
         if self.hpy_abi == 'universal':
             return self.load_universal_module(name, so_filename, debug=False)
@@ -338,7 +341,7 @@ class HPyTest:
 
     def compile_module(self, main_src, name='mytest', extra_sources=()):
         ExtensionTemplate = self.ExtensionTemplate
-        return self.compiler.compile_module(ExtensionTemplate, main_src, name,
+        return self.compiler.compile_module(main_src, ExtensionTemplate, name,
                                      extra_sources)
 
     def supports_refcounts(self):

--- a/test/support.py
+++ b/test/support.py
@@ -305,7 +305,8 @@ class PythonSubprocessRunner:
             load_module = "import sys;" + \
                           "import hpy.universal;" + \
                           "mod = hpy.universal.load('{name}', '{so_filename}', debug={debug});"
-            load_module = load_module.format(name=mod.name, so_filename=mod.so_filename,
+            escaped_filename = mod.so_filename.replace("\\", "\\\\")  # Needed for Windows paths
+            load_module = load_module.format(name=mod.name, so_filename=escaped_filename,
                                              debug=self.hpy_abi == 'debug')
         else:
             # CPython module


### PR DESCRIPTION
Several tests infrastructure refactorings that will be used more in my next PR (#236) + few new tests.

* factor out code for running python subprocesses in the tests (fixture `python_subprocess`)
   * runs the subprocess tests in all the supported "ABI modes"
   * updated `HPy_FatalError` tests to use this new internal API
* add `hpy_debug_cature` fixture for capturing calls to the "invalid handle" hook in the debug mode
   * allow to reset the hook back to `NULL` (via setting it to `None` on the Python level)
* Split test_handles to test_handles_leak and test_handles_invalid
   * test_handles_invalid can run with the leak detector on
   * add few more tests to test_handles_invalid

@rlamy hope this will work fine with the PyPy's apptests

Note: rebased version of https://github.com/hpyproject/hpy/pull/247