### PR TITLE
Small autogen fixes and improvements.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,12 +266,9 @@ jobs:
       - name: Install/Upgrade Python dependencies
         run: python -m pip install --upgrade pip wheel
 
-      - name: Install dependencies
-        run: |
-          pip install pycparser==2.20
-          pip install py==1.8.0
-          pip install packaging==19.2
-          pip install attrs==19.3.0
+      - name: Install autogen dependencies
+        run: pip install -r requirements-autogen.txt
+
       - name: make autogen
         run: |
           make autogen

--- a/hpy/tools/autogen/__main__.py
+++ b/hpy/tools/autogen/__main__.py
@@ -5,8 +5,8 @@ import sys
 import py
 import pycparser
 from packaging import version
-if version.parse(pycparser.__version__) < version.parse('2.20'):
-    raise ImportError('You need pycparser>=2.20 to run autogen')
+if version.parse(pycparser.__version__) < version.parse('2.21'):
+    raise ImportError('You need pycparser>=2.21 to run autogen')
 
 from .parse import HPyAPI, PUBLIC_API_H
 from .ctx import autogen_ctx_h, autogen_ctx_def_h

--- a/hpy/tools/autogen/parse.py
+++ b/hpy/tools/autogen/parse.py
@@ -24,7 +24,7 @@ def get_context_return_type(func_node, const_return):
 
 def make_void(func_node):
     voidid = c_ast.IdentifierType(names=['void'])
-    func_node.type.type.type = c_ast.TypeDecl(declname='void', quals=[], type=voidid)
+    func_node.type.type.type = c_ast.TypeDecl(declname='void', quals=[], align=[], type=voidid)
 
 def get_return_constant(func):
     return RETURN_CONSTANT.get(func.node.name)

--- a/requirements-autogen.txt
+++ b/requirements-autogen.txt
@@ -1,0 +1,4 @@
+pycparser==2.21
+py==1.8.0
+packaging==19.2
+attrs==19.3.0


### PR DESCRIPTION
* Fixes incompatibility with newest `pycparser`
* Add `requirements-autogen.txt` to install packages needed for autogen and testing.
* Sort declarations after parsing of `public_api.h` by line/col number to ensure deterministic autogen output.