### PR TITLE
Remove HPyModuleDef.dummy and remove m_ prefix of fields.

### DIFF
--- a/docs/examples/mixed-example/mixed.c
+++ b/docs/examples/mixed-example/mixed.c
@@ -39,10 +39,9 @@ static PyMethodDef py_defines[] = {
 };
 
 static HPyModuleDef moduledef = {
-    HPyModuleDef_HEAD_INIT,
-    .m_name = "mixed",
-    .m_doc = "HPy Example of mixing CPython API and HPy API",
-    .m_size = -1,
+    .name = "mixed",
+    .doc = "HPy Example of mixing CPython API and HPy API",
+    .size = -1,
     .defines = hpy_defines,
     .legacy_methods = py_defines
 };

--- a/docs/examples/simple-example/simple.c
+++ b/docs/examples/simple-example/simple.c
@@ -22,10 +22,9 @@ static HPyDef *SimpleMethods[] = {
 };
 
 static HPyModuleDef simple = {
-        HPyModuleDef_HEAD_INIT,
-        .m_name = "simple",
-        .m_doc = "HPy Example",
-        .m_size = -1,
+        .name = "simple",
+        .doc = "HPy Example",
+        .size = -1,
         .defines = SimpleMethods,
         .legacy_methods = NULL
 };

--- a/docs/examples/snippets/hpyvarargs.c
+++ b/docs/examples/snippets/hpyvarargs.c
@@ -37,10 +37,9 @@ static HPyDef *SimpleMethods[] = {
 // END: methodsdef
 
 static HPyModuleDef simple = {
-        HPyModuleDef_HEAD_INIT,
-        .m_name = "hpyvarargs",
-        .m_doc = "HPy Example of varargs calling convention",
-        .m_size = -1,
+        .name = "hpyvarargs",
+        .doc = "HPy Example of varargs calling convention",
+        .size = -1,
         .defines = SimpleMethods
 };
 

--- a/docs/examples/snippets/snippets.c
+++ b/docs/examples/snippets/snippets.c
@@ -47,10 +47,9 @@ static HPyDef *Methods[] = {
 };
 
 static HPyModuleDef snippets = {
-        HPyModuleDef_HEAD_INIT,
-        .m_name = "snippets",
-        .m_doc = "Various HPy code snippets for the docs",
-        .m_size = -1,
+        .name = "snippets",
+        .doc = "Various HPy code snippets for the docs",
+        .size = -1,
         .defines = Methods
 };
 

--- a/hpy/debug/src/_debugmod.c
+++ b/hpy/debug/src/_debugmod.c
@@ -290,10 +290,9 @@ static HPyDef *module_defines[] = {
 };
 
 static HPyModuleDef moduledef = {
-    HPyModuleDef_HEAD_INIT,
-    .m_name = "hpy.debug._debug",
-    .m_doc = "HPy debug mode",
-    .m_size = -1,
+    .name = "hpy.debug._debug",
+    .doc = "HPy debug mode",
+    .size = -1,
     .defines = module_defines
 };
 

--- a/hpy/devel/include/hpy/hpymodule.h
+++ b/hpy/devel/include/hpy/hpymodule.h
@@ -13,13 +13,10 @@
 // this is defined by HPy_MODINIT
 extern HPyContext *_ctx_for_trampolines;
 
-#define HPyModuleDef_HEAD_INIT NULL
-
 typedef struct {
-    void *dummy; // this is needed because we put a comma after HPyModuleDef_HEAD_INIT :(
-    const char* m_name;
-    const char* m_doc;
-    HPy_ssize_t m_size;
+    const char* name;
+    const char* doc;
+    HPy_ssize_t size;
     cpy_PyMethodDef *legacy_methods;
     HPyDef **defines;   /* points to an array of 'HPyDef *' */
 } HPyModuleDef;

--- a/hpy/devel/src/runtime/ctx_module.c
+++ b/hpy/devel/src/runtime/ctx_module.c
@@ -25,9 +25,9 @@ ctx_Module_Create(HPyContext *ctx, HPyModuleDef *hpydef)
         return HPy_NULL;
     }
     memcpy(def, &empty_moduledef, sizeof(PyModuleDef));
-    def->m_name = hpydef->m_name;
-    def->m_doc = hpydef->m_doc;
-    def->m_size = hpydef->m_size;
+    def->m_name = hpydef->name;
+    def->m_doc = hpydef->doc;
+    def->m_size = hpydef->size;
     def->m_methods = create_method_defs(hpydef->defines, hpydef->legacy_methods);
     if (def->m_methods == NULL) {
         PyMem_Free(def);

--- a/microbench/src/hpy_simple.c
+++ b/microbench/src/hpy_simple.c
@@ -117,10 +117,9 @@ static HPyDef *module_defines[] = {
 
 
 static HPyModuleDef moduledef = {
-    HPyModuleDef_HEAD_INIT,
-    .m_name = "hpy_simple",
-    .m_doc = "HPy microbenchmarks",
-    .m_size = -1,
+    .name = "hpy_simple",
+    .doc = "HPy microbenchmarks",
+    .size = -1,
     .defines = module_defines,
 };
 

--- a/proof-of-concept/Makefile
+++ b/proof-of-concept/Makefile
@@ -1,9 +1,9 @@
 pof.cpython-37m-x86_64-linux-gnu.so: pof.c
-	python3.7 setup.py build_ext -i -f
+	python3 setup.py build_ext -i -f
 
 .PHONY: test
 test: pof.cpython-37m-x86_64-linux-gnu.so
-	python3.7 -m pytest test_pof.py
+	python3 -m pytest test_pof.py
 
 universal: pof.hpy.so
 

--- a/proof-of-concept/pof.c
+++ b/proof-of-concept/pof.c
@@ -84,10 +84,9 @@ static HPyDef *module_defines[] = {
     NULL
 };
 static HPyModuleDef moduledef = {
-    HPyModuleDef_HEAD_INIT,
-    .m_name = "pof",
-    .m_doc = "HPy Proof of Concept",
-    .m_size = -1,
+    .name = "pof",
+    .doc = "HPy Proof of Concept",
+    .size = -1,
     .defines = module_defines
 };
 

--- a/proof-of-concept/pofpackage/foo.c
+++ b/proof-of-concept/pofpackage/foo.c
@@ -12,10 +12,9 @@ static HPyDef *module_defines[] = {
     NULL
 };
 static HPyModuleDef moduledef = {
-    HPyModuleDef_HEAD_INIT,
-    .m_name = "foo",
-    .m_doc = "HPy Proof of Concept",
-    .m_size = -1,
+    .name = "foo",
+    .doc = "HPy Proof of Concept",
+    .size = -1,
     .defines = module_defines
 };
 

--- a/test/support.py
+++ b/test/support.py
@@ -23,10 +23,9 @@ class DefaultExtensionTemplate(object):
         NULL
     };
     static HPyModuleDef moduledef = {
-        HPyModuleDef_HEAD_INIT,
-        .m_name = "%(name)s",
-        .m_doc = "some test for hpy",
-        .m_size = -1,
+        .name = "%(name)s",
+        .doc = "some test for hpy",
+        .size = -1,
         .legacy_methods = %(legacy_methods)s,
         .defines = moduledefs
     };

--- a/test/test_hpymodule.py
+++ b/test/test_hpymodule.py
@@ -7,9 +7,9 @@ class TestModule(HPyTest):
             static HPy f_impl(HPyContext *ctx, HPy self)
             {
                 HPyModuleDef def = {
-                    .m_name = "foo",
-                    .m_doc = "Some doc",
-                    .m_size = -1,
+                    .name = "foo",
+                    .doc = "Some doc",
+                    .size = -1,
                 };
                 return HPyModule_Create(ctx, &def);
             }


### PR DESCRIPTION
As suggested in #189, removes field `HPyModuleDef.dummy` and also removes the `m_` prefix.
This is a breaking change, i.e, will cause that current HPy modules will no longer compile without adoption and also introduces binary compatibility. Therefore, I think we should do such changes earlier than later.

If approved, I will also migrate all other modules in `hpyproject`.