### PR TITLE
Python.h should be included before any standard header

### DIFF
--- a/hpy/devel/include/hpy.h
+++ b/hpy/devel/include/hpy.h
@@ -1,6 +1,14 @@
 #ifndef HPy_H
 #define HPy_H
 
+#ifndef HPY_UNIVERSAL_ABI
+/*  It would be nice if we could include hpy.h WITHOUT bringing in all the
+    stuff from Python.h, to make sure that people don't use the CPython API by
+    mistake. How to achieve it, though? */
+#   define PY_SSIZE_T_CLEAN
+#   include <Python.h>
+#endif
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdarg.h>
@@ -117,11 +125,6 @@ typedef struct _HPyContext_s HPyContext;
     typedef intptr_t HPy_ssize_t;
     typedef intptr_t HPy_hash_t;
 #else
-/*  It would be nice if we could include hpy.h WITHOUT bringing in all the
-    stuff from Python.h, to make sure that people don't use the CPython API by
-    mistake. How to achieve it, though? */
-#   define PY_SSIZE_T_CLEAN
-#   include <Python.h>
     typedef Py_ssize_t HPy_ssize_t;
     typedef Py_hash_t HPy_hash_t;
 #endif

--- a/hpy/devel/src/runtime/argparse.c
+++ b/hpy/devel/src/runtime/argparse.c
@@ -131,9 +131,9 @@
  *
  */
 
+#include "hpy.h"
 #include <limits.h>
 #include <stdio.h>
-#include "hpy.h"
 
 #define _BREAK_IF_OPTIONAL(current_arg) if (HPy_IsNull(current_arg)) break;
 #define _ERR_STRING_MAX_LENGTH 512


### PR DESCRIPTION
According to the [Python docs](https://docs.python.org/3/c-api/intro.html#include-files), "Since Python may define some pre-processor definitions which affect the standard headers on some systems, you must include Python.h before any standard headers are included."

Not doing that causes warnings such as `warning: "_POSIX_C_SOURCE" redefined`, which currently cause failures in the [numpy-hpy tests](https://github.com/hpyproject/numpy-hpy/runs/4777382414?check_suite_focus=true#step:4:1871). (I'm not sure why we don't see these in hpy's own CI)