### PR TITLE
RFC: Support HPyFields in HPy_AsPyObject

### DIFF
--- a/hpy/universal/src/handles.h
+++ b/hpy/universal/src/handles.h
@@ -23,14 +23,12 @@ static inline PyObject *_h2py(HPy h) {
 
 static inline HPyField _py2hf(PyObject *obj)
 {
-    HPy h = _py2h(obj);
-    return (HPyField){ ._i = h._i };
+    return (HPyField){(intptr_t) obj};
 }
 
 static inline PyObject * _hf2py(HPyField hf)
 {
-    HPy h = { ._i = hf._i };
-    return _h2py(h);
+    return (PyObject*)hf._i;
 }
 
 #endif /* HPY_HANDLES_H */

--- a/test/test_cpy_compat.py
+++ b/test/test_cpy_compat.py
@@ -116,12 +116,14 @@ class TestCPythonCompatibility(HPyTest):
 
     def test_aspyobject_hpy_type(self):
         mod = self.make_module("""
+            #include <Python.h>
+
             typedef struct {
+                PyObject_HEAD
                 int magic;
                 HPyField f;
             } MyHPyType;
 
-            #include <Python.h>
             typedef struct {
                 PyObject_HEAD
                 int magic;
@@ -152,7 +154,8 @@ class TestCPythonCompatibility(HPyTest):
                 .name = "mytest.MyType",
                 .basicsize = sizeof(MyHPyType),
                 .flags = HPy_TPFLAGS_DEFAULT | HPy_TPFLAGS_HAVE_GC,
-                .defines = MyType_defines
+                .defines = MyType_defines,
+                .legacy = true,
             };
 
             HPyDef_METH(f, "f", f_impl, HPyFunc_O)


### PR DESCRIPTION
The change in code is tiny. The main thing are the implications of it: if `HPyField` is `PyObject*` in both universal and CPython ABI, then, at least in CPython at runtime, `HPy_AsPyObject` gives you a chunk of memory that is usable as the original `PyObject*`, so conversion to `HPyField`s does not have to be all-or-nothing. See the test for an example of what I have in mind.

I don't know about PyPy, but I think that in theory we could even support this on GraalPython, it would be slow, but it would work. `HPy_AsPyObject` would basically transform the object to CPython compatible layout and leave it there. Not great, but pragmatic.

The main motivation is that `PyArray_Descr` (and other types) migration in numpy-hpy could then be more gradual.

What do you think @rlamy?

Re the fact that we now make it easier to the users to abuse the API: yes, but the handles are still `PyObject-1`, so I think we're still have quite some obstacles to prevent users from being CPython specific. We could maybe add some checks of this to the debug mode. We should also add check that makes sure that tp_traverse visits all the fields, i.e., we'll need to remember them, so with that it may not be that difficult to obfuscate the memory and deobfuscate it in `HPy_AsPyObject`.