### PR TITLE
Debug mode: check validity of args handles in the call trampolines

### DIFF
--- a/hpy/debug/src/autogen_debug_ctx_call.i
+++ b/hpy/debug/src/autogen_debug_ctx_call.i
@@ -15,7 +15,7 @@
         _HPyFunc_args_UNARYFUNC *a = (_HPyFunc_args_UNARYFUNC*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_result = f(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -26,8 +26,8 @@
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         DHPy dh_result = f(dctx, dh_arg0, dh_arg1);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -39,9 +39,9 @@
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         DHPy dh_arg2 = _py2dh(dctx, a->arg2);
         DHPy dh_result = f(dctx, dh_arg0, dh_arg1, dh_arg2);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
-        DHPy_close(dctx, dh_arg2);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg2);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -51,7 +51,7 @@
         _HPyFunc_args_INQUIRY *a = (_HPyFunc_args_INQUIRY*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         a->result = f(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         return;
     }
     case HPyFunc_LENFUNC: {
@@ -59,7 +59,7 @@
         _HPyFunc_args_LENFUNC *a = (_HPyFunc_args_LENFUNC*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         a->result = f(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         return;
     }
     case HPyFunc_SSIZEARGFUNC: {
@@ -67,7 +67,7 @@
         _HPyFunc_args_SSIZEARGFUNC *a = (_HPyFunc_args_SSIZEARGFUNC*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_result = f(dctx, dh_arg0, a->arg1);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -77,7 +77,7 @@
         _HPyFunc_args_SSIZESSIZEARGFUNC *a = (_HPyFunc_args_SSIZESSIZEARGFUNC*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_result = f(dctx, dh_arg0, a->arg1, a->arg2);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -88,8 +88,8 @@
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_arg2 = _py2dh(dctx, a->arg2);
         a->result = f(dctx, dh_arg0, a->arg1, dh_arg2);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg2);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg2);
         return;
     }
     case HPyFunc_SSIZESSIZEOBJARGPROC: {
@@ -98,8 +98,8 @@
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_arg3 = _py2dh(dctx, a->arg3);
         a->result = f(dctx, dh_arg0, a->arg1, a->arg2, dh_arg3);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg3);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg3);
         return;
     }
     case HPyFunc_OBJOBJARGPROC: {
@@ -109,9 +109,9 @@
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         DHPy dh_arg2 = _py2dh(dctx, a->arg2);
         a->result = f(dctx, dh_arg0, dh_arg1, dh_arg2);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
-        DHPy_close(dctx, dh_arg2);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg2);
         return;
     }
     case HPyFunc_FREEFUNC: {
@@ -125,7 +125,7 @@
         _HPyFunc_args_GETATTRFUNC *a = (_HPyFunc_args_GETATTRFUNC*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_result = f(dctx, dh_arg0, a->arg1);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -136,8 +136,8 @@
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         DHPy dh_result = f(dctx, dh_arg0, dh_arg1);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -148,8 +148,8 @@
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_arg2 = _py2dh(dctx, a->arg2);
         a->result = f(dctx, dh_arg0, a->arg1, dh_arg2);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg2);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg2);
         return;
     }
     case HPyFunc_SETATTROFUNC: {
@@ -159,9 +159,9 @@
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         DHPy dh_arg2 = _py2dh(dctx, a->arg2);
         a->result = f(dctx, dh_arg0, dh_arg1, dh_arg2);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
-        DHPy_close(dctx, dh_arg2);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg2);
         return;
     }
     case HPyFunc_REPRFUNC: {
@@ -169,7 +169,7 @@
         _HPyFunc_args_REPRFUNC *a = (_HPyFunc_args_REPRFUNC*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_result = f(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -179,7 +179,7 @@
         _HPyFunc_args_HASHFUNC *a = (_HPyFunc_args_HASHFUNC*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         a->result = f(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         return;
     }
     case HPyFunc_RICHCMPFUNC: {
@@ -188,8 +188,8 @@
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         DHPy dh_result = f(dctx, dh_arg0, dh_arg1, a->arg2);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -199,7 +199,7 @@
         _HPyFunc_args_GETITERFUNC *a = (_HPyFunc_args_GETITERFUNC*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_result = f(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -209,7 +209,7 @@
         _HPyFunc_args_ITERNEXTFUNC *a = (_HPyFunc_args_ITERNEXTFUNC*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_result = f(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -221,9 +221,9 @@
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         DHPy dh_arg2 = _py2dh(dctx, a->arg2);
         DHPy dh_result = f(dctx, dh_arg0, dh_arg1, dh_arg2);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
-        DHPy_close(dctx, dh_arg2);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg2);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -235,9 +235,9 @@
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         DHPy dh_arg2 = _py2dh(dctx, a->arg2);
         a->result = f(dctx, dh_arg0, dh_arg1, dh_arg2);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
-        DHPy_close(dctx, dh_arg2);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg2);
         return;
     }
     case HPyFunc_GETTER: {
@@ -245,7 +245,7 @@
         _HPyFunc_args_GETTER *a = (_HPyFunc_args_GETTER*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_result = f(dctx, dh_arg0, a->arg1);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -256,8 +256,8 @@
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         a->result = f(dctx, dh_arg0, dh_arg1, a->arg2);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
         return;
     }
     case HPyFunc_OBJOBJPROC: {
@@ -266,8 +266,8 @@
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         DHPy dh_arg1 = _py2dh(dctx, a->arg1);
         a->result = f(dctx, dh_arg0, dh_arg1);
-        DHPy_close(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg1);
+        DHPy_close_and_check(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg1);
         return;
     }
     case HPyFunc_DESTRUCTOR: {
@@ -275,6 +275,6 @@
         _HPyFunc_args_DESTRUCTOR *a = (_HPyFunc_args_DESTRUCTOR*)args;
         DHPy dh_arg0 = _py2dh(dctx, a->arg0);
         f(dctx, dh_arg0);
-        DHPy_close(dctx, dh_arg0);
+        DHPy_close_and_check(dctx, dh_arg0);
         return;
     }

--- a/hpy/debug/src/debug_ctx_cpython.c
+++ b/hpy/debug/src/debug_ctx_cpython.c
@@ -79,7 +79,7 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
         _HPyFunc_args_NOARGS *a = (_HPyFunc_args_NOARGS*)args;
         DHPy dh_self = _py2dh(dctx, a->self);
         DHPy dh_result = f(dctx, dh_self);
-        DHPy_close(dctx, dh_self);
+        DHPy_close_and_check(dctx, dh_self);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -90,8 +90,8 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
         DHPy dh_self = _py2dh(dctx, a->self);
         DHPy dh_arg = _py2dh(dctx, a->arg);
         DHPy dh_result = f(dctx, dh_self, dh_arg);
-        DHPy_close(dctx, dh_self);
-        DHPy_close(dctx, dh_arg);
+        DHPy_close_and_check(dctx, dh_self);
+        DHPy_close_and_check(dctx, dh_arg);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -106,9 +106,9 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
             dh_args[i] = _py2dh(dctx, PyTuple_GET_ITEM(a->args, i));
         }
         DHPy dh_result = f(dctx, dh_self, dh_args, nargs);
-        DHPy_close(dctx, dh_self);
+        DHPy_close_and_check(dctx, dh_self);
         for (Py_ssize_t i = 0; i < nargs; i++) {
-            DHPy_close(dctx, dh_args[i]);
+            DHPy_close_and_check(dctx, dh_args[i]);
         }
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
@@ -125,11 +125,11 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
         }
         DHPy dh_kw = _py2dh(dctx, a->kw);
         DHPy dh_result = f(dctx, dh_self, dh_args, nargs, dh_kw);
-        DHPy_close(dctx, dh_self);
+        DHPy_close_and_check(dctx, dh_self);
         for (Py_ssize_t i = 0; i < nargs; i++) {
-            DHPy_close(dctx, dh_args[i]);
+            DHPy_close_and_check(dctx, dh_args[i]);
         }
-        DHPy_close(dctx, dh_kw);
+        DHPy_close_and_check(dctx, dh_kw);
         a->result = _dh2py(dctx, dh_result);
         DHPy_close(dctx, dh_result);
         return;
@@ -145,11 +145,11 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
         }
         DHPy dh_kw = _py2dh(dctx, a->kw);
         a->result = f(dctx, dh_self, dh_args, nargs, dh_kw);
-        DHPy_close(dctx, dh_self);
+        DHPy_close_and_check(dctx, dh_self);
         for (Py_ssize_t i = 0; i < nargs; i++) {
-            DHPy_close(dctx, dh_args[i]);
+            DHPy_close_and_check(dctx, dh_args[i]);
         }
-        DHPy_close(dctx, dh_kw);
+        DHPy_close_and_check(dctx, dh_kw);
         return;
     }
     case HPyFunc_GETBUFFERPROC: {
@@ -158,7 +158,7 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
         HPy_buffer hbuf;
         DHPy dh_self = _py2dh(dctx, a->self);
         a->result = f(dctx, dh_self, &hbuf, a->flags);
-        DHPy_close(dctx, dh_self);
+        DHPy_close_and_check(dctx, dh_self);
         if (a->result < 0) {
             a->view->obj = NULL;
             return;
@@ -174,7 +174,7 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
         _buffer_py2h(dctx, a->view, &hbuf);
         DHPy dh_self = _py2dh(dctx, a->self);
         f(dctx, dh_self, &hbuf);
-        DHPy_close(dctx, dh_self);
+        DHPy_close_and_check(dctx, dh_self);
         // XXX: copy back from hbuf?
         HPy_Close(dctx, hbuf.obj);
         return;

--- a/hpy/debug/src/debug_handles.c
+++ b/hpy/debug/src/debug_handles.c
@@ -94,6 +94,17 @@ void DHPy_invalid_handle(HPyContext *dctx, DHPy dh)
     HPy_Close(uctx, uh_res);
 }
 
+// DHPy_close, unlike debug_ctx_Close does not check the validity of the handle.
+// Use this in case you want to close only the debug handle like DHPy_close,
+// you but still want to check its validity
+void DHPy_close_and_check(HPyContext *dctx, DHPy dh) {
+    DHPy_unwrap(dctx, dh);
+    DHPy_close(dctx, dh);
+}
+
+// Note: the difference from just HPy_Close(dctx, dh), which calls debug_ctx_Close,
+// is that this only closes the debug handle. This is useful in situations
+// where we know that the wrapped handle will be closed by the wrapped context.
 void DHPy_close(HPyContext *dctx, DHPy dh)
 {
     DHPy_sanity_check(dh);

--- a/hpy/debug/src/debug_internal.h
+++ b/hpy/debug/src/debug_internal.h
@@ -157,6 +157,7 @@ static inline DHPy as_DHPy(DebugHandle *handle) {
 
 DHPy DHPy_open(HPyContext *dctx, UHPy uh);
 void DHPy_close(HPyContext *dctx, DHPy dh);
+void DHPy_close_and_check(HPyContext *dctx, DHPy dh);
 void DHPy_free(HPyContext *dctx, DHPy dh);
 void DHPy_invalid_handle(HPyContext *dctx, DHPy dh);
 

--- a/hpy/tools/autogen/debug.py
+++ b/hpy/tools/autogen/debug.py
@@ -160,7 +160,7 @@ class autogen_debug_ctx_call_i(AutoGenFile):
                 w(f'        a->result = f({args});')
             #
             for pname in dhpys:
-                w(f'        DHPy_close(dctx, dh_{pname});')
+                w(f'        DHPy_close_and_check(dctx, dh_{pname});')
             #
             if c_ret_type == 'HPy':
                 w(f'        a->result = _dh2py(dctx, dh_result);')


### PR DESCRIPTION
See the test for an example of a wrong behavior that wasn't previously detected in the debug mode, but is detected now.

Follow-up of https://github.com/hpyproject/hpy/issues/258

I think we should also think about giving a better error message with more context "argument was closed prematurely", "return value is not valid handle, maybe you forgot to HPy_Duplicate it", etc. But I'd leave that for another issue/PR.