### PR TITLE
Add pyproject.toml to support PEP 518 and isolated builds.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = [ "setuptools>=40.6.0", "setuptools-scm[toml]>=6.0", "wheel>=0.34.2",]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -155,5 +155,4 @@ setup(
         ],
     },
     use_scm_version=get_scm_config,
-    setup_requires=['setuptools_scm'],
 )


### PR DESCRIPTION
This allows tools like pip to install build dependencies when building `hpy` from source. Currently, building without the `wheel` package installed fails. With this change pip will install the necessary dependencies in an isolated environment.

See https://www.python.org/dev/peps/pep-0518/ for more information.