### PR TITLE
Support parsing nested tuples in HPyArg_Parse

### DIFF
--- a/hpy/devel/src/runtime/argparse.c
+++ b/hpy/devel/src/runtime/argparse.c
@@ -423,8 +423,8 @@ parse_tuple_items(HPyContext *ctx,
     for (HPy_ssize_t i = 0; i < tuple_length && fmt != fmt_end; i++) {
         if (*(*fmt) == 'O' && ht == NULL) {
             set_error(ctx, ctx->h_SystemError, err_fmt,
-                "parsing tuples cannot be used unless"
-                " an HPyTracker is provided. Please supply an HPyTracker.");
+                "parsing tuples cannot be used unless an HPyTracker is provided. "
+                "Please supply an HPyTracker.");
             return 0;
         }
         current_arg = HPy_GetItem_i(ctx, tuple, i);
@@ -437,7 +437,8 @@ parse_tuple_items(HPyContext *ctx,
 
             case '(': {
                 if (tuple_nested_level >= 30) { // same limit as CPython
-                    HPy_FatalError(ctx, "too many tuple nesting levels in argument format string");
+                    set_error(ctx, ctx->h_SystemError, err_fmt, 
+                        "too many tuple nesting levels in argument format string");
                     HPy_Close(ctx, current_arg);
                     return 0;
                 }
@@ -456,16 +457,14 @@ parse_tuple_items(HPyContext *ctx,
                 }
             }
         }
-        if (*(*fmt) != 'O') {
-            HPy_Close(ctx, current_arg);
-        }
+        HPy_Close(ctx, current_arg);
     }
 
     if (*(*fmt) == ')') {
         (*fmt)++;
         return 1;
     } else {
-        HPy_FatalError(ctx, "missing ')' in getargs format");
+        set_error(ctx, ctx->h_SystemError, err_fmt, "missing ')' in getargs format");
         return 0;
     }
 }

--- a/hpy/devel/src/runtime/argparse.c
+++ b/hpy/devel/src/runtime/argparse.c
@@ -112,8 +112,8 @@
  *
  * ``()``
  *     HPyArg_Parse() only: Indicates that arguments between `(` and `)` are 
- *     nested within a tuple. Thus, the tuple length must match the number of 
- *     nested arguments. Recursive nested arguments is allowed up to 30 levels.
+ *     nested within a tuple/list. Thus, the tuple/list length must match the number 
+ *     of nested arguments. Recursive nested arguments is allowed up to 30 levels.
  *
  * ``$``
  *     HPyArg_ParseKeywords() only: Indicates that the remaining arguments in
@@ -414,7 +414,7 @@ parse_tuple_items(HPyContext *ctx,
                     va_list *vl, 
                     const char *err_fmt)
 {
-    if (!HPyTuple_Check(ctx, tuple)) {
+    if (!HPyTuple_Check(ctx, tuple) && !HPyList_Check(ctx, tuple)) {
         set_error(ctx, ctx->h_TypeError, err_fmt, "argument is not a tuple object");
         return 0;
     }


### PR DESCRIPTION
In the effort of porting `matplotlib` library, there are multiple places where `()` are being used in argparse formats.