### PR TITLE
Ensure HPyContext backwards compatibility when adding handles or functions.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ def pre_process(app, filename, contents, *args):
     # remove HPyAPI_HELPER so that the sphinx-c-autodoc and clang
     # find and render the API functions
     contents[:] = [
-        re.sub(r"^(HPyAPI_HELPER|HPyAPI_FUNC\(\d+\)|HPyAPI_HANDLE\(\d+\))", r"", part, flags=re.MULTILINE)
+        re.sub(r"^(HPyAPI_HELPER|HPy_ID\(\d+\))", r"", part, flags=re.MULTILINE)
         for part in contents
     ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ def pre_process(app, filename, contents, *args):
     # remove HPyAPI_HELPER so that the sphinx-c-autodoc and clang
     # find and render the API functions
     contents[:] = [
-        re.sub(r"^HPyAPI_HELPER ", r"", part, flags=re.MULTILINE)
+        re.sub(r"^(HPyAPI_HELPER|HPyAPI_FUNC\(\d+\)|HPyAPI_HANDLE\(\d+\))", r"", part, flags=re.MULTILINE)
         for part in contents
     ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 # Requirements for building the documentation
+Jinja2<3.1
 sphinx==3.3.1
 sphinx-rtd-theme==0.5.0
 sphinx-autobuild==0.7.1

--- a/hpy/tools/autogen/__main__.py
+++ b/hpy/tools/autogen/__main__.py
@@ -8,7 +8,7 @@ from packaging import version
 if version.parse(pycparser.__version__) < version.parse('2.21'):
     raise ImportError('You need pycparser>=2.21 to run autogen')
 
-from .parse import HPyAPI, PUBLIC_API_H
+from .parse import HPyAPI, AUTOGEN_H
 from .ctx import autogen_ctx_h, autogen_ctx_def_h
 from .trampolines import (autogen_trampolines_h,
                           cpython_autogen_api_impl_h,
@@ -29,7 +29,7 @@ def main():
         sys.exit(1)
     outdir = py.path.local(sys.argv[1])
 
-    api = HPyAPI.parse(PUBLIC_API_H)
+    api = HPyAPI.parse(AUTOGEN_H)
     ## for func in api.functions:
     ##     print(func)
 

--- a/hpy/tools/autogen/autogen.h
+++ b/hpy/tools/autogen/autogen.h
@@ -1,7 +1,5 @@
 #define STRINGIFY(X) #X
-#define HPyAPI_HANDLE(X) _Pragma(STRINGIFY(ctx_index=X)) \
-
-#define HPyAPI_FUNC(X) _Pragma(STRINGIFY(ctx_index=X))
+#define HPy_ID(X) _Pragma(STRINGIFY(id=X)) \
 
 #define AUTOGEN 1
 

--- a/hpy/tools/autogen/autogen.h
+++ b/hpy/tools/autogen/autogen.h
@@ -6,8 +6,6 @@
 #define AUTOGEN 1
 
 // These are not real typedefs: they are there only to make pycparser happy
-// and this comment is not on the top of the file, so that it is not picked up
-// by autodoc
 typedef int HPy;
 typedef int HPyContext;
 typedef int HPyModuleDef;

--- a/hpy/tools/autogen/autogen.h
+++ b/hpy/tools/autogen/autogen.h
@@ -1,0 +1,34 @@
+#define STRINGIFY(X) #X
+#define HPyAPI_HANDLE(X) _Pragma(STRINGIFY(ctx_index=X)) \
+
+#define HPyAPI_FUNC(X) _Pragma(STRINGIFY(ctx_index=X))
+
+#define AUTOGEN 1
+
+// These are not real typedefs: they are there only to make pycparser happy
+// and this comment is not on the top of the file, so that it is not picked up
+// by autodoc
+typedef int HPy;
+typedef int HPyContext;
+typedef int HPyModuleDef;
+typedef int HPyType_Spec;
+typedef int HPyType_SpecParam;
+typedef int HPyCFunction;
+typedef int HPy_ssize_t;
+typedef int HPy_hash_t;
+typedef int wchar_t;
+typedef int size_t;
+typedef int HPyFunc_Signature;
+typedef int cpy_PyObject;
+typedef int HPyField;
+typedef int HPyGlobal;
+typedef int HPyListBuilder;
+typedef int HPyTupleBuilder;
+typedef int HPyTracker;
+typedef int HPy_RichCmpOp;
+typedef int HPy_buffer;
+typedef int HPyFunc_visitproc;
+typedef int HPy_UCS4;
+typedef int HPyThreadState;
+
+#include "public_api.h"

--- a/hpy/tools/autogen/ctx.py
+++ b/hpy/tools/autogen/ctx.py
@@ -23,9 +23,8 @@ class autogen_ctx_h(AutoGenFile):
         # We need to remember the output function per item (either
         # 'declare_var' or 'declare_func'). So, we create tuples with structure
         # '(decl, declare_*)'.
-        all_decls = []
-        all_decls.extend(map(lambda x: (x, self.declare_var), self.api.variables))
-        all_decls.extend(map(lambda x: (x, self.declare_func), self.api.functions))
+        all_decls = [(x, self.declare_var) for x in self.api.variables]
+        all_decls += [(x, self.declare_func) for x in self.api.functions]
 
         # sort the list of all declaration by 'decl.ctx_index'
         all_decls.sort(key=lambda x: x[0].ctx_index)

--- a/hpy/tools/autogen/ctx.py
+++ b/hpy/tools/autogen/ctx.py
@@ -18,16 +18,26 @@ class autogen_ctx_h(AutoGenFile):
     ## }
 
     def generate(self):
+        # Put all declarations (variables and functions) into one list in order
+        # to be able to sort them by their given context index.
+        # We need to remember the output function per item (either
+        # 'declare_var' or 'declare_func'). So, we create tuples with structure
+        # '(decl, declare_*)'.
+        all_decls = []
+        all_decls.extend(map(lambda x: (x, self.declare_var), self.api.variables))
+        all_decls.extend(map(lambda x: (x, self.declare_func), self.api.functions))
+
+        # sort the list of all declaration by 'decl.ctx_index'
+        all_decls.sort(key=lambda x: x[0].ctx_index)
+
         lines = []
         w = lines.append
         w('struct _HPyContext_s {')
         w('    const char *name; // used just to make debugging and testing easier')
         w('    void *_private;   // used by implementations to store custom data')
         w('    int ctx_version;')
-        for var in self.api.variables:
-            w('    %s;' % self.declare_var(var))
-        for func in self.api.functions:
-            w('    %s;' % self.declare_func(func))
+        for var, cons in all_decls:
+            w('    %s;' % cons(var))
         w('};')
         return '\n'.join(lines)
 

--- a/hpy/tools/autogen/parse.py
+++ b/hpy/tools/autogen/parse.py
@@ -8,6 +8,8 @@ from pycparser.c_generator import CGenerator
 from .conf import SPECIAL_CASES, RETURN_CONSTANT
 
 PUBLIC_API_H = py.path.local(__file__).dirpath('public_api.h')
+CURRENT_DIR = py.path.local(__file__).dirpath()
+AUTOGEN_H = py.path.local(__file__).dirpath('autogen.h')
 
 
 def toC(node):
@@ -106,8 +108,8 @@ class HPyAPIVisitor(pycparser.c_ast.NodeVisitor):
 
     def verify_context_indices(self):
         """
-        Verifies if context indices are monotone and without gaps. This
-        function raises an assertion error if not.
+        Verifies if context indices are without gaps. This function raises an
+        assertion error if not.
         For example:
         [0, 1, 2, 3] is valid
         [0, 1, 3] is invalid

--- a/hpy/tools/autogen/parse.py
+++ b/hpy/tools/autogen/parse.py
@@ -1,10 +1,12 @@
 from copy import deepcopy
+import sys
 import attr
 import re
 import py
 import pycparser
 from pycparser import c_ast
 from pycparser.c_generator import CGenerator
+from distutils.sysconfig import get_config_var
 from .conf import SPECIAL_CASES, RETURN_CONSTANT
 
 PUBLIC_API_H = py.path.local(__file__).dirpath('public_api.h')
@@ -200,8 +202,16 @@ class HPyAPI:
                             re.DOTALL | re.MULTILINE)
 
     def __init__(self, filename):
-        with open(filename, 'r') as f:
-            csource = f.read()
+        cpp_cmd = get_config_var('CC').split(' ')
+        if sys.platform == 'win32':
+            cpp_cmd += ['/E', '/I%s' % CURRENT_DIR]
+        else:
+            cpp_cmd += ['-E', '-I%s' % CURRENT_DIR]
+
+        csource = pycparser.preprocess_file(filename,
+                                  cpp_path=str(cpp_cmd[0]),
+                                  cpp_args=cpp_cmd[1:])
+
         # Remove comments.  NOTE: this assumes that comments are never inside
         # string literals, but there shouldn't be any here.
         def replace_keeping_newlines(m):

--- a/hpy/tools/autogen/parse.py
+++ b/hpy/tools/autogen/parse.py
@@ -39,6 +39,7 @@ class Function:
 
     name = attr.ib()
     cpython_name = attr.ib()
+    ctx_index = attr.ib()
     node = attr.ib(repr=False)
 
     def base_name(self):
@@ -56,6 +57,7 @@ class Function:
 @attr.s
 class GlobalVar:
     name = attr.ib()
+    ctx_index = attr.ib()
     node = attr.ib(repr=False)
 
     def ctx_name(self):
@@ -93,6 +95,29 @@ class HPyAPIVisitor(pycparser.c_ast.NodeVisitor):
     def __init__(self, api, convert_name):
         self.api = api
         self.convert_name = convert_name
+        self.cur_index = -1
+        self.all_indices = []
+
+    def _consume_ctx_index(self):
+        idx = self.cur_index
+        self.all_indices.append(idx)
+        self.cur_index = -1
+        return idx
+
+    def verify_context_indices(self):
+        """
+        Verifies if context indices are monotone and without gaps. This
+        function raises an assertion error if not.
+        For example:
+        [0, 1, 2, 3] is valid
+        [0, 1, 3] is invalid
+        """
+        self.all_indices.sort()
+        for i in range(1, len(self.all_indices)):
+            prev = self.all_indices[i-1]
+            cur = self.all_indices[i]
+            assert prev + 1 == cur, \
+                "context indices have gaps: %s -> %s" % (prev, cur)
 
     def _is_function_ptr(self, node):
         return (isinstance(node, c_ast.PtrDecl) and
@@ -111,6 +136,12 @@ class HPyAPIVisitor(pycparser.c_ast.NodeVisitor):
         elif node.name == 'HPySlot_Slot':
             self._visit_hpyslot_slot(node)
 
+    def visit_Pragma(self, node):
+        parts = node.string.split('=')
+        if len(parts) != 2:
+            raise ValueError('invalid pragma: %s' % node)
+        self.cur_index = int(parts[1])
+
     def _visit_function(self, node):
         name = node.name
         if not name.startswith('HPy') and not name.startswith('_HPy'):
@@ -121,7 +152,10 @@ class HPyAPIVisitor(pycparser.c_ast.NodeVisitor):
                 raise ValueError("non-named argument in declaration of %s" %
                                  name)
         cpy_name = self.convert_name(name)
-        func = Function(name, cpy_name, node)
+        idx = self._consume_ctx_index()
+        if idx == -1:
+            raise ValueError('missing context index for %s' % name)
+        func = Function(name, cpy_name, idx, node)
         self.api.functions.append(func)
 
     def _visit_global_var(self, node):
@@ -130,7 +164,10 @@ class HPyAPIVisitor(pycparser.c_ast.NodeVisitor):
             print('WARNING: Ignoring non-hpy variable declaration: %s' % name)
             return
         assert toC(node.type.type) == "HPy"
-        var = GlobalVar(name, node)
+        idx = self._consume_ctx_index()
+        if idx == -1:
+            raise ValueError('missing context index for %s' % name)
+        var = GlobalVar(name, idx, node)
         self.api.variables.append(var)
 
     def _visit_hpyfunc_typedef(self, node):
@@ -201,6 +238,8 @@ class HPyAPI:
         self.hpyslots = []
         v = HPyAPIVisitor(self, convert_name)
         v.visit(self.ast)
+
+        v.verify_context_indices()
 
         # Sort lists such that the generated files are deterministic.
         # List elements are either 'Function', 'GlobalVar', or 'HPyFunc'. All

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -3,274 +3,407 @@
 #if AUTOGEN
 
 /* Constants */
-HPy h_None;
-HPy h_True;
-HPy h_False;
-HPy h_NotImplemented;
-HPy h_Ellipsis;
+HPyAPI_HANDLE(0) HPy h_None;
+HPyAPI_HANDLE(1) HPy h_True;
+HPyAPI_HANDLE(2) HPy h_False;
+HPyAPI_HANDLE(3) HPy h_NotImplemented;
+HPyAPI_HANDLE(4) HPy h_Ellipsis;
 
 /* Exceptions */
-HPy h_BaseException;
-HPy h_Exception;
-HPy h_StopAsyncIteration;
-HPy h_StopIteration;
-HPy h_GeneratorExit;
-HPy h_ArithmeticError;
-HPy h_LookupError;
-HPy h_AssertionError;
-HPy h_AttributeError;
-HPy h_BufferError;
-HPy h_EOFError;
-HPy h_FloatingPointError;
-HPy h_OSError;
-HPy h_ImportError;
-HPy h_ModuleNotFoundError;
-HPy h_IndexError;
-HPy h_KeyError;
-HPy h_KeyboardInterrupt;
-HPy h_MemoryError;
-HPy h_NameError;
-HPy h_OverflowError;
-HPy h_RuntimeError;
-HPy h_RecursionError;
-HPy h_NotImplementedError;
-HPy h_SyntaxError;
-HPy h_IndentationError;
-HPy h_TabError;
-HPy h_ReferenceError;
-HPy h_SystemError;
-HPy h_SystemExit;
-HPy h_TypeError;
-HPy h_UnboundLocalError;
-HPy h_UnicodeError;
-HPy h_UnicodeEncodeError;
-HPy h_UnicodeDecodeError;
-HPy h_UnicodeTranslateError;
-HPy h_ValueError;
-HPy h_ZeroDivisionError;
-HPy h_BlockingIOError;
-HPy h_BrokenPipeError;
-HPy h_ChildProcessError;
-HPy h_ConnectionError;
-HPy h_ConnectionAbortedError;
-HPy h_ConnectionRefusedError;
-HPy h_ConnectionResetError;
-HPy h_FileExistsError;
-HPy h_FileNotFoundError;
-HPy h_InterruptedError;
-HPy h_IsADirectoryError;
-HPy h_NotADirectoryError;
-HPy h_PermissionError;
-HPy h_ProcessLookupError;
-HPy h_TimeoutError;
+HPyAPI_HANDLE(5) HPy h_BaseException;
+HPyAPI_HANDLE(6) HPy h_Exception;
+HPyAPI_HANDLE(7) HPy h_StopAsyncIteration;
+HPyAPI_HANDLE(8) HPy h_StopIteration;
+HPyAPI_HANDLE(9) HPy h_GeneratorExit;
+HPyAPI_HANDLE(10) HPy h_ArithmeticError;
+HPyAPI_HANDLE(11) HPy h_LookupError;
+HPyAPI_HANDLE(12) HPy h_AssertionError;
+HPyAPI_HANDLE(13) HPy h_AttributeError;
+HPyAPI_HANDLE(14) HPy h_BufferError;
+HPyAPI_HANDLE(15) HPy h_EOFError;
+HPyAPI_HANDLE(16) HPy h_FloatingPointError;
+HPyAPI_HANDLE(17) HPy h_OSError;
+HPyAPI_HANDLE(18) HPy h_ImportError;
+HPyAPI_HANDLE(19) HPy h_ModuleNotFoundError;
+HPyAPI_HANDLE(20) HPy h_IndexError;
+HPyAPI_HANDLE(21) HPy h_KeyError;
+HPyAPI_HANDLE(22) HPy h_KeyboardInterrupt;
+HPyAPI_HANDLE(23) HPy h_MemoryError;
+HPyAPI_HANDLE(24) HPy h_NameError;
+HPyAPI_HANDLE(25) HPy h_OverflowError;
+HPyAPI_HANDLE(26) HPy h_RuntimeError;
+HPyAPI_HANDLE(27) HPy h_RecursionError;
+HPyAPI_HANDLE(28) HPy h_NotImplementedError;
+HPyAPI_HANDLE(29) HPy h_SyntaxError;
+HPyAPI_HANDLE(30) HPy h_IndentationError;
+HPyAPI_HANDLE(31) HPy h_TabError;
+HPyAPI_HANDLE(32) HPy h_ReferenceError;
+HPyAPI_HANDLE(33) HPy h_SystemError;
+HPyAPI_HANDLE(34) HPy h_SystemExit;
+HPyAPI_HANDLE(35) HPy h_TypeError;
+HPyAPI_HANDLE(36) HPy h_UnboundLocalError;
+HPyAPI_HANDLE(37) HPy h_UnicodeError;
+HPyAPI_HANDLE(38) HPy h_UnicodeEncodeError;
+HPyAPI_HANDLE(39) HPy h_UnicodeDecodeError;
+HPyAPI_HANDLE(40) HPy h_UnicodeTranslateError;
+HPyAPI_HANDLE(41) HPy h_ValueError;
+HPyAPI_HANDLE(42) HPy h_ZeroDivisionError;
+HPyAPI_HANDLE(43) HPy h_BlockingIOError;
+HPyAPI_HANDLE(44) HPy h_BrokenPipeError;
+HPyAPI_HANDLE(45) HPy h_ChildProcessError;
+HPyAPI_HANDLE(46) HPy h_ConnectionError;
+HPyAPI_HANDLE(47) HPy h_ConnectionAbortedError;
+HPyAPI_HANDLE(48) HPy h_ConnectionRefusedError;
+HPyAPI_HANDLE(49) HPy h_ConnectionResetError;
+HPyAPI_HANDLE(50) HPy h_FileExistsError;
+HPyAPI_HANDLE(51) HPy h_FileNotFoundError;
+HPyAPI_HANDLE(52) HPy h_InterruptedError;
+HPyAPI_HANDLE(53) HPy h_IsADirectoryError;
+HPyAPI_HANDLE(54) HPy h_NotADirectoryError;
+HPyAPI_HANDLE(55) HPy h_PermissionError;
+HPyAPI_HANDLE(56) HPy h_ProcessLookupError;
+HPyAPI_HANDLE(57) HPy h_TimeoutError;
 // EnvironmentError, IOError and WindowsError are intentionally omitted (they
 // are all aliases of OSError since Python 3.3).
 
 /* Warnings */
-HPy h_Warning;
-HPy h_UserWarning;
-HPy h_DeprecationWarning;
-HPy h_PendingDeprecationWarning;
-HPy h_SyntaxWarning;
-HPy h_RuntimeWarning;
-HPy h_FutureWarning;
-HPy h_ImportWarning;
-HPy h_UnicodeWarning;
-HPy h_BytesWarning;
-HPy h_ResourceWarning;
+HPyAPI_HANDLE(58) HPy h_Warning;
+HPyAPI_HANDLE(59) HPy h_UserWarning;
+HPyAPI_HANDLE(60) HPy h_DeprecationWarning;
+HPyAPI_HANDLE(61) HPy h_PendingDeprecationWarning;
+HPyAPI_HANDLE(62) HPy h_SyntaxWarning;
+HPyAPI_HANDLE(63) HPy h_RuntimeWarning;
+HPyAPI_HANDLE(64) HPy h_FutureWarning;
+HPyAPI_HANDLE(65) HPy h_ImportWarning;
+HPyAPI_HANDLE(66) HPy h_UnicodeWarning;
+HPyAPI_HANDLE(67) HPy h_BytesWarning;
+HPyAPI_HANDLE(68) HPy h_ResourceWarning;
 
 /* Types */
-HPy h_BaseObjectType;   /* built-in 'object' */
-HPy h_TypeType;         /* built-in 'type' */
-HPy h_BoolType;         /* built-in 'bool' */
-HPy h_LongType;         /* built-in 'int' */
-HPy h_FloatType;        /* built-in 'float' */
-HPy h_UnicodeType;      /* built-in 'str' */
-HPy h_TupleType;        /* built-in 'tuple' */
-HPy h_ListType;         /* built-in 'list' */
+HPyAPI_HANDLE(69) HPy h_BaseObjectType;   /* built-in 'object' */
+HPyAPI_HANDLE(70) HPy h_TypeType;         /* built-in 'type' */
+HPyAPI_HANDLE(71) HPy h_BoolType;         /* built-in 'bool' */
+HPyAPI_HANDLE(72) HPy h_LongType;         /* built-in 'int' */
+HPyAPI_HANDLE(73) HPy h_FloatType;        /* built-in 'float' */
+HPyAPI_HANDLE(74) HPy h_UnicodeType;      /* built-in 'str' */
+HPyAPI_HANDLE(75) HPy h_TupleType;        /* built-in 'tuple' */
+HPyAPI_HANDLE(76) HPy h_ListType;         /* built-in 'list' */
 
 #endif
 
+HPyAPI_FUNC(77)
 HPy HPyModule_Create(HPyContext *ctx, HPyModuleDef *def);
+HPyAPI_FUNC(78)
 HPy HPy_Dup(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(79)
 void HPy_Close(HPyContext *ctx, HPy h);
 
+HPyAPI_FUNC(80)
 HPy HPyLong_FromLong(HPyContext *ctx, long value);
+HPyAPI_FUNC(81)
 HPy HPyLong_FromUnsignedLong(HPyContext *ctx, unsigned long value);
+HPyAPI_FUNC(82)
 HPy HPyLong_FromLongLong(HPyContext *ctx, long long v);
+HPyAPI_FUNC(83)
 HPy HPyLong_FromUnsignedLongLong(HPyContext *ctx, unsigned long long v);
+HPyAPI_FUNC(84)
 HPy HPyLong_FromSize_t(HPyContext *ctx, size_t value);
+HPyAPI_FUNC(85)
 HPy HPyLong_FromSsize_t(HPyContext *ctx, HPy_ssize_t value);
 
+HPyAPI_FUNC(86)
 long HPyLong_AsLong(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(87)
 unsigned long HPyLong_AsUnsignedLong(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(88)
 unsigned long HPyLong_AsUnsignedLongMask(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(89)
 long long HPyLong_AsLongLong(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(90)
 unsigned long long HPyLong_AsUnsignedLongLong(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(91)
 unsigned long long HPyLong_AsUnsignedLongLongMask(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(92)
 size_t HPyLong_AsSize_t(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(93)
 HPy_ssize_t HPyLong_AsSsize_t(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(94)
 void* HPyLong_AsVoidPtr(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(95)
 double HPyLong_AsDouble(HPyContext *ctx, HPy h);
 
+HPyAPI_FUNC(96)
 HPy HPyFloat_FromDouble(HPyContext *ctx, double v);
+HPyAPI_FUNC(97)
 double HPyFloat_AsDouble(HPyContext *ctx, HPy h);
 
+HPyAPI_FUNC(98)
 HPy HPyBool_FromLong(HPyContext *ctx, long v);
 
 
 /* abstract.h */
+HPyAPI_FUNC(99)
 HPy_ssize_t HPy_Length(HPyContext *ctx, HPy h);
 
+HPyAPI_FUNC(100)
 int HPyNumber_Check(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(101)
 HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(102)
 HPy HPy_Subtract(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(103)
 HPy HPy_Multiply(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(104)
 HPy HPy_MatrixMultiply(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(105)
 HPy HPy_FloorDivide(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(106)
 HPy HPy_TrueDivide(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(107)
 HPy HPy_Remainder(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(108)
 HPy HPy_Divmod(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(109)
 HPy HPy_Power(HPyContext *ctx, HPy h1, HPy h2, HPy h3);
+HPyAPI_FUNC(110)
 HPy HPy_Negative(HPyContext *ctx, HPy h1);
+HPyAPI_FUNC(111)
 HPy HPy_Positive(HPyContext *ctx, HPy h1);
+HPyAPI_FUNC(112)
 HPy HPy_Absolute(HPyContext *ctx, HPy h1);
+HPyAPI_FUNC(113)
 HPy HPy_Invert(HPyContext *ctx, HPy h1);
+HPyAPI_FUNC(114)
 HPy HPy_Lshift(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(115)
 HPy HPy_Rshift(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(116)
 HPy HPy_And(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(117)
 HPy HPy_Xor(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(118)
 HPy HPy_Or(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(119)
 HPy HPy_Index(HPyContext *ctx, HPy h1);
+HPyAPI_FUNC(120)
 HPy HPy_Long(HPyContext *ctx, HPy h1);
+HPyAPI_FUNC(121)
 HPy HPy_Float(HPyContext *ctx, HPy h1);
 
+HPyAPI_FUNC(122)
 HPy HPy_InPlaceAdd(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(123)
 HPy HPy_InPlaceSubtract(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(124)
 HPy HPy_InPlaceMultiply(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(125)
 HPy HPy_InPlaceMatrixMultiply(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(126)
 HPy HPy_InPlaceFloorDivide(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(127)
 HPy HPy_InPlaceTrueDivide(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(128)
 HPy HPy_InPlaceRemainder(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(129)
 HPy HPy_InPlacePower(HPyContext *ctx, HPy h1, HPy h2, HPy h3);
+HPyAPI_FUNC(130)
 HPy HPy_InPlaceLshift(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(131)
 HPy HPy_InPlaceRshift(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(132)
 HPy HPy_InPlaceAnd(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(133)
 HPy HPy_InPlaceXor(HPyContext *ctx, HPy h1, HPy h2);
+HPyAPI_FUNC(134)
 HPy HPy_InPlaceOr(HPyContext *ctx, HPy h1, HPy h2);
 
+HPyAPI_FUNC(135)
 int HPyCallable_Check(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(136)
 HPy HPy_CallTupleDict(HPyContext *ctx, HPy callable, HPy args, HPy kw);
 
 /* pyerrors.h */
+HPyAPI_FUNC(137)
 void HPy_FatalError(HPyContext *ctx, const char *message);
+HPyAPI_FUNC(138)
 HPy HPyErr_SetString(HPyContext *ctx, HPy h_type, const char *message);
+HPyAPI_FUNC(139)
 HPy HPyErr_SetObject(HPyContext *ctx, HPy h_type, HPy h_value);
 /* note: the filename will be FS decoded */
+HPyAPI_FUNC(140)
 HPy HPyErr_SetFromErrnoWithFilename(HPyContext *ctx, HPy h_type, const char *filename_fsencoded);
+HPyAPI_FUNC(141)
 HPy HPyErr_SetFromErrnoWithFilenameObjects(HPyContext *ctx, HPy h_type, HPy filename1, HPy filename2);
 /* note: HPyErr_Occurred() returns a flag 0-or-1, instead of a 'PyObject *' */
+HPyAPI_FUNC(142)
 int HPyErr_Occurred(HPyContext *ctx);
+HPyAPI_FUNC(143)
 int HPyErr_ExceptionMatches(HPyContext *ctx, HPy exc);
+HPyAPI_FUNC(144)
 HPy HPyErr_NoMemory(HPyContext *ctx);
+HPyAPI_FUNC(145)
 void HPyErr_Clear(HPyContext *ctx);
+HPyAPI_FUNC(146)
 HPy HPyErr_NewException(HPyContext *ctx, const char *name, HPy base, HPy dict);
+HPyAPI_FUNC(147)
 HPy HPyErr_NewExceptionWithDoc(HPyContext *ctx, const char *name, const char *doc, HPy base, HPy dict);
+HPyAPI_FUNC(148)
 int HPyErr_WarnEx(HPyContext *ctx, HPy category, const char *message, HPy_ssize_t stack_level);
+HPyAPI_FUNC(149)
 void HPyErr_WriteUnraisable(HPyContext *ctx, HPy obj);
 
 /* object.h */
+HPyAPI_FUNC(150)
 int HPy_IsTrue(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(151)
 HPy HPyType_FromSpec(HPyContext *ctx, HPyType_Spec *spec,
                      HPyType_SpecParam *params);
+HPyAPI_FUNC(152)
 HPy HPyType_GenericNew(HPyContext *ctx, HPy type, HPy *args, HPy_ssize_t nargs, HPy kw);
 
+HPyAPI_FUNC(153)
 HPy HPy_GetAttr(HPyContext *ctx, HPy obj, HPy name);
+HPyAPI_FUNC(154)
 HPy HPy_GetAttr_s(HPyContext *ctx, HPy obj, const char *name);
 
+HPyAPI_FUNC(155)
 int HPy_HasAttr(HPyContext *ctx, HPy obj, HPy name);
+HPyAPI_FUNC(156)
 int HPy_HasAttr_s(HPyContext *ctx, HPy obj, const char *name);
 
+HPyAPI_FUNC(157)
 int HPy_SetAttr(HPyContext *ctx, HPy obj, HPy name, HPy value);
+HPyAPI_FUNC(158)
 int HPy_SetAttr_s(HPyContext *ctx, HPy obj, const char *name, HPy value);
 
+HPyAPI_FUNC(159)
 HPy HPy_GetItem(HPyContext *ctx, HPy obj, HPy key);
+HPyAPI_FUNC(160)
 HPy HPy_GetItem_i(HPyContext *ctx, HPy obj, HPy_ssize_t idx);
+HPyAPI_FUNC(161)
 HPy HPy_GetItem_s(HPyContext *ctx, HPy obj, const char *key);
 
+HPyAPI_FUNC(162)
 int HPy_Contains(HPyContext *ctx, HPy container, HPy key);
 
+HPyAPI_FUNC(163)
 int HPy_SetItem(HPyContext *ctx, HPy obj, HPy key, HPy value);
+HPyAPI_FUNC(164)
 int HPy_SetItem_i(HPyContext *ctx, HPy obj, HPy_ssize_t idx, HPy value);
+HPyAPI_FUNC(165)
 int HPy_SetItem_s(HPyContext *ctx, HPy obj, const char *key, HPy value);
 
+HPyAPI_FUNC(166)
 HPy HPy_Type(HPyContext *ctx, HPy obj);
 // WARNING: HPy_TypeCheck could be tweaked/removed in the future, see issue #160
+HPyAPI_FUNC(167)
 int HPy_TypeCheck(HPyContext *ctx, HPy obj, HPy type);
 
+HPyAPI_FUNC(168)
 int HPy_Is(HPyContext *ctx, HPy obj, HPy other);
 
+HPyAPI_FUNC(169)
 void* HPy_AsStruct(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(170)
 void* HPy_AsStructLegacy(HPyContext *ctx, HPy h);
 
+HPyAPI_FUNC(171)
 HPy _HPy_New(HPyContext *ctx, HPy h_type, void **data);
 
+HPyAPI_FUNC(172)
 HPy HPy_Repr(HPyContext *ctx, HPy obj);
+HPyAPI_FUNC(173)
 HPy HPy_Str(HPyContext *ctx, HPy obj);
+HPyAPI_FUNC(174)
 HPy HPy_ASCII(HPyContext *ctx, HPy obj);
+HPyAPI_FUNC(175)
 HPy HPy_Bytes(HPyContext *ctx, HPy obj);
 
+HPyAPI_FUNC(176)
 HPy HPy_RichCompare(HPyContext *ctx, HPy v, HPy w, int op);
+HPyAPI_FUNC(177)
 int HPy_RichCompareBool(HPyContext *ctx, HPy v, HPy w, int op);
 
+HPyAPI_FUNC(178)
 HPy_hash_t HPy_Hash(HPyContext *ctx, HPy obj);
 
 /* bytesobject.h */
+HPyAPI_FUNC(179)
 int HPyBytes_Check(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(180)
 HPy_ssize_t HPyBytes_Size(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(181)
 HPy_ssize_t HPyBytes_GET_SIZE(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(182)
 char* HPyBytes_AsString(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(183)
 char* HPyBytes_AS_STRING(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(184)
 HPy HPyBytes_FromString(HPyContext *ctx, const char *v);
+HPyAPI_FUNC(185)
 HPy HPyBytes_FromStringAndSize(HPyContext *ctx, const char *v, HPy_ssize_t len);
 
 /* unicodeobject.h */
+HPyAPI_FUNC(186)
 HPy HPyUnicode_FromString(HPyContext *ctx, const char *utf8);
+HPyAPI_FUNC(187)
 int HPyUnicode_Check(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(188)
 HPy HPyUnicode_AsASCIIString(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(189)
 HPy HPyUnicode_AsLatin1String(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(190)
 HPy HPyUnicode_AsUTF8String(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(191)
 const char* HPyUnicode_AsUTF8AndSize(HPyContext *ctx, HPy h, HPy_ssize_t *size);
+HPyAPI_FUNC(192)
 HPy HPyUnicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_ssize_t size);
+HPyAPI_FUNC(193)
 HPy HPyUnicode_DecodeFSDefault(HPyContext *ctx, const char* v);
+HPyAPI_FUNC(194)
 HPy HPyUnicode_DecodeFSDefaultAndSize(HPyContext *ctx, const char* v, HPy_ssize_t size);
+HPyAPI_FUNC(195)
 HPy HPyUnicode_EncodeFSDefault(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(196)
 HPy_UCS4 HPyUnicode_ReadChar(HPyContext *ctx, HPy h, HPy_ssize_t index);
+HPyAPI_FUNC(197)
 HPy HPyUnicode_DecodeASCII(HPyContext *ctx, const char *s, HPy_ssize_t size, const char *errors);
+HPyAPI_FUNC(198)
 HPy HPyUnicode_DecodeLatin1(HPyContext *ctx, const char *s, HPy_ssize_t size, const char *errors);
 
 /* listobject.h */
+HPyAPI_FUNC(199)
 int HPyList_Check(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(200)
 HPy HPyList_New(HPyContext *ctx, HPy_ssize_t len);
+HPyAPI_FUNC(201)
 int HPyList_Append(HPyContext *ctx, HPy h_list, HPy h_item);
 
 /* dictobject.h */
+HPyAPI_FUNC(202)
 int HPyDict_Check(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(203)
 HPy HPyDict_New(HPyContext *ctx);
 
 /* tupleobject.h */
+HPyAPI_FUNC(204)
 int HPyTuple_Check(HPyContext *ctx, HPy h);
+HPyAPI_FUNC(205)
 HPy HPyTuple_FromArray(HPyContext *ctx, HPy items[], HPy_ssize_t n);
 // note: HPyTuple_Pack is implemented as a macro in common/macros.h
 
 /* import.h */
+HPyAPI_FUNC(206)
 HPy HPyImport_ImportModule(HPyContext *ctx, const char *name);
 
 /* integration with the old CPython API */
+HPyAPI_FUNC(207)
 HPy HPy_FromPyObject(HPyContext *ctx, cpy_PyObject *obj);
+HPyAPI_FUNC(208)
 cpy_PyObject *HPy_AsPyObject(HPyContext *ctx, HPy h);
 
 /* internal helpers which need to be exposed to modules for practical reasons :( */
+HPyAPI_FUNC(209)
 void _HPy_CallRealFunctionFromTrampoline(HPyContext *ctx,
                                          HPyFunc_Signature sig,
                                          HPyCFunction func,
@@ -278,23 +411,35 @@ void _HPy_CallRealFunctionFromTrampoline(HPyContext *ctx,
 
 /* Builders */
 
+HPyAPI_FUNC(210)
 HPyListBuilder HPyListBuilder_New(HPyContext *ctx, HPy_ssize_t initial_size);
+HPyAPI_FUNC(211)
 void HPyListBuilder_Set(HPyContext *ctx, HPyListBuilder builder,
                         HPy_ssize_t index, HPy h_item);
+HPyAPI_FUNC(212)
 HPy HPyListBuilder_Build(HPyContext *ctx, HPyListBuilder builder);
+HPyAPI_FUNC(213)
 void HPyListBuilder_Cancel(HPyContext *ctx, HPyListBuilder builder);
 
+HPyAPI_FUNC(214)
 HPyTupleBuilder HPyTupleBuilder_New(HPyContext *ctx, HPy_ssize_t initial_size);
+HPyAPI_FUNC(215)
 void HPyTupleBuilder_Set(HPyContext *ctx, HPyTupleBuilder builder,
                          HPy_ssize_t index, HPy h_item);
+HPyAPI_FUNC(216)
 HPy HPyTupleBuilder_Build(HPyContext *ctx, HPyTupleBuilder builder);
+HPyAPI_FUNC(217)
 void HPyTupleBuilder_Cancel(HPyContext *ctx, HPyTupleBuilder builder);
 
 /* Helper for correctly closing handles */
 
+HPyAPI_FUNC(218)
 HPyTracker HPyTracker_New(HPyContext *ctx, HPy_ssize_t size);
+HPyAPI_FUNC(219)
 int HPyTracker_Add(HPyContext *ctx, HPyTracker ht, HPy h);
+HPyAPI_FUNC(220)
 void HPyTracker_ForgetAll(HPyContext *ctx, HPyTracker ht);
+HPyAPI_FUNC(221)
 void HPyTracker_Close(HPyContext *ctx, HPyTracker ht);
 
 /**
@@ -329,7 +474,9 @@ void HPyTracker_Close(HPyContext *ctx, HPyTracker ht);
  * needs to add write and/or read barriers on the objects. They are ignored by
  * CPython but e.g. PyPy needs a write barrier.
 */
+HPyAPI_FUNC(222)
 void HPyField_Store(HPyContext *ctx, HPy target_object, HPyField *target_field, HPy h);
+HPyAPI_FUNC(223)
 HPy HPyField_Load(HPyContext *ctx, HPy source_object, HPyField source_field);
 
 /**
@@ -354,7 +501,9 @@ HPy HPyField_Load(HPyContext *ctx, HPy source_object, HPyField source_field);
  * HPy_BEGIN_LEAVE_PYTHON/HPy_END_LEAVE_PYTHON becomes equivalent to
  * Py_BEGIN_ALLOW_THREADS/Py_END_ALLOW_THREADS.
 */
+HPyAPI_FUNC(224)
 void HPy_ReenterPythonExecution(HPyContext *ctx, HPyThreadState state);
+HPyAPI_FUNC(225)
 HPyThreadState HPy_LeavePythonExecution(HPyContext *ctx);
 
 /**
@@ -411,10 +560,13 @@ HPyThreadState HPy_LeavePythonExecution(HPyContext *ctx);
  * also be activated only by some runtime option, letting the HPy implementation
  * use more optimized HPyGlobal implementation otherwise.
 */
+HPyAPI_FUNC(226)
 void HPyGlobal_Store(HPyContext *ctx, HPyGlobal *global, HPy h);
+HPyAPI_FUNC(227)
 HPy HPyGlobal_Load(HPyContext *ctx, HPyGlobal global);
 
 /* Debugging helpers */
+HPyAPI_FUNC(228)
 void _HPy_Dump(HPyContext *ctx, HPy h);
 
 

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -1,30 +1,6 @@
-typedef int HPy;
-typedef int HPyContext;
-typedef int HPyModuleDef;
-typedef int HPyType_Spec;
-typedef int HPyType_SpecParam;
-typedef int HPyCFunction;
-typedef int HPy_ssize_t;
-typedef int HPy_hash_t;
-typedef int wchar_t;
-typedef int size_t;
-typedef int HPyFunc_Signature;
-typedef int cpy_PyObject;
-typedef int HPyField;
-typedef int HPyGlobal;
-typedef int HPyListBuilder;
-typedef int HPyTupleBuilder;
-typedef int HPyTracker;
-typedef int HPy_RichCmpOp;
-typedef int HPy_buffer;
-typedef int HPyFunc_visitproc;
-typedef int HPy_UCS4;
-typedef int HPyThreadState;
-// ^ these are not real typedefs: they are there only to make pycparser happy
-// and this comment is not on the top of the file, so that it is not picked up
-// by autodoc
-
 /* HPy public API */
+
+#if AUTOGEN
 
 /* Constants */
 HPy h_None;
@@ -112,6 +88,8 @@ HPy h_FloatType;        /* built-in 'float' */
 HPy h_UnicodeType;      /* built-in 'str' */
 HPy h_TupleType;        /* built-in 'tuple' */
 HPy h_ListType;         /* built-in 'list' */
+
+#endif
 
 HPy HPyModule_Create(HPyContext *ctx, HPyModuleDef *def);
 HPy HPy_Dup(HPyContext *ctx, HPy h);

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -2,11 +2,10 @@
 
 /*
  * IMPORTANT: In order to ensure backwards compatibility of HPyContext, it is
- * necessary to define the order of the context members. To do so, use macros
- * 'HPyAPI_HANDLE(idx)' for context handles and 'HPyAPI_FUNC(idx)' for
- * context functions. When adding members, it doesn't matter where they are
- * located in this file. It's just important that the maximum context index is
- * incremented by exactly one.
+ * necessary to define the order of the context members. To do so, use macro
+ * 'HPy_ID(idx)' for context handles and functions. When adding members, it
+ * doesn't matter where they are located in this file. It's just important that
+ * the maximum context index is incremented by exactly one.
  */
 
 #ifdef AUTOGEN

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -1,5 +1,14 @@
 /* HPy public API */
 
+/*
+ * IMPORTANT: In order to ensure backwards compatibility of HPyContext, it is
+ * necessary to define the order of the context members. To do so, use macros
+ * 'HPyAPI_HANDLE(idx)' for context handles and 'HPyAPI_FUNC(idx)' for
+ * context functions. When adding members, it doesn't matter where they are
+ * located in this file. It's just important that the maximum context index is
+ * incremented by exactly one.
+ */
+
 #if AUTOGEN
 
 /* Constants */

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -12,407 +12,407 @@
 #ifdef AUTOGEN
 
 /* Constants */
-HPyAPI_HANDLE(0) HPy h_None;
-HPyAPI_HANDLE(1) HPy h_True;
-HPyAPI_HANDLE(2) HPy h_False;
-HPyAPI_HANDLE(3) HPy h_NotImplemented;
-HPyAPI_HANDLE(4) HPy h_Ellipsis;
+HPy_ID(0) HPy h_None;
+HPy_ID(1) HPy h_True;
+HPy_ID(2) HPy h_False;
+HPy_ID(3) HPy h_NotImplemented;
+HPy_ID(4) HPy h_Ellipsis;
 
 /* Exceptions */
-HPyAPI_HANDLE(5) HPy h_BaseException;
-HPyAPI_HANDLE(6) HPy h_Exception;
-HPyAPI_HANDLE(7) HPy h_StopAsyncIteration;
-HPyAPI_HANDLE(8) HPy h_StopIteration;
-HPyAPI_HANDLE(9) HPy h_GeneratorExit;
-HPyAPI_HANDLE(10) HPy h_ArithmeticError;
-HPyAPI_HANDLE(11) HPy h_LookupError;
-HPyAPI_HANDLE(12) HPy h_AssertionError;
-HPyAPI_HANDLE(13) HPy h_AttributeError;
-HPyAPI_HANDLE(14) HPy h_BufferError;
-HPyAPI_HANDLE(15) HPy h_EOFError;
-HPyAPI_HANDLE(16) HPy h_FloatingPointError;
-HPyAPI_HANDLE(17) HPy h_OSError;
-HPyAPI_HANDLE(18) HPy h_ImportError;
-HPyAPI_HANDLE(19) HPy h_ModuleNotFoundError;
-HPyAPI_HANDLE(20) HPy h_IndexError;
-HPyAPI_HANDLE(21) HPy h_KeyError;
-HPyAPI_HANDLE(22) HPy h_KeyboardInterrupt;
-HPyAPI_HANDLE(23) HPy h_MemoryError;
-HPyAPI_HANDLE(24) HPy h_NameError;
-HPyAPI_HANDLE(25) HPy h_OverflowError;
-HPyAPI_HANDLE(26) HPy h_RuntimeError;
-HPyAPI_HANDLE(27) HPy h_RecursionError;
-HPyAPI_HANDLE(28) HPy h_NotImplementedError;
-HPyAPI_HANDLE(29) HPy h_SyntaxError;
-HPyAPI_HANDLE(30) HPy h_IndentationError;
-HPyAPI_HANDLE(31) HPy h_TabError;
-HPyAPI_HANDLE(32) HPy h_ReferenceError;
-HPyAPI_HANDLE(33) HPy h_SystemError;
-HPyAPI_HANDLE(34) HPy h_SystemExit;
-HPyAPI_HANDLE(35) HPy h_TypeError;
-HPyAPI_HANDLE(36) HPy h_UnboundLocalError;
-HPyAPI_HANDLE(37) HPy h_UnicodeError;
-HPyAPI_HANDLE(38) HPy h_UnicodeEncodeError;
-HPyAPI_HANDLE(39) HPy h_UnicodeDecodeError;
-HPyAPI_HANDLE(40) HPy h_UnicodeTranslateError;
-HPyAPI_HANDLE(41) HPy h_ValueError;
-HPyAPI_HANDLE(42) HPy h_ZeroDivisionError;
-HPyAPI_HANDLE(43) HPy h_BlockingIOError;
-HPyAPI_HANDLE(44) HPy h_BrokenPipeError;
-HPyAPI_HANDLE(45) HPy h_ChildProcessError;
-HPyAPI_HANDLE(46) HPy h_ConnectionError;
-HPyAPI_HANDLE(47) HPy h_ConnectionAbortedError;
-HPyAPI_HANDLE(48) HPy h_ConnectionRefusedError;
-HPyAPI_HANDLE(49) HPy h_ConnectionResetError;
-HPyAPI_HANDLE(50) HPy h_FileExistsError;
-HPyAPI_HANDLE(51) HPy h_FileNotFoundError;
-HPyAPI_HANDLE(52) HPy h_InterruptedError;
-HPyAPI_HANDLE(53) HPy h_IsADirectoryError;
-HPyAPI_HANDLE(54) HPy h_NotADirectoryError;
-HPyAPI_HANDLE(55) HPy h_PermissionError;
-HPyAPI_HANDLE(56) HPy h_ProcessLookupError;
-HPyAPI_HANDLE(57) HPy h_TimeoutError;
+HPy_ID(5) HPy h_BaseException;
+HPy_ID(6) HPy h_Exception;
+HPy_ID(7) HPy h_StopAsyncIteration;
+HPy_ID(8) HPy h_StopIteration;
+HPy_ID(9) HPy h_GeneratorExit;
+HPy_ID(10) HPy h_ArithmeticError;
+HPy_ID(11) HPy h_LookupError;
+HPy_ID(12) HPy h_AssertionError;
+HPy_ID(13) HPy h_AttributeError;
+HPy_ID(14) HPy h_BufferError;
+HPy_ID(15) HPy h_EOFError;
+HPy_ID(16) HPy h_FloatingPointError;
+HPy_ID(17) HPy h_OSError;
+HPy_ID(18) HPy h_ImportError;
+HPy_ID(19) HPy h_ModuleNotFoundError;
+HPy_ID(20) HPy h_IndexError;
+HPy_ID(21) HPy h_KeyError;
+HPy_ID(22) HPy h_KeyboardInterrupt;
+HPy_ID(23) HPy h_MemoryError;
+HPy_ID(24) HPy h_NameError;
+HPy_ID(25) HPy h_OverflowError;
+HPy_ID(26) HPy h_RuntimeError;
+HPy_ID(27) HPy h_RecursionError;
+HPy_ID(28) HPy h_NotImplementedError;
+HPy_ID(29) HPy h_SyntaxError;
+HPy_ID(30) HPy h_IndentationError;
+HPy_ID(31) HPy h_TabError;
+HPy_ID(32) HPy h_ReferenceError;
+HPy_ID(33) HPy h_SystemError;
+HPy_ID(34) HPy h_SystemExit;
+HPy_ID(35) HPy h_TypeError;
+HPy_ID(36) HPy h_UnboundLocalError;
+HPy_ID(37) HPy h_UnicodeError;
+HPy_ID(38) HPy h_UnicodeEncodeError;
+HPy_ID(39) HPy h_UnicodeDecodeError;
+HPy_ID(40) HPy h_UnicodeTranslateError;
+HPy_ID(41) HPy h_ValueError;
+HPy_ID(42) HPy h_ZeroDivisionError;
+HPy_ID(43) HPy h_BlockingIOError;
+HPy_ID(44) HPy h_BrokenPipeError;
+HPy_ID(45) HPy h_ChildProcessError;
+HPy_ID(46) HPy h_ConnectionError;
+HPy_ID(47) HPy h_ConnectionAbortedError;
+HPy_ID(48) HPy h_ConnectionRefusedError;
+HPy_ID(49) HPy h_ConnectionResetError;
+HPy_ID(50) HPy h_FileExistsError;
+HPy_ID(51) HPy h_FileNotFoundError;
+HPy_ID(52) HPy h_InterruptedError;
+HPy_ID(53) HPy h_IsADirectoryError;
+HPy_ID(54) HPy h_NotADirectoryError;
+HPy_ID(55) HPy h_PermissionError;
+HPy_ID(56) HPy h_ProcessLookupError;
+HPy_ID(57) HPy h_TimeoutError;
 // EnvironmentError, IOError and WindowsError are intentionally omitted (they
 // are all aliases of OSError since Python 3.3).
 
 /* Warnings */
-HPyAPI_HANDLE(58) HPy h_Warning;
-HPyAPI_HANDLE(59) HPy h_UserWarning;
-HPyAPI_HANDLE(60) HPy h_DeprecationWarning;
-HPyAPI_HANDLE(61) HPy h_PendingDeprecationWarning;
-HPyAPI_HANDLE(62) HPy h_SyntaxWarning;
-HPyAPI_HANDLE(63) HPy h_RuntimeWarning;
-HPyAPI_HANDLE(64) HPy h_FutureWarning;
-HPyAPI_HANDLE(65) HPy h_ImportWarning;
-HPyAPI_HANDLE(66) HPy h_UnicodeWarning;
-HPyAPI_HANDLE(67) HPy h_BytesWarning;
-HPyAPI_HANDLE(68) HPy h_ResourceWarning;
+HPy_ID(58) HPy h_Warning;
+HPy_ID(59) HPy h_UserWarning;
+HPy_ID(60) HPy h_DeprecationWarning;
+HPy_ID(61) HPy h_PendingDeprecationWarning;
+HPy_ID(62) HPy h_SyntaxWarning;
+HPy_ID(63) HPy h_RuntimeWarning;
+HPy_ID(64) HPy h_FutureWarning;
+HPy_ID(65) HPy h_ImportWarning;
+HPy_ID(66) HPy h_UnicodeWarning;
+HPy_ID(67) HPy h_BytesWarning;
+HPy_ID(68) HPy h_ResourceWarning;
 
 /* Types */
-HPyAPI_HANDLE(69) HPy h_BaseObjectType;   /* built-in 'object' */
-HPyAPI_HANDLE(70) HPy h_TypeType;         /* built-in 'type' */
-HPyAPI_HANDLE(71) HPy h_BoolType;         /* built-in 'bool' */
-HPyAPI_HANDLE(72) HPy h_LongType;         /* built-in 'int' */
-HPyAPI_HANDLE(73) HPy h_FloatType;        /* built-in 'float' */
-HPyAPI_HANDLE(74) HPy h_UnicodeType;      /* built-in 'str' */
-HPyAPI_HANDLE(75) HPy h_TupleType;        /* built-in 'tuple' */
-HPyAPI_HANDLE(76) HPy h_ListType;         /* built-in 'list' */
+HPy_ID(69) HPy h_BaseObjectType;   /* built-in 'object' */
+HPy_ID(70) HPy h_TypeType;         /* built-in 'type' */
+HPy_ID(71) HPy h_BoolType;         /* built-in 'bool' */
+HPy_ID(72) HPy h_LongType;         /* built-in 'int' */
+HPy_ID(73) HPy h_FloatType;        /* built-in 'float' */
+HPy_ID(74) HPy h_UnicodeType;      /* built-in 'str' */
+HPy_ID(75) HPy h_TupleType;        /* built-in 'tuple' */
+HPy_ID(76) HPy h_ListType;         /* built-in 'list' */
 
 #endif
 
-HPyAPI_FUNC(77)
+HPy_ID(77)
 HPy HPyModule_Create(HPyContext *ctx, HPyModuleDef *def);
-HPyAPI_FUNC(78)
+HPy_ID(78)
 HPy HPy_Dup(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(79)
+HPy_ID(79)
 void HPy_Close(HPyContext *ctx, HPy h);
 
-HPyAPI_FUNC(80)
+HPy_ID(80)
 HPy HPyLong_FromLong(HPyContext *ctx, long value);
-HPyAPI_FUNC(81)
+HPy_ID(81)
 HPy HPyLong_FromUnsignedLong(HPyContext *ctx, unsigned long value);
-HPyAPI_FUNC(82)
+HPy_ID(82)
 HPy HPyLong_FromLongLong(HPyContext *ctx, long long v);
-HPyAPI_FUNC(83)
+HPy_ID(83)
 HPy HPyLong_FromUnsignedLongLong(HPyContext *ctx, unsigned long long v);
-HPyAPI_FUNC(84)
+HPy_ID(84)
 HPy HPyLong_FromSize_t(HPyContext *ctx, size_t value);
-HPyAPI_FUNC(85)
+HPy_ID(85)
 HPy HPyLong_FromSsize_t(HPyContext *ctx, HPy_ssize_t value);
 
-HPyAPI_FUNC(86)
+HPy_ID(86)
 long HPyLong_AsLong(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(87)
+HPy_ID(87)
 unsigned long HPyLong_AsUnsignedLong(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(88)
+HPy_ID(88)
 unsigned long HPyLong_AsUnsignedLongMask(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(89)
+HPy_ID(89)
 long long HPyLong_AsLongLong(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(90)
+HPy_ID(90)
 unsigned long long HPyLong_AsUnsignedLongLong(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(91)
+HPy_ID(91)
 unsigned long long HPyLong_AsUnsignedLongLongMask(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(92)
+HPy_ID(92)
 size_t HPyLong_AsSize_t(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(93)
+HPy_ID(93)
 HPy_ssize_t HPyLong_AsSsize_t(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(94)
+HPy_ID(94)
 void* HPyLong_AsVoidPtr(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(95)
+HPy_ID(95)
 double HPyLong_AsDouble(HPyContext *ctx, HPy h);
 
-HPyAPI_FUNC(96)
+HPy_ID(96)
 HPy HPyFloat_FromDouble(HPyContext *ctx, double v);
-HPyAPI_FUNC(97)
+HPy_ID(97)
 double HPyFloat_AsDouble(HPyContext *ctx, HPy h);
 
-HPyAPI_FUNC(98)
+HPy_ID(98)
 HPy HPyBool_FromLong(HPyContext *ctx, long v);
 
 
 /* abstract.h */
-HPyAPI_FUNC(99)
+HPy_ID(99)
 HPy_ssize_t HPy_Length(HPyContext *ctx, HPy h);
 
-HPyAPI_FUNC(100)
+HPy_ID(100)
 int HPyNumber_Check(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(101)
+HPy_ID(101)
 HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(102)
+HPy_ID(102)
 HPy HPy_Subtract(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(103)
+HPy_ID(103)
 HPy HPy_Multiply(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(104)
+HPy_ID(104)
 HPy HPy_MatrixMultiply(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(105)
+HPy_ID(105)
 HPy HPy_FloorDivide(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(106)
+HPy_ID(106)
 HPy HPy_TrueDivide(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(107)
+HPy_ID(107)
 HPy HPy_Remainder(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(108)
+HPy_ID(108)
 HPy HPy_Divmod(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(109)
+HPy_ID(109)
 HPy HPy_Power(HPyContext *ctx, HPy h1, HPy h2, HPy h3);
-HPyAPI_FUNC(110)
+HPy_ID(110)
 HPy HPy_Negative(HPyContext *ctx, HPy h1);
-HPyAPI_FUNC(111)
+HPy_ID(111)
 HPy HPy_Positive(HPyContext *ctx, HPy h1);
-HPyAPI_FUNC(112)
+HPy_ID(112)
 HPy HPy_Absolute(HPyContext *ctx, HPy h1);
-HPyAPI_FUNC(113)
+HPy_ID(113)
 HPy HPy_Invert(HPyContext *ctx, HPy h1);
-HPyAPI_FUNC(114)
+HPy_ID(114)
 HPy HPy_Lshift(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(115)
+HPy_ID(115)
 HPy HPy_Rshift(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(116)
+HPy_ID(116)
 HPy HPy_And(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(117)
+HPy_ID(117)
 HPy HPy_Xor(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(118)
+HPy_ID(118)
 HPy HPy_Or(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(119)
+HPy_ID(119)
 HPy HPy_Index(HPyContext *ctx, HPy h1);
-HPyAPI_FUNC(120)
+HPy_ID(120)
 HPy HPy_Long(HPyContext *ctx, HPy h1);
-HPyAPI_FUNC(121)
+HPy_ID(121)
 HPy HPy_Float(HPyContext *ctx, HPy h1);
 
-HPyAPI_FUNC(122)
+HPy_ID(122)
 HPy HPy_InPlaceAdd(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(123)
+HPy_ID(123)
 HPy HPy_InPlaceSubtract(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(124)
+HPy_ID(124)
 HPy HPy_InPlaceMultiply(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(125)
+HPy_ID(125)
 HPy HPy_InPlaceMatrixMultiply(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(126)
+HPy_ID(126)
 HPy HPy_InPlaceFloorDivide(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(127)
+HPy_ID(127)
 HPy HPy_InPlaceTrueDivide(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(128)
+HPy_ID(128)
 HPy HPy_InPlaceRemainder(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(129)
+HPy_ID(129)
 HPy HPy_InPlacePower(HPyContext *ctx, HPy h1, HPy h2, HPy h3);
-HPyAPI_FUNC(130)
+HPy_ID(130)
 HPy HPy_InPlaceLshift(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(131)
+HPy_ID(131)
 HPy HPy_InPlaceRshift(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(132)
+HPy_ID(132)
 HPy HPy_InPlaceAnd(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(133)
+HPy_ID(133)
 HPy HPy_InPlaceXor(HPyContext *ctx, HPy h1, HPy h2);
-HPyAPI_FUNC(134)
+HPy_ID(134)
 HPy HPy_InPlaceOr(HPyContext *ctx, HPy h1, HPy h2);
 
-HPyAPI_FUNC(135)
+HPy_ID(135)
 int HPyCallable_Check(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(136)
+HPy_ID(136)
 HPy HPy_CallTupleDict(HPyContext *ctx, HPy callable, HPy args, HPy kw);
 
 /* pyerrors.h */
-HPyAPI_FUNC(137)
+HPy_ID(137)
 void HPy_FatalError(HPyContext *ctx, const char *message);
-HPyAPI_FUNC(138)
+HPy_ID(138)
 HPy HPyErr_SetString(HPyContext *ctx, HPy h_type, const char *message);
-HPyAPI_FUNC(139)
+HPy_ID(139)
 HPy HPyErr_SetObject(HPyContext *ctx, HPy h_type, HPy h_value);
 /* note: the filename will be FS decoded */
-HPyAPI_FUNC(140)
+HPy_ID(140)
 HPy HPyErr_SetFromErrnoWithFilename(HPyContext *ctx, HPy h_type, const char *filename_fsencoded);
-HPyAPI_FUNC(141)
+HPy_ID(141)
 HPy HPyErr_SetFromErrnoWithFilenameObjects(HPyContext *ctx, HPy h_type, HPy filename1, HPy filename2);
 /* note: HPyErr_Occurred() returns a flag 0-or-1, instead of a 'PyObject *' */
-HPyAPI_FUNC(142)
+HPy_ID(142)
 int HPyErr_Occurred(HPyContext *ctx);
-HPyAPI_FUNC(143)
+HPy_ID(143)
 int HPyErr_ExceptionMatches(HPyContext *ctx, HPy exc);
-HPyAPI_FUNC(144)
+HPy_ID(144)
 HPy HPyErr_NoMemory(HPyContext *ctx);
-HPyAPI_FUNC(145)
+HPy_ID(145)
 void HPyErr_Clear(HPyContext *ctx);
-HPyAPI_FUNC(146)
+HPy_ID(146)
 HPy HPyErr_NewException(HPyContext *ctx, const char *name, HPy base, HPy dict);
-HPyAPI_FUNC(147)
+HPy_ID(147)
 HPy HPyErr_NewExceptionWithDoc(HPyContext *ctx, const char *name, const char *doc, HPy base, HPy dict);
-HPyAPI_FUNC(148)
+HPy_ID(148)
 int HPyErr_WarnEx(HPyContext *ctx, HPy category, const char *message, HPy_ssize_t stack_level);
-HPyAPI_FUNC(149)
+HPy_ID(149)
 void HPyErr_WriteUnraisable(HPyContext *ctx, HPy obj);
 
 /* object.h */
-HPyAPI_FUNC(150)
+HPy_ID(150)
 int HPy_IsTrue(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(151)
+HPy_ID(151)
 HPy HPyType_FromSpec(HPyContext *ctx, HPyType_Spec *spec,
                      HPyType_SpecParam *params);
-HPyAPI_FUNC(152)
+HPy_ID(152)
 HPy HPyType_GenericNew(HPyContext *ctx, HPy type, HPy *args, HPy_ssize_t nargs, HPy kw);
 
-HPyAPI_FUNC(153)
+HPy_ID(153)
 HPy HPy_GetAttr(HPyContext *ctx, HPy obj, HPy name);
-HPyAPI_FUNC(154)
+HPy_ID(154)
 HPy HPy_GetAttr_s(HPyContext *ctx, HPy obj, const char *name);
 
-HPyAPI_FUNC(155)
+HPy_ID(155)
 int HPy_HasAttr(HPyContext *ctx, HPy obj, HPy name);
-HPyAPI_FUNC(156)
+HPy_ID(156)
 int HPy_HasAttr_s(HPyContext *ctx, HPy obj, const char *name);
 
-HPyAPI_FUNC(157)
+HPy_ID(157)
 int HPy_SetAttr(HPyContext *ctx, HPy obj, HPy name, HPy value);
-HPyAPI_FUNC(158)
+HPy_ID(158)
 int HPy_SetAttr_s(HPyContext *ctx, HPy obj, const char *name, HPy value);
 
-HPyAPI_FUNC(159)
+HPy_ID(159)
 HPy HPy_GetItem(HPyContext *ctx, HPy obj, HPy key);
-HPyAPI_FUNC(160)
+HPy_ID(160)
 HPy HPy_GetItem_i(HPyContext *ctx, HPy obj, HPy_ssize_t idx);
-HPyAPI_FUNC(161)
+HPy_ID(161)
 HPy HPy_GetItem_s(HPyContext *ctx, HPy obj, const char *key);
 
-HPyAPI_FUNC(162)
+HPy_ID(162)
 int HPy_Contains(HPyContext *ctx, HPy container, HPy key);
 
-HPyAPI_FUNC(163)
+HPy_ID(163)
 int HPy_SetItem(HPyContext *ctx, HPy obj, HPy key, HPy value);
-HPyAPI_FUNC(164)
+HPy_ID(164)
 int HPy_SetItem_i(HPyContext *ctx, HPy obj, HPy_ssize_t idx, HPy value);
-HPyAPI_FUNC(165)
+HPy_ID(165)
 int HPy_SetItem_s(HPyContext *ctx, HPy obj, const char *key, HPy value);
 
-HPyAPI_FUNC(166)
+HPy_ID(166)
 HPy HPy_Type(HPyContext *ctx, HPy obj);
 // WARNING: HPy_TypeCheck could be tweaked/removed in the future, see issue #160
-HPyAPI_FUNC(167)
+HPy_ID(167)
 int HPy_TypeCheck(HPyContext *ctx, HPy obj, HPy type);
 
-HPyAPI_FUNC(168)
+HPy_ID(168)
 int HPy_Is(HPyContext *ctx, HPy obj, HPy other);
 
-HPyAPI_FUNC(169)
+HPy_ID(169)
 void* HPy_AsStruct(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(170)
+HPy_ID(170)
 void* HPy_AsStructLegacy(HPyContext *ctx, HPy h);
 
-HPyAPI_FUNC(171)
+HPy_ID(171)
 HPy _HPy_New(HPyContext *ctx, HPy h_type, void **data);
 
-HPyAPI_FUNC(172)
+HPy_ID(172)
 HPy HPy_Repr(HPyContext *ctx, HPy obj);
-HPyAPI_FUNC(173)
+HPy_ID(173)
 HPy HPy_Str(HPyContext *ctx, HPy obj);
-HPyAPI_FUNC(174)
+HPy_ID(174)
 HPy HPy_ASCII(HPyContext *ctx, HPy obj);
-HPyAPI_FUNC(175)
+HPy_ID(175)
 HPy HPy_Bytes(HPyContext *ctx, HPy obj);
 
-HPyAPI_FUNC(176)
+HPy_ID(176)
 HPy HPy_RichCompare(HPyContext *ctx, HPy v, HPy w, int op);
-HPyAPI_FUNC(177)
+HPy_ID(177)
 int HPy_RichCompareBool(HPyContext *ctx, HPy v, HPy w, int op);
 
-HPyAPI_FUNC(178)
+HPy_ID(178)
 HPy_hash_t HPy_Hash(HPyContext *ctx, HPy obj);
 
 /* bytesobject.h */
-HPyAPI_FUNC(179)
+HPy_ID(179)
 int HPyBytes_Check(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(180)
+HPy_ID(180)
 HPy_ssize_t HPyBytes_Size(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(181)
+HPy_ID(181)
 HPy_ssize_t HPyBytes_GET_SIZE(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(182)
+HPy_ID(182)
 char* HPyBytes_AsString(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(183)
+HPy_ID(183)
 char* HPyBytes_AS_STRING(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(184)
+HPy_ID(184)
 HPy HPyBytes_FromString(HPyContext *ctx, const char *v);
-HPyAPI_FUNC(185)
+HPy_ID(185)
 HPy HPyBytes_FromStringAndSize(HPyContext *ctx, const char *v, HPy_ssize_t len);
 
 /* unicodeobject.h */
-HPyAPI_FUNC(186)
+HPy_ID(186)
 HPy HPyUnicode_FromString(HPyContext *ctx, const char *utf8);
-HPyAPI_FUNC(187)
+HPy_ID(187)
 int HPyUnicode_Check(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(188)
+HPy_ID(188)
 HPy HPyUnicode_AsASCIIString(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(189)
+HPy_ID(189)
 HPy HPyUnicode_AsLatin1String(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(190)
+HPy_ID(190)
 HPy HPyUnicode_AsUTF8String(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(191)
+HPy_ID(191)
 const char* HPyUnicode_AsUTF8AndSize(HPyContext *ctx, HPy h, HPy_ssize_t *size);
-HPyAPI_FUNC(192)
+HPy_ID(192)
 HPy HPyUnicode_FromWideChar(HPyContext *ctx, const wchar_t *w, HPy_ssize_t size);
-HPyAPI_FUNC(193)
+HPy_ID(193)
 HPy HPyUnicode_DecodeFSDefault(HPyContext *ctx, const char* v);
-HPyAPI_FUNC(194)
+HPy_ID(194)
 HPy HPyUnicode_DecodeFSDefaultAndSize(HPyContext *ctx, const char* v, HPy_ssize_t size);
-HPyAPI_FUNC(195)
+HPy_ID(195)
 HPy HPyUnicode_EncodeFSDefault(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(196)
+HPy_ID(196)
 HPy_UCS4 HPyUnicode_ReadChar(HPyContext *ctx, HPy h, HPy_ssize_t index);
-HPyAPI_FUNC(197)
+HPy_ID(197)
 HPy HPyUnicode_DecodeASCII(HPyContext *ctx, const char *s, HPy_ssize_t size, const char *errors);
-HPyAPI_FUNC(198)
+HPy_ID(198)
 HPy HPyUnicode_DecodeLatin1(HPyContext *ctx, const char *s, HPy_ssize_t size, const char *errors);
 
 /* listobject.h */
-HPyAPI_FUNC(199)
+HPy_ID(199)
 int HPyList_Check(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(200)
+HPy_ID(200)
 HPy HPyList_New(HPyContext *ctx, HPy_ssize_t len);
-HPyAPI_FUNC(201)
+HPy_ID(201)
 int HPyList_Append(HPyContext *ctx, HPy h_list, HPy h_item);
 
 /* dictobject.h */
-HPyAPI_FUNC(202)
+HPy_ID(202)
 int HPyDict_Check(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(203)
+HPy_ID(203)
 HPy HPyDict_New(HPyContext *ctx);
 
 /* tupleobject.h */
-HPyAPI_FUNC(204)
+HPy_ID(204)
 int HPyTuple_Check(HPyContext *ctx, HPy h);
-HPyAPI_FUNC(205)
+HPy_ID(205)
 HPy HPyTuple_FromArray(HPyContext *ctx, HPy items[], HPy_ssize_t n);
 // note: HPyTuple_Pack is implemented as a macro in common/macros.h
 
 /* import.h */
-HPyAPI_FUNC(206)
+HPy_ID(206)
 HPy HPyImport_ImportModule(HPyContext *ctx, const char *name);
 
 /* integration with the old CPython API */
-HPyAPI_FUNC(207)
+HPy_ID(207)
 HPy HPy_FromPyObject(HPyContext *ctx, cpy_PyObject *obj);
-HPyAPI_FUNC(208)
+HPy_ID(208)
 cpy_PyObject *HPy_AsPyObject(HPyContext *ctx, HPy h);
 
 /* internal helpers which need to be exposed to modules for practical reasons :( */
-HPyAPI_FUNC(209)
+HPy_ID(209)
 void _HPy_CallRealFunctionFromTrampoline(HPyContext *ctx,
                                          HPyFunc_Signature sig,
                                          HPyCFunction func,
@@ -420,35 +420,35 @@ void _HPy_CallRealFunctionFromTrampoline(HPyContext *ctx,
 
 /* Builders */
 
-HPyAPI_FUNC(210)
+HPy_ID(210)
 HPyListBuilder HPyListBuilder_New(HPyContext *ctx, HPy_ssize_t initial_size);
-HPyAPI_FUNC(211)
+HPy_ID(211)
 void HPyListBuilder_Set(HPyContext *ctx, HPyListBuilder builder,
                         HPy_ssize_t index, HPy h_item);
-HPyAPI_FUNC(212)
+HPy_ID(212)
 HPy HPyListBuilder_Build(HPyContext *ctx, HPyListBuilder builder);
-HPyAPI_FUNC(213)
+HPy_ID(213)
 void HPyListBuilder_Cancel(HPyContext *ctx, HPyListBuilder builder);
 
-HPyAPI_FUNC(214)
+HPy_ID(214)
 HPyTupleBuilder HPyTupleBuilder_New(HPyContext *ctx, HPy_ssize_t initial_size);
-HPyAPI_FUNC(215)
+HPy_ID(215)
 void HPyTupleBuilder_Set(HPyContext *ctx, HPyTupleBuilder builder,
                          HPy_ssize_t index, HPy h_item);
-HPyAPI_FUNC(216)
+HPy_ID(216)
 HPy HPyTupleBuilder_Build(HPyContext *ctx, HPyTupleBuilder builder);
-HPyAPI_FUNC(217)
+HPy_ID(217)
 void HPyTupleBuilder_Cancel(HPyContext *ctx, HPyTupleBuilder builder);
 
 /* Helper for correctly closing handles */
 
-HPyAPI_FUNC(218)
+HPy_ID(218)
 HPyTracker HPyTracker_New(HPyContext *ctx, HPy_ssize_t size);
-HPyAPI_FUNC(219)
+HPy_ID(219)
 int HPyTracker_Add(HPyContext *ctx, HPyTracker ht, HPy h);
-HPyAPI_FUNC(220)
+HPy_ID(220)
 void HPyTracker_ForgetAll(HPyContext *ctx, HPyTracker ht);
-HPyAPI_FUNC(221)
+HPy_ID(221)
 void HPyTracker_Close(HPyContext *ctx, HPyTracker ht);
 
 /**
@@ -483,9 +483,9 @@ void HPyTracker_Close(HPyContext *ctx, HPyTracker ht);
  * needs to add write and/or read barriers on the objects. They are ignored by
  * CPython but e.g. PyPy needs a write barrier.
 */
-HPyAPI_FUNC(222)
+HPy_ID(222)
 void HPyField_Store(HPyContext *ctx, HPy target_object, HPyField *target_field, HPy h);
-HPyAPI_FUNC(223)
+HPy_ID(223)
 HPy HPyField_Load(HPyContext *ctx, HPy source_object, HPyField source_field);
 
 /**
@@ -510,9 +510,9 @@ HPy HPyField_Load(HPyContext *ctx, HPy source_object, HPyField source_field);
  * HPy_BEGIN_LEAVE_PYTHON/HPy_END_LEAVE_PYTHON becomes equivalent to
  * Py_BEGIN_ALLOW_THREADS/Py_END_ALLOW_THREADS.
 */
-HPyAPI_FUNC(224)
+HPy_ID(224)
 void HPy_ReenterPythonExecution(HPyContext *ctx, HPyThreadState state);
-HPyAPI_FUNC(225)
+HPy_ID(225)
 HPyThreadState HPy_LeavePythonExecution(HPyContext *ctx);
 
 /**
@@ -569,13 +569,13 @@ HPyThreadState HPy_LeavePythonExecution(HPyContext *ctx);
  * also be activated only by some runtime option, letting the HPy implementation
  * use more optimized HPyGlobal implementation otherwise.
 */
-HPyAPI_FUNC(226)
+HPy_ID(226)
 void HPyGlobal_Store(HPyContext *ctx, HPyGlobal *global, HPy h);
-HPyAPI_FUNC(227)
+HPy_ID(227)
 HPy HPyGlobal_Load(HPyContext *ctx, HPyGlobal global);
 
 /* Debugging helpers */
-HPyAPI_FUNC(228)
+HPy_ID(228)
 void _HPy_Dump(HPyContext *ctx, HPy h);
 
 

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -9,7 +9,7 @@
  * incremented by exactly one.
  */
 
-#if AUTOGEN
+#ifdef AUTOGEN
 
 /* Constants */
 HPyAPI_HANDLE(0) HPy h_None;

--- a/hpy/tools/autogen/testing/test_autogen.py
+++ b/hpy/tools/autogen/testing/test_autogen.py
@@ -47,9 +47,9 @@ class TestHPyAPI(BaseTestAutogen):
 
     def test_ctx_name(self):
         api = self.parse("""
-            HPy h_None;
-            HPy HPy_Dup(HPyContext *ctx, HPy h);
-            void* _HPy_AsStruct(HPyContext *ctx, HPy h);
+            HPy_ID(0) HPy h_None;
+            HPy_ID(1) HPy HPy_Dup(HPyContext *ctx, HPy h);
+            HPy_ID(2) void* _HPy_AsStruct(HPyContext *ctx, HPy h);
         """)
         assert api.get_var('h_None').ctx_name() == 'h_None'
         assert api.get_func('HPy_Dup').ctx_name() == 'ctx_Dup'
@@ -57,9 +57,9 @@ class TestHPyAPI(BaseTestAutogen):
 
     def test_cpython_name(self):
         api = self.parse("""
-            HPy HPy_Dup(HPyContext *ctx, HPy h);
-            long HPyLong_AsLong(HPyContext *ctx, HPy h);
-            HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
+            HPy_ID(0) HPy HPy_Dup(HPyContext *ctx, HPy h);
+            HPy_ID(1) long HPyLong_AsLong(HPyContext *ctx, HPy h);
+            HPy_ID(2) HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
         """)
         assert api.get_func('HPy_Dup').cpython_name is None
         assert api.get_func('HPyLong_AsLong').cpython_name == 'PyLong_AsLong'
@@ -121,8 +121,8 @@ class TestAutoGen(BaseTestAutogen):
 
     def test_autogen_ctx_h(self):
         api = self.parse("""
-            HPy h_None;
-            HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
+            HPy_ID(0) HPy h_None;
+            HPy_ID(1) HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
         """)
         got = autogen_ctx_h(api).generate()
         exp = """
@@ -138,8 +138,8 @@ class TestAutoGen(BaseTestAutogen):
 
     def test_autogen_ctx_def_h(self):
         api = self.parse("""
-            HPy h_None;
-            HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
+            HPy_ID(0) HPy h_None;
+            HPy_ID(1) HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
         """)
         got = autogen_ctx_def_h(api).generate()
         exp = """
@@ -155,9 +155,9 @@ class TestAutoGen(BaseTestAutogen):
 
     def test_autogen_trampolines_h(self):
         api = self.parse("""
-            HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
-            void HPy_Close(HPyContext *ctx, HPy h);
-            void* _HPy_AsStruct(HPyContext *ctx, HPy h);
+            HPy_ID(0) HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
+            HPy_ID(1) void HPy_Close(HPyContext *ctx, HPy h);
+            HPy_ID(2) void* _HPy_AsStruct(HPyContext *ctx, HPy h);
         """)
         got = autogen_trampolines_h(api).generate()
         exp = """
@@ -177,10 +177,10 @@ class TestAutoGen(BaseTestAutogen):
 
     def test_cpython_api_impl_h(self):
         api = self.parse("""
-            HPy HPy_Dup(HPyContext *ctx, HPy h);
-            HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
-            HPy HPyLong_FromLong(HPyContext *ctx, long value);
-            char* HPyBytes_AsString(HPyContext *ctx, HPy h);
+            HPy_ID(0) HPy HPy_Dup(HPyContext *ctx, HPy h);
+            HPy_ID(1) HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2);
+            HPy_ID(2) HPy HPyLong_FromLong(HPyContext *ctx, long value);
+            HPy_ID(3) char* HPyBytes_AsString(HPyContext *ctx, HPy h);
         """)
         got = cpython_autogen_api_impl_h(api).generate()
         exp = """

--- a/hpy/tools/autogen/testing/test_autogen.py
+++ b/hpy/tools/autogen/testing/test_autogen.py
@@ -122,15 +122,15 @@ class TestAutoGen(BaseTestAutogen):
         """)
         got = autogen_trampolines_h(api).generate()
         exp = """
-            static inline HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2) {
+            HPyAPI_FUNC HPy HPy_Add(HPyContext *ctx, HPy h1, HPy h2) {
                 return ctx->ctx_Add ( ctx, h1, h2 );
             }
 
-            static inline void HPy_Close(HPyContext *ctx, HPy h) {
+            HPyAPI_FUNC void HPy_Close(HPyContext *ctx, HPy h) {
                 ctx->ctx_Close ( ctx, h );
             }
 
-            static inline void *_HPy_AsStruct(HPyContext *ctx, HPy h) {
+            HPyAPI_FUNC void *_HPy_AsStruct(HPyContext *ctx, HPy h) {
                 return ctx->ctx_AsStruct ( ctx, h );
             }
         """


### PR DESCRIPTION
When we add handles or functions to the context, the order of how the context members are generated is determined by their position in `public_api.h`.
As soon as we want to be backwards compatible between HPy releases, we may only append members to the context. That is, however, annoying because we still want to group API functions and handles that belong somehow together in `public_api.h`.

Hence, this PR introduces two macros (i.e. `HPyAPI_FUNC` and `HPyAPI_HANDLE`) that allow to specify the index in the context.
Unfortunately, `pycparser` is currently not able to parse macros. We therefore need to run the preprocessor and the macros expand to a pragma (which pycparser is able to handle).

I've changed autogen such that i will sort the handles and functions using the specified index. Autogen also verifies the indices (there must not be gaps and there must be an index for each handle/function).

Since it was anyway necessary to restructure everything a bit, I took the opportunity to prepare `public_api.h` to be included as a real header into `hpy.h` (or something).
For this, I've moved dummy type declarations to a new header `autogen.h` and the context handles (which are syntactically defines as C globals) are protected by an `#if` directive such they won't really be added when included in `hpy.h`.