### PR TITLE
Add HPy_Contains as way to call the 'in' operator from HPy

### DIFF
--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -91,6 +91,7 @@ int debug_ctx_SetAttr_s(HPyContext *dctx, DHPy obj, const char *name, DHPy value
 DHPy debug_ctx_GetItem(HPyContext *dctx, DHPy obj, DHPy key);
 DHPy debug_ctx_GetItem_i(HPyContext *dctx, DHPy obj, HPy_ssize_t idx);
 DHPy debug_ctx_GetItem_s(HPyContext *dctx, DHPy obj, const char *key);
+int debug_ctx_Contains(HPyContext *dctx, DHPy container, DHPy key);
 int debug_ctx_SetItem(HPyContext *dctx, DHPy obj, DHPy key, DHPy value);
 int debug_ctx_SetItem_i(HPyContext *dctx, DHPy obj, HPy_ssize_t idx, DHPy value);
 int debug_ctx_SetItem_s(HPyContext *dctx, DHPy obj, const char *key, DHPy value);
@@ -307,6 +308,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_GetItem = &debug_ctx_GetItem;
     dctx->ctx_GetItem_i = &debug_ctx_GetItem_i;
     dctx->ctx_GetItem_s = &debug_ctx_GetItem_s;
+    dctx->ctx_Contains = &debug_ctx_Contains;
     dctx->ctx_SetItem = &debug_ctx_SetItem;
     dctx->ctx_SetItem_i = &debug_ctx_SetItem_i;
     dctx->ctx_SetItem_s = &debug_ctx_SetItem_s;

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -402,6 +402,11 @@ DHPy debug_ctx_GetItem_s(HPyContext *dctx, DHPy obj, const char *key)
     return DHPy_open(dctx, HPy_GetItem_s(get_info(dctx)->uctx, DHPy_unwrap(dctx, obj), key));
 }
 
+int debug_ctx_Contains(HPyContext *dctx, DHPy container, DHPy key)
+{
+    return HPy_Contains(get_info(dctx)->uctx, DHPy_unwrap(dctx, container), DHPy_unwrap(dctx, key));
+}
+
 int debug_ctx_SetItem(HPyContext *dctx, DHPy obj, DHPy key, DHPy value)
 {
     return HPy_SetItem(get_info(dctx)->uctx, DHPy_unwrap(dctx, obj), DHPy_unwrap(dctx, key), DHPy_unwrap(dctx, value));

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -365,6 +365,11 @@ HPyAPI_FUNC HPy HPy_GetItem(HPyContext *ctx, HPy obj, HPy key)
     return _py2h(PyObject_GetItem(_h2py(obj), _h2py(key)));
 }
 
+HPyAPI_FUNC int HPy_Contains(HPyContext *ctx, HPy container, HPy key)
+{
+    return PySequence_Contains(_h2py(container), _h2py(key));
+}
+
 HPyAPI_FUNC int HPy_SetItem(HPyContext *ctx, HPy obj, HPy key, HPy value)
 {
     return PyObject_SetItem(_h2py(obj), _h2py(key), _h2py(value));

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -172,6 +172,7 @@ struct _HPyContext_s {
     HPy (*ctx_GetItem)(HPyContext *ctx, HPy obj, HPy key);
     HPy (*ctx_GetItem_i)(HPyContext *ctx, HPy obj, HPy_ssize_t idx);
     HPy (*ctx_GetItem_s)(HPyContext *ctx, HPy obj, const char *key);
+    int (*ctx_Contains)(HPyContext *ctx, HPy container, HPy key);
     int (*ctx_SetItem)(HPyContext *ctx, HPy obj, HPy key, HPy value);
     int (*ctx_SetItem_i)(HPyContext *ctx, HPy obj, HPy_ssize_t idx, HPy value);
     int (*ctx_SetItem_s)(HPyContext *ctx, HPy obj, const char *key, HPy value);

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -330,6 +330,10 @@ HPyAPI_FUNC HPy HPy_GetItem_s(HPyContext *ctx, HPy obj, const char *key) {
      return ctx->ctx_GetItem_s ( ctx, obj, key ); 
 }
 
+HPyAPI_FUNC int HPy_Contains(HPyContext *ctx, HPy container, HPy key) {
+     return ctx->ctx_Contains ( ctx, container, key ); 
+}
+
 HPyAPI_FUNC int HPy_SetItem(HPyContext *ctx, HPy obj, HPy key, HPy value) {
      return ctx->ctx_SetItem ( ctx, obj, key, value ); 
 }

--- a/hpy/tools/autogen/parse.py
+++ b/hpy/tools/autogen/parse.py
@@ -153,6 +153,7 @@ SPECIAL_CASES = {
     'HPy_SetItem': 'PyObject_SetItem',
     'HPy_SetItem_i': None,
     'HPy_SetItem_s': None,
+    'HPy_Contains': 'PySequence_Contains',
     'HPy_Length': 'PyObject_Length',
     'HPy_CallTupleDict': None,
     'HPy_FromPyObject': None,

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -211,6 +211,8 @@ HPy HPy_GetItem(HPyContext *ctx, HPy obj, HPy key);
 HPy HPy_GetItem_i(HPyContext *ctx, HPy obj, HPy_ssize_t idx);
 HPy HPy_GetItem_s(HPyContext *ctx, HPy obj, const char *key);
 
+int HPy_Contains(HPyContext *ctx, HPy container, HPy key);
+
 int HPy_SetItem(HPyContext *ctx, HPy obj, HPy key, HPy value);
 int HPy_SetItem_i(HPyContext *ctx, HPy obj, HPy_ssize_t idx, HPy value);
 int HPy_SetItem_s(HPyContext *ctx, HPy obj, const char *key, HPy value);

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -96,6 +96,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_GetItem = &ctx_GetItem,
     .ctx_GetItem_i = &ctx_GetItem_i,
     .ctx_GetItem_s = &ctx_GetItem_s,
+    .ctx_Contains = &ctx_Contains,
     .ctx_SetItem = &ctx_SetItem,
     .ctx_SetItem_i = &ctx_SetItem_i,
     .ctx_SetItem_s = &ctx_SetItem_s,

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -365,6 +365,11 @@ HPyAPI_IMPL HPy ctx_GetItem(HPyContext *ctx, HPy obj, HPy key)
     return _py2h(PyObject_GetItem(_h2py(obj), _h2py(key)));
 }
 
+HPyAPI_IMPL int ctx_Contains(HPyContext *ctx, HPy container, HPy key)
+{
+    return PySequence_Contains(_h2py(container), _h2py(key));
+}
+
 HPyAPI_IMPL int ctx_SetItem(HPyContext *ctx, HPy obj, HPy key, HPy value)
 {
     return PyObject_SetItem(_h2py(obj), _h2py(key), _h2py(value));


### PR DESCRIPTION
I need `PySequence_Contains` for porting psutil on MacOS, but it seems to me that calling it just `HPy_Contains` would be more in line with `HPy_GetItem` and friends and with the notes from `leysin-2020-design-decisions.md`:

```
Question: Should we have separate HPySequence_GetItem and HPyMapping_GetItem
or just one HPy_GetItem? Should we explore the idea of protocols for such
access.

Decisions:

* We should start with `HPy_GetItem` and `HPy_SetItem` and `HPy_GetItem_i` and
  `HPy_SetItem_i` for item access and `HPy_GetAttr`, `HPy_SetAttr`,
  `HPy_GetAttr_s` and `HPy_SetAttr_s` for attribute access..
```