### PR TITLE
Don't clobber legacy tp_dealloc unnecessarily.

### DIFF
--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -539,6 +539,17 @@ static int check_legacy_consistent(HPyType_Spec *hpyspec)
             " set .legacy=true instead");
         return -1;
     }
+    if (hpyspec->legacy_slots && needs_hpytype_dealloc(hpyspec)) {
+        PyType_Slot *legacy_slots = (PyType_Slot *)hpyspec->legacy_slots;
+        for (int i = 0; legacy_slots[i].slot != 0; i++) {
+            if (legacy_slots[i].slot == Py_tp_dealloc) {
+                PyErr_SetString(PyExc_TypeError,
+                    "legacy tp_dealloc is incompatible with HPy_tp_traverse"
+                    " or HPy_tp_destroy.");
+                return -1;
+            }
+        }
+    }
     return 0;
 }
 

--- a/test/test_hpytype_legacy.py
+++ b/test/test_hpytype_legacy.py
@@ -51,7 +51,7 @@ class TestLegacyType(_TestType):
                 {0, NULL},
             };
             static HPyType_Spec Point_spec = {
-                .name = "Point",
+                .name = "mytest.Point",
                 .basicsize = sizeof(PointObject),
                 .defines = Point_defines,
                 .legacy = true,

--- a/test/test_hpytype_legacy.py
+++ b/test/test_hpytype_legacy.py
@@ -43,6 +43,7 @@ class TestLegacyType(_TestType):
             static void Point_dealloc(PyObject *self)
             {
                 dealloc_counter++;
+                Py_TYPE(self)->tp_free(self);
             }
 
             static HPyDef *Point_defines[] = {&Point_new, NULL};


### PR DESCRIPTION
We now only use hpytype_dealloc if the user supplied HPy_tp_traverse
or HPy_tp_destroy.