### PR TITLE
HPy_LeavePythonExecution/HPy_ReenterPythonExecution

### DIFF
--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -154,6 +154,8 @@ void debug_ctx_Tracker_ForgetAll(HPyContext *dctx, HPyTracker ht);
 void debug_ctx_Tracker_Close(HPyContext *dctx, HPyTracker ht);
 void debug_ctx_Field_Store(HPyContext *dctx, DHPy target_object, HPyField *target_field, DHPy h);
 DHPy debug_ctx_Field_Load(HPyContext *dctx, DHPy source_object, HPyField source_field);
+HPyThreadState debug_ctx_LeavePythonExecution(HPyContext *dctx);
+void debug_ctx_ReenterPythonExecution(HPyContext *dctx, HPyThreadState state);
 void debug_ctx_Dump(HPyContext *dctx, DHPy h);
 
 static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
@@ -379,5 +381,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_Tracker_Close = &debug_ctx_Tracker_Close;
     dctx->ctx_Field_Store = &debug_ctx_Field_Store;
     dctx->ctx_Field_Load = &debug_ctx_Field_Load;
+    dctx->ctx_LeavePythonExecution = &debug_ctx_LeavePythonExecution;
+    dctx->ctx_ReenterPythonExecution = &debug_ctx_ReenterPythonExecution;
     dctx->ctx_Dump = &debug_ctx_Dump;
 }

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -682,6 +682,16 @@ DHPy debug_ctx_Field_Load(HPyContext *dctx, DHPy source_object, HPyField source_
     return DHPy_open(dctx, HPyField_Load(get_info(dctx)->uctx, DHPy_unwrap(dctx, source_object), source_field));
 }
 
+HPyThreadState debug_ctx_LeavePythonExecution(HPyContext *dctx)
+{
+    return HPy_LeavePythonExecution(get_info(dctx)->uctx);
+}
+
+void debug_ctx_ReenterPythonExecution(HPyContext *dctx, HPyThreadState state)
+{
+    HPy_ReenterPythonExecution(get_info(dctx)->uctx, state);
+}
+
 void debug_ctx_Dump(HPyContext *dctx, DHPy h)
 {
     _HPy_Dump(get_info(dctx)->uctx, DHPy_unwrap(dctx, h));

--- a/hpy/devel/include/hpy.h
+++ b/hpy/devel/include/hpy.h
@@ -110,6 +110,7 @@ typedef struct { intptr_t _i; } HPyField;
 typedef struct { intptr_t _lst; } HPyListBuilder;
 typedef struct { intptr_t _tup; } HPyTupleBuilder;
 typedef struct { intptr_t _i; } HPyTracker;
+typedef struct { intptr_t _i; } HPyThreadState;
 
 
 /* A null handle is officially defined as a handle whose _i is 0. This is true

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -554,3 +554,13 @@ HPyAPI_FUNC HPy HPyImport_ImportModule(HPyContext *ctx, const char *name)
     return _py2h(PyImport_ImportModule(name));
 }
 
+HPyAPI_FUNC HPyThreadState HPy_LeavePythonExecution(HPyContext *ctx)
+{
+    return _threads2h(PyEval_SaveThread());
+}
+
+HPyAPI_FUNC void HPy_ReenterPythonExecution(HPyContext *ctx, HPyThreadState state)
+{
+    PyEval_RestoreThread(_h2threads(state));
+}
+

--- a/hpy/devel/include/hpy/cpython/misc.h
+++ b/hpy/devel/include/hpy/cpython/misc.h
@@ -1,9 +1,21 @@
 #ifndef HPY_CPYTHON_MISC_H
 #define HPY_CPYTHON_MISC_H
 
+#include <Python.h>
+#include "hpy.h"
+#include "hpy/runtime/ctx_funcs.h"
+
 // XXX: turn these into static inline functions
 #define _h2py(h) ((PyObject*)h._i)
 #define _py2h(o) _hconv((intptr_t)o)
+
+static inline HPyThreadState _threads2h(PyThreadState *s) {
+    return (HPyThreadState) { (intptr_t) s };
+}
+
+static inline PyThreadState* _h2threads(HPyThreadState h) {
+    return (PyThreadState*) h._i;
+}
 
 static inline HPyField _py2hf(PyObject *obj)
 {
@@ -194,7 +206,6 @@ HPyAPI_FUNC HPyContext * _HPyGetContext(void) {
     }
     return ctx;
 }
-
 
 HPyAPI_FUNC HPy HPy_Dup(HPyContext *ctx, HPy handle)
 {

--- a/hpy/devel/include/hpy/cpython/misc.h
+++ b/hpy/devel/include/hpy/cpython/misc.h
@@ -10,7 +10,8 @@
 #define _py2h(o) _hconv((intptr_t)o)
 
 static inline HPyThreadState _threads2h(PyThreadState *s) {
-    return (HPyThreadState) { (intptr_t) s };
+    HPyThreadState res = { ._i = (intptr_t) s };
+    return res;
 }
 
 static inline PyThreadState* _h2threads(HPyThreadState h) {

--- a/hpy/devel/include/hpy/macros.h
+++ b/hpy/devel/include/hpy/macros.h
@@ -69,3 +69,11 @@ typedef enum {
 #else
 #error "sizeof(pid_t) is neither sizeof(int), sizeof(long) or sizeof(long long)"
 #endif /* SIZEOF_PID_T */
+
+#define HPy_BEGIN_LEAVE_PYTHON(context) { \
+    HPyThreadState _token;                                    \
+    _token = HPy_LeavePythonExecution(context);
+
+#define HPy_END_LEAVE_PYTHON(context)   \
+    HPy_ReenterPythonExecution(context, _token); \
+    }

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -235,5 +235,7 @@ struct _HPyContext_s {
     void (*ctx_Tracker_Close)(HPyContext *ctx, HPyTracker ht);
     void (*ctx_Field_Store)(HPyContext *ctx, HPy target_object, HPyField *target_field, HPy h);
     HPy (*ctx_Field_Load)(HPyContext *ctx, HPy source_object, HPyField source_field);
+    HPyThreadState (*ctx_LeavePythonExecution)(HPyContext *ctx);
+    void (*ctx_ReenterPythonExecution)(HPyContext *ctx, HPyThreadState state);
     void (*ctx_Dump)(HPyContext *ctx, HPy h);
 };

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -578,6 +578,14 @@ HPyAPI_FUNC HPy HPyField_Load(HPyContext *ctx, HPy source_object, HPyField sourc
      return ctx->ctx_Field_Load ( ctx, source_object, source_field ); 
 }
 
+HPyAPI_FUNC HPyThreadState HPy_LeavePythonExecution(HPyContext *ctx) {
+     return ctx->ctx_LeavePythonExecution ( ctx ); 
+}
+
+HPyAPI_FUNC void HPy_ReenterPythonExecution(HPyContext *ctx, HPyThreadState state) {
+     ctx->ctx_ReenterPythonExecution ( ctx, state ); 
+}
+
 HPyAPI_FUNC void _HPy_Dump(HPyContext *ctx, HPy h) {
      ctx->ctx_Dump ( ctx, h ); 
 }

--- a/hpy/tools/autogen/conf.py
+++ b/hpy/tools/autogen/conf.py
@@ -109,4 +109,6 @@ SPECIAL_CASES = {
     'HPy_TypeCheck': None,
     'HPy_Is': None,
     'HPyBytes_FromStringAndSize': None,
+    'HPy_LeavePythonExecution': 'PyEval_SaveThread',
+    'HPy_ReenterPythonExecution': 'PyEval_RestoreThread',
 }

--- a/hpy/tools/autogen/trampolines.py
+++ b/hpy/tools/autogen/trampolines.py
@@ -85,12 +85,16 @@ class cpython_autogen_api_impl_h(AutoGenFile):
                     continue
                 elif toC(p.type) == 'HPy':
                     arg = '_h2py(%s)' % p.name
+                elif toC(p.type) == 'HPyThreadState':
+                    arg = '_h2threads(%s)' % p.name
                 else:
                     arg = p.name
                 args.append(arg)
             result = '%s(%s)' % (pyfunc, ', '.join(args))
             if return_type == 'HPy':
                 result = '_py2h(%s)' % result
+            elif return_type == 'HPyThreadState':
+                result = '_threads2h(%s)' % result
             return result
         #
         lines = []

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -159,5 +159,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_Tracker_Close = &ctx_Tracker_Close,
     .ctx_Field_Store = &ctx_Field_Store,
     .ctx_Field_Load = &ctx_Field_Load,
+    .ctx_LeavePythonExecution = &ctx_LeavePythonExecution,
+    .ctx_ReenterPythonExecution = &ctx_ReenterPythonExecution,
     .ctx_Dump = &ctx_Dump,
 };

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -550,3 +550,13 @@ HPyAPI_IMPL HPy ctx_Import_ImportModule(HPyContext *ctx, const char *name)
     return _py2h(PyImport_ImportModule(name));
 }
 
+HPyAPI_IMPL HPyThreadState ctx_LeavePythonExecution(HPyContext *ctx)
+{
+    return _threads2h(PyEval_SaveThread());
+}
+
+HPyAPI_IMPL void ctx_ReenterPythonExecution(HPyContext *ctx, HPyThreadState state)
+{
+    PyEval_RestoreThread(_h2threads(state));
+}
+

--- a/hpy/universal/src/handles.h
+++ b/hpy/universal/src/handles.h
@@ -33,4 +33,12 @@ static inline PyObject * _hf2py(HPyField hf)
     return _h2py(h);
 }
 
+static inline HPyThreadState _threads2h(PyThreadState* s) {
+    return (HPyThreadState) { (intptr_t) s };
+}
+
+static inline PyThreadState* _h2threads(HPyThreadState h) {
+    return (PyThreadState*) h._i;
+}
+
 #endif /* HPY_HANDLES_H */

--- a/test/test_00_basic.py
+++ b/test/test_00_basic.py
@@ -433,3 +433,24 @@ class TestBasic(HPyTest):
             @INIT
         """)
         assert mod.f(42) == 42
+
+    def test_leave_python(self):
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", f_impl, HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                HPy_ssize_t data_len;
+                const char* data = HPyUnicode_AsUTF8AndSize(ctx, arg, &data_len);
+                HPy_ssize_t acount = 0;
+                HPy_BEGIN_LEAVE_PYTHON(ctx);
+                for (HPy_ssize_t i = 0; i < data_len; ++i) {
+                    if (data[i] == 'a')
+                        acount++;
+                }
+                HPy_END_LEAVE_PYTHON(ctx);
+                return HPyLong_FromSize_t(ctx, acount);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f("abraka") == 3


### PR DESCRIPTION
This is supposed to be a 1:1 replacement for `Py_BEGIN_ALLOW_THREADS`/`Py_END_ALLOW_THREADS` when migrating CPython extensions.

Question left is if we should try to specify bit more generic GIL independent semantics like in this PR or have just `HPyEval_SaveThread` and `HPY_BEGIN_ALLOW_THREADS`. 

I could not yet come up with a concrete example where knowing that the C code will be in a section where it will not call any HPy API is beneficial other than GIL (maybe for GC?, in theory it can maybe scan stacks at that point). At the same time in the light of GIL removal efforts in CPython, it seems to me that we should not stick to obviously GIL specific APIs.

Fixes #34.