### PR TITLE
Fix: Do not visit uninitialized HPyField during traversal.

### DIFF
--- a/hpy/devel/include/hpy.h
+++ b/hpy/devel/include/hpy.h
@@ -100,6 +100,7 @@ typedef struct { intptr_t _i; } HPyTracker;
 #define HPy_IsNull(h) ((h)._i == 0)
 
 #define HPyField_NULL ((HPyField){0})
+#define HPyField_IsNull(f) ((f)._i == 0)
 
 /* Convenience functions to cast between HPy and void*.  We need to decide
    whether these are part of the official API or not, and maybe introduce a

--- a/hpy/devel/include/hpy/hpyfunc.h
+++ b/hpy/devel/include/hpy/hpyfunc.h
@@ -97,9 +97,11 @@ typedef int (*HPyFunc_visitproc)(HPyField *, void *);
  */
 #define HPy_VISIT(hpyfield)                                             \
     do {                                                                \
-        int vret = visit(hpyfield, arg);                                \
-        if (vret)                                                       \
-            return vret;                                                \
+        if (!HPyField_IsNull(*hpyfield)) {                              \
+            int vret = visit(hpyfield, arg);                            \
+            if (vret)                                                   \
+                return vret;                                            \
+            }                                                           \
     } while (0)
 
 

--- a/test/test_hpyfield.py
+++ b/test/test_hpyfield.py
@@ -98,9 +98,6 @@ class TestHPyField(HPyTest):
             import pytest
             pytest.skip("CPython only")
         import sys
-        if hasattr(sys, 'gettotalrefcount'):
-            import pytest
-            pytest.skip("Test fails on debug build: https://github.com/hpyproject/hpy/issues/255")
         # Test that we correctly call PyObject_GC_Track on CPython. The
         # easiest way is to check whether the object is in
         # gc.get_objects().
@@ -137,9 +134,6 @@ class TestHPyField(HPyTest):
 
     def test_tp_traverse(self):
         import sys
-        if hasattr(sys, 'gettotalrefcount'):
-            import pytest
-            pytest.skip("Test fails on debug build: https://github.com/hpyproject/hpy/issues/255")
         import gc
         mod = self.make_module("""
             @DEFINE_PairObject
@@ -248,9 +242,6 @@ class TestHPyField(HPyTest):
 
     def test_automatic_tp_dealloc(self):
         import sys
-        if hasattr(sys, 'gettotalrefcount'):
-            import pytest
-            pytest.skip("Test fails on debug build: https://github.com/hpyproject/hpy/issues/255")
         if not self.supports_refcounts():
             import pytest
             pytest.skip("CPython only")
@@ -278,9 +269,6 @@ class TestHPyField(HPyTest):
             import pytest
             pytest.skip("CPython only")
         import sys
-        if hasattr(sys, 'gettotalrefcount'):
-            import pytest
-            pytest.skip("Test fails on debug build: https://github.com/hpyproject/hpy/issues/255")
 
         import gc
         mod = self.make_module("""


### PR DESCRIPTION
Should fix #255 .
I'm not sure why we did not copy everything from `Py_VISIT` to `HPy_VISIT` but clearly, `Py_VISIT` will only visit non-null `PyObject *`.
The only drawback now is that we need to do an additional dereference of `hpyfield`.
However, the alternative would be to expose something like `PyObject_GC_Track` in HPy and don't it in `ctx_New`. But I would really not like that.