### PR TITLE
Implement HPy_tp_finalize

### DIFF
--- a/hpy/debug/src/autogen_debug_ctx_call.i
+++ b/hpy/debug/src/autogen_debug_ctx_call.i
@@ -270,3 +270,11 @@
         DHPy_close(dctx, dh_arg1);
         return;
     }
+    case HPyFunc_DESTRUCTOR: {
+        HPyFunc_destructor f = (HPyFunc_destructor)func;
+        _HPyFunc_args_DESTRUCTOR *a = (_HPyFunc_args_DESTRUCTOR*)args;
+        DHPy dh_arg0 = _py2dh(dctx, a->arg0);
+        f(dctx, dh_arg0);
+        DHPy_close(dctx, dh_arg0);
+        return;
+    }

--- a/hpy/devel/include/hpy/autogen_hpyfunc_declare.h
+++ b/hpy/devel/include/hpy/autogen_hpyfunc_declare.h
@@ -43,6 +43,7 @@
 #define _HPyFunc_DECLARE_HPyFunc_GETBUFFERPROC(SYM) static int SYM(HPyContext *ctx, HPy, HPy_buffer *, int)
 #define _HPyFunc_DECLARE_HPyFunc_RELEASEBUFFERPROC(SYM) static void SYM(HPyContext *ctx, HPy, HPy_buffer *)
 #define _HPyFunc_DECLARE_HPyFunc_TRAVERSEPROC(SYM) static int SYM(void *object, HPyFunc_visitproc visit, void *arg)
+#define _HPyFunc_DECLARE_HPyFunc_DESTRUCTOR(SYM) static void SYM(HPyContext *ctx, HPy)
 #define _HPyFunc_DECLARE_HPyFunc_DESTROYFUNC(SYM) static void SYM(void *)
 
 typedef HPy (*HPyFunc_noargs)(HPyContext *ctx, HPy self);
@@ -78,4 +79,5 @@ typedef int (*HPyFunc_objobjproc)(HPyContext *ctx, HPy, HPy);
 typedef int (*HPyFunc_getbufferproc)(HPyContext *ctx, HPy, HPy_buffer *, int);
 typedef void (*HPyFunc_releasebufferproc)(HPyContext *ctx, HPy, HPy_buffer *);
 typedef int (*HPyFunc_traverseproc)(void *object, HPyFunc_visitproc visit, void *arg);
+typedef void (*HPyFunc_destructor)(HPyContext *ctx, HPy);
 typedef void (*HPyFunc_destroyfunc)(void *);

--- a/hpy/devel/include/hpy/autogen_hpyslot.h
+++ b/hpy/devel/include/hpy/autogen_hpyslot.h
@@ -61,6 +61,7 @@ typedef enum {
     HPy_tp_traverse = 71,
     HPy_nb_matrix_multiply = 75,
     HPy_nb_inplace_matrix_multiply = 76,
+    HPy_tp_finalize = 80,
     HPy_tp_destroy = 1000,
 } HPySlot_Slot;
 
@@ -114,4 +115,5 @@ typedef enum {
 #define _HPySlot_SIG__HPy_tp_traverse HPyFunc_TRAVERSEPROC
 #define _HPySlot_SIG__HPy_nb_matrix_multiply HPyFunc_BINARYFUNC
 #define _HPySlot_SIG__HPy_nb_inplace_matrix_multiply HPyFunc_BINARYFUNC
+#define _HPySlot_SIG__HPy_tp_finalize HPyFunc_DESTRUCTOR
 #define _HPySlot_SIG__HPy_tp_destroy HPyFunc_DESTROYFUNC

--- a/hpy/devel/include/hpy/cpython/autogen_hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/cpython/autogen_hpyfunc_trampolines.h
@@ -63,7 +63,8 @@
 #define _HPyFunc_TRAMPOLINE_HPyFunc_FREEFUNC(SYM, IMPL) \
     static void SYM(void *arg0) \
     { \
-        return (IMPL(_HPyGetContext(), arg0)); \
+        IMPL(_HPyGetContext(), arg0); \
+        return; \
     }
 #define _HPyFunc_TRAMPOLINE_HPyFunc_GETATTRFUNC(SYM, IMPL) \
     static cpy_PyObject *SYM(cpy_PyObject *arg0, char *arg1) \
@@ -133,5 +134,6 @@
 #define _HPyFunc_TRAMPOLINE_HPyFunc_DESTRUCTOR(SYM, IMPL) \
     static void SYM(cpy_PyObject *arg0) \
     { \
-        return (IMPL(_HPyGetContext(), _py2h(arg0))); \
+        IMPL(_HPyGetContext(), _py2h(arg0)); \
+        return; \
     }

--- a/hpy/devel/include/hpy/cpython/autogen_hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/cpython/autogen_hpyfunc_trampolines.h
@@ -130,3 +130,8 @@
     { \
         return (IMPL(_HPyGetContext(), _py2h(arg0), _py2h(arg1))); \
     }
+#define _HPyFunc_TRAMPOLINE_HPyFunc_DESTRUCTOR(SYM, IMPL) \
+    static void SYM(cpy_PyObject *arg0) \
+    { \
+        return (IMPL(_HPyGetContext(), _py2h(arg0))); \
+    }

--- a/hpy/devel/include/hpy/hpyfunc.h
+++ b/hpy/devel/include/hpy/hpyfunc.h
@@ -38,6 +38,7 @@ typedef enum {
     HPyFunc_SETTER,
     HPyFunc_OBJOBJPROC,
     HPyFunc_TRAVERSEPROC,
+    HPyFunc_DESTRUCTOR,
 
 } HPyFunc_Signature;
 

--- a/hpy/devel/include/hpy/universal/autogen_hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_hpyfunc_trampolines.h
@@ -372,3 +372,16 @@ typedef struct {
         return a.result; \
     }
 
+typedef struct {
+    cpy_PyObject *arg0;
+} _HPyFunc_args_DESTRUCTOR;
+
+#define _HPyFunc_TRAMPOLINE_HPyFunc_DESTRUCTOR(SYM, IMPL) \
+    static void SYM(cpy_PyObject *arg0) \
+    { \
+        _HPyFunc_args_DESTRUCTOR a = { arg0 }; \
+        _HPy_CallRealFunctionFromTrampoline( \
+           _ctx_for_trampolines, HPyFunc_DESTRUCTOR, IMPL, &a); \
+        return; \
+    }
+

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -735,6 +735,11 @@ ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
     /* note that we do NOT free the memory which was allocated by
        create_method_defs, because that one is referenced internally by
        CPython (which probably assumes it's statically allocated) */
+#if PY_VERSION_HEX < 0x03080000
+    if (((PyTypeObject*)result)->tp_finalize != NULL) {
+        ((PyTypeObject*)result)->tp_flags |= Py_TPFLAGS_HAVE_FINALIZE;
+    }
+#endif
     Py_XDECREF(bases);
     PyMem_Free(spec->slots);
     PyMem_Free(spec);

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -80,11 +80,21 @@ static void hpytype_clear(PyObject *self)
    types created by HPyType_FromSpec */
 static void hpytype_dealloc(PyObject *self)
 {
+    PyTypeObject *tp = Py_TYPE(self);
+    // Call finalizer if it exists
+    if (tp->tp_finalize) {
+        // Exit early if resurrected
+        if (PyObject_CallFinalizerFromDealloc(self) < 0) {
+            return;
+        }
+    }
+    if (PyType_IS_GC(tp))
+        PyObject_GC_UnTrack(self);
+
     // decref and clear all the HPyFields
     hpytype_clear(self);
 
     // call tp_destroy on all the HPy types of the hierarchy
-    PyTypeObject *tp = Py_TYPE(self);
     PyTypeObject *base = tp;
     while(base) {
         if (base->tp_flags & HPy_TPFLAGS_INTERNAL_IS_HPY_TYPE) {

--- a/hpy/tools/autogen/hpyfunc.py
+++ b/hpy/tools/autogen/hpyfunc.py
@@ -172,6 +172,10 @@ class autogen_cpython_hpyfunc_trampoline_h(AutoGenFile):
             w(f'#define _HPyFunc_TRAMPOLINE_HPyFunc_{NAME}(SYM, IMPL) \\')
             w(f'    static {toC(tramp_node)} \\')
             w(f'    {{ \\')
-            w(f'        return {result}(IMPL({args})); \\')
+            if toC(tramp_node.type) == 'void':
+                w(f'        IMPL({args}); \\')
+                w(f'        return; \\')
+            else:
+                w(f'        return {result}(IMPL({args})); \\')
             w(f'    }}')
         return '\n'.join(lines)

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -385,6 +385,7 @@ typedef int (*HPyFunc_objobjproc)(HPyContext *ctx, HPy, HPy);
 typedef int (*HPyFunc_getbufferproc)(HPyContext *ctx, HPy, HPy_buffer *, int);
 typedef void (*HPyFunc_releasebufferproc)(HPyContext *ctx, HPy, HPy_buffer *);
 typedef int (*HPyFunc_traverseproc)(void *object, HPyFunc_visitproc visit, void *arg);
+typedef void (*HPyFunc_destructor)(HPyContext *ctx, HPy);
 
 typedef void (*HPyFunc_destroyfunc)(void *);
 
@@ -483,7 +484,7 @@ typedef enum {
     //HPy_am_await = SLOT(77, HPyFunc_X),
     //HPy_am_aiter = SLOT(78, HPyFunc_X),
     //HPy_am_anext = SLOT(79, HPyFunc_X),
-    //HPy_tp_finalize = SLOT(80, HPyFunc_X),
+    HPy_tp_finalize = SLOT(80, HPyFunc_DESTRUCTOR),
 
     /* extra HPy slots */
     HPy_tp_destroy = SLOT(1000, HPyFunc_DESTROYFUNC),

--- a/hpy/universal/src/autogen_ctx_call.i
+++ b/hpy/universal/src/autogen_ctx_call.i
@@ -160,3 +160,9 @@
         a->result = f(ctx, _py2h(a->arg0), _py2h(a->arg1));
         return;
     }
+    case HPyFunc_DESTRUCTOR: {
+        HPyFunc_destructor f = (HPyFunc_destructor)func;
+        _HPyFunc_args_DESTRUCTOR *a = (_HPyFunc_args_DESTRUCTOR*)args;
+        f(ctx, _py2h(a->arg0));
+        return;
+    }


### PR DESCRIPTION
This implements `HPy_tp_finalize` and adds the `HPyFunc_DESTRUCTOR` `HPyFunc_Signature`.

I'm a bit unsure about how `hpytype_dealloc()` and `HPy_tp_finalize` should interact. Currently, `HPy_tp_finalize` has no effect on whether we supply `hpytype_dealloc()` as the type's tp_dealloc, which allows the user to implement a legacy tp_dealloc if they need to. OTOH, that means that `test_tp_finalize_nongc()` passes only because `subtype_dealloc()` (CPython's default tp_dealloc for heaptypes)  happens to do the right thing in this case.