### PR TITLE
Support metaclasses in HPy.

### DIFF
--- a/hpy/devel/include/hpy/hpytype.h
+++ b/hpy/devel/include/hpy/hpytype.h
@@ -58,7 +58,7 @@ typedef struct {
 typedef enum {
     HPyType_SpecParam_Base = 1,
     HPyType_SpecParam_BasesTuple = 2,
-    //HPyType_SpecParam_Metaclass = 3,
+    HPyType_SpecParam_Metaclass = 3,
     //HPyType_SpecParam_Module = 4,
 } HPyType_SpecParam_Kind;
 

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -1105,6 +1105,8 @@ ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
     /* On Python 3.12 an newer, we can just use 'PyType_FromMetaclass'. */
     PyObject *result = PyType_FromMetaclass(meta, NULL, spec, bases);
 #else
+    /* On Python 3.11 an older, we need to use our own
+       '_PyType_FromMetaclass'. */
     PyObject *result = _PyType_FromMetaclass(spec, bases, metatype);
 #endif
 

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -985,11 +985,13 @@ _PyType_FromMetaclass(PyType_Spec *spec, PyObject *bases,
         if (PyType_Ready(tp) < 0)
             goto fail;
 
-        /* The following is the tail of 'PyType_FromSpecWithBases'. */
-
-        if (tp->tp_dictoffset) {
-            ht->ht_cached_keys = _PyDict_NewKeysForClass();
+        /* Restore 'ht_cached_keys' after call to 'PyType_Ready' */
+        if (temp_ht->ht_cached_keys) {
+            Py_INCREF(temp_ht->ht_cached_keys);
+            ht->ht_cached_keys = temp_ht->ht_cached_keys;
         }
+
+        /* The following is the tail of 'PyType_FromSpecWithBases'. */
 
         /* Set type.__module__ */
         s = strrchr(spec->name, '.');

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -874,6 +874,134 @@ _HPy_HIDDEN struct _typeobject *get_metatype(HPyType_SpecParam *params) {
     return &PyType_Type;
 }
 
+static PyObject *
+_PyType_FromMetaclass(PyType_Spec *spec, PyObject *bases, struct _typeobject *meta)
+{
+#if PY_VERSION_HEX >= 0x030C0000
+    /* On Python 3.11 an newer, we can just use 'PyType_FromMetaclass'. */
+    return PyType_FromMetaclass(meta, NULL, spec, bases);
+#else
+    /* On older Python versions, we need to workaround the missing support for
+       metaclasses. We create a temporary heap type using
+       'PyType_FromSpecWithBases' and if a metaclass was provided, we use it to
+       allocate the appropriate type object and memcpy most of the contents
+       from the heap type to the manually allocated one. Then we clear some key
+       slots and call 'PyType_Ready' on it to re-initialize everything. The
+       temporary heap type is then expired. */
+
+    PyObject *temp = PyType_FromSpecWithBases(spec, bases);
+    if (!temp)
+        return NULL;
+
+    if (meta)
+    {
+        PyHeapTypeObject *temp_ht = (PyHeapTypeObject *) temp;
+        PyTypeObject *temp_tp = &temp_ht->ht_type;
+
+        Py_INCREF(temp_ht->ht_name);
+        Py_INCREF(temp_ht->ht_qualname);
+        Py_XINCREF(temp_ht->ht_slots);
+        Py_INCREF(temp_tp->tp_base);
+
+        /* Count the members as 'PyType_FromSpecWithBases' does such that we
+           can properly allocate the size later when allocating the type. */
+        Py_ssize_t nmembers = 0;
+        PyType_Slot *slot;
+        PyMemberDef *memb;
+        for (slot = spec->slots; slot->slot; slot++) {
+            if (slot->slot == Py_tp_members) {
+                nmembers = 0;
+                for (memb = slot->pfunc; memb->name != NULL; memb++) {
+                    nmembers++;
+                }
+            }
+        }
+
+        PyObject *result = PyType_GenericAlloc(meta, nmembers);
+        if (!result)
+            goto fail;
+
+        PyHeapTypeObject *ht = (PyHeapTypeObject *) result;
+        PyTypeObject *tp = &ht->ht_type;
+
+        /* Set the type name and qualname */
+        const char *s = strrchr(spec->name, '.');
+        if (s == NULL)
+            s = (char*)spec->name;
+        else
+            s++;
+
+        memcpy(ht, temp_ht, sizeof(PyHeapTypeObject));
+
+        tp->ob_base.ob_base.ob_type = meta;
+        tp->ob_base.ob_base.ob_refcnt = 1;
+        tp->ob_base.ob_size = 0;
+        tp->tp_as_async = &ht->as_async;
+        tp->tp_as_number = &ht->as_number;
+        tp->tp_as_sequence = &ht->as_sequence;
+        tp->tp_as_mapping = &ht->as_mapping;
+        tp->tp_as_buffer = &ht->as_buffer;
+        tp->tp_flags = spec->flags | Py_TPFLAGS_HEAPTYPE;
+
+        tp->tp_dict = NULL;
+        tp->tp_bases = NULL;
+        tp->tp_mro = NULL;
+        tp->tp_cache = NULL;
+        tp->tp_subclasses = NULL;
+        tp->tp_weaklist = NULL;
+        ht->ht_cached_keys = NULL;
+        tp->tp_version_tag = 0;
+
+        /* Refresh 'tp_doc'. This is necessary because
+           'PyType_FromSpecWithBases' allocates its own buffer which will be
+           free'd. */
+        if (temp_tp->tp_doc)
+        {
+            size_t len = strlen(temp_tp->tp_doc)+1;
+            char *tp_doc = PyObject_MALLOC(len);
+            if (!tp_doc)
+                goto fail;
+            memcpy(tp_doc, temp_tp->tp_doc, len);
+            tp->tp_doc = tp_doc;
+        }
+
+        /* Sanity check: GC objects need to provide 'tp_traverse' and
+           'tp_clear'. */
+        assert(!PyType_IS_GC(tp) || tp->tp_traverse != NULL || tp->tp_clear != NULL);
+
+        PyType_Ready(tp);
+
+        /* The following is the tail of 'PyType_FromSpecWithBases'. */
+
+        if (tp->tp_dictoffset) {
+            ht->ht_cached_keys = _PyDict_NewKeysForClass();
+        }
+
+        /* Set type.__module__ */
+        s = strrchr(spec->name, '.');
+        if (s != NULL) {
+            int err;
+            PyObject *modname = PyUnicode_FromStringAndSize(
+                    spec->name, (Py_ssize_t)(s - spec->name));
+            if (!modname) {
+                goto fail;
+            }
+            err = PyDict_SetItemString(tp->tp_dict, "__module__", modname);
+            Py_DECREF(modname);
+            if (err != 0)
+                goto fail;
+        }
+        return result;
+
+fail:
+        Py_DECREF(temp);
+        Py_XDECREF(result);
+        return NULL;
+    }
+    return temp;
+#endif
+}
+
 HPy
 ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
                   HPyType_SpecParam *params)
@@ -943,7 +1071,7 @@ ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
     // PyType_FromSpecWithBases does not support passing a metaclass,
     // so we have to use a patched CPython with PyType_FromSpecWithBasesAndMeta
     // See also: https://bugs.python.org/issue15870
-    PyObject *result = PyType_FromSpecWithBasesAndMeta(spec, bases, metatype);
+    PyObject *result = _PyType_FromMetaclass(spec, bases, metatype);
 
     /* note that we do NOT free the memory which was allocated by
        create_method_defs, because that one is referenced internally by

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -706,6 +706,8 @@ static int check_unknown_params(HPyType_SpecParam *params, const char *name)
             case HPyType_SpecParam_BasesTuple:
                 found_basestuple++;
                 break;
+            case HPyType_SpecParam_Metaclass:
+                break;
 
             default:
                 PyErr_Format(PyExc_TypeError,
@@ -832,6 +834,9 @@ static PyObject *build_bases_from_params(HPyType_SpecParam *params)
                 tup = _h2py(p->object);
                 Py_INCREF(tup);
                 return tup;
+            case HPyType_SpecParam_Metaclass:
+                // intentionally ignored
+                break;
         }
     }
     if (found_base == 0)
@@ -853,7 +858,23 @@ static PyObject *build_bases_from_params(HPyType_SpecParam *params)
     return tup;
 }
 
-_HPy_HIDDEN HPy
+_HPy_HIDDEN struct _typeobject *get_metatype(HPyType_SpecParam *params) {
+    if (params != NULL) {
+        for (HPyType_SpecParam *p = params; p->kind != 0; p++) {
+            switch (p->kind) {
+                case HPyType_SpecParam_Metaclass:
+                    return (struct _typeobject*) _h2py(p->object);
+                    break;
+                default:
+                    // other values are intentionally ignored
+                    break;
+            }
+        }
+    }
+    return &PyType_Type;
+}
+
+HPy
 ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
                   HPyType_SpecParam *params)
 {
@@ -917,7 +938,13 @@ ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
         PyMem_Free(spec);
         return HPy_NULL;
     }
-    PyObject *result = PyType_FromSpecWithBases(spec, bases);
+    struct _typeobject *metatype = get_metatype(params);
+
+    // PyType_FromSpecWithBases does not support passing a metaclass,
+    // so we have to use a patched CPython with PyType_FromSpecWithBasesAndMeta
+    // See also: https://bugs.python.org/issue15870
+    PyObject *result = PyType_FromSpecWithBasesAndMeta(spec, bases, metatype);
+
     /* note that we do NOT free the memory which was allocated by
        create_method_defs, because that one is referenced internally by
        CPython (which probably assumes it's statically allocated) */

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -940,13 +940,6 @@ _PyType_FromMetaclass(PyType_Spec *spec, PyObject *bases,
         PyHeapTypeObject *ht = (PyHeapTypeObject *) result;
         PyTypeObject *tp = &ht->ht_type;
 
-        /* Set the type name and qualname */
-        const char *s = strrchr(spec->name, '.');
-        if (s == NULL)
-            s = (char*)spec->name;
-        else
-            s++;
-
         /* IMPORTANT: CPython debug builds may store additional information in
            the object header (i.e. before 'ob_refcnt') for tracing references
            or whatever. In this case, we MUST NOT copy the object header. So we
@@ -1004,7 +997,7 @@ _PyType_FromMetaclass(PyType_Spec *spec, PyObject *bases,
         /* The following is the tail of 'PyType_FromSpecWithBases'. */
 
         /* Set type.__module__ */
-        s = strrchr(spec->name, '.');
+        const char *s = strrchr(spec->name, '.');
         if (s != NULL) {
             int err;
             PyObject *modname = PyUnicode_FromStringAndSize(

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -871,6 +871,10 @@ _HPy_HIDDEN struct _typeobject *get_metatype(HPyType_SpecParam *params) {
             }
         }
     }
+    /* Returning NULL here does not indicate an error but that the metaclass
+       has not explicitly been specified. We could default here to &PyType_Type
+       but we actually want to use the bare 'PyType_FromSpecWithBases' if
+       nothing was specified. */
     return NULL;
 }
 
@@ -878,7 +882,7 @@ static PyObject *
 _PyType_FromMetaclass(PyType_Spec *spec, PyObject *bases, struct _typeobject *meta)
 {
 #if PY_VERSION_HEX >= 0x030C0000
-    /* On Python 3.11 an newer, we can just use 'PyType_FromMetaclass'. */
+    /* On Python 3.12 an newer, we can just use 'PyType_FromMetaclass'. */
     return PyType_FromMetaclass(meta, NULL, spec, bases);
 #else
     /* On older Python versions, we need to workaround the missing support for
@@ -1068,9 +1072,6 @@ ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
     }
     struct _typeobject *metatype = get_metatype(params);
 
-    // PyType_FromSpecWithBases does not support passing a metaclass,
-    // so we have to use a patched CPython with PyType_FromSpecWithBasesAndMeta
-    // See also: https://bugs.python.org/issue15870
     PyObject *result = _PyType_FromMetaclass(spec, bases, metatype);
 
     /* note that we do NOT free the memory which was allocated by

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -1103,6 +1103,13 @@ ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
     /* note that we do NOT free the memory which was allocated by
        create_method_defs, because that one is referenced internally by
        CPython (which probably assumes it's statically allocated) */
+    Py_XDECREF(bases);
+    PyMem_Free(spec->slots);
+    PyMem_Free(spec);
+    if (result == NULL) {
+        return HPy_NULL;
+    }
+
 #if PY_VERSION_HEX < 0x03080000
     /*
     py3.7 compatibility
@@ -1113,12 +1120,7 @@ ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
         ((PyTypeObject*)result)->tp_flags |= Py_TPFLAGS_HAVE_FINALIZE;
     }
 #endif
-    Py_XDECREF(bases);
-    PyMem_Free(spec->slots);
-    PyMem_Free(spec);
-    if (result == NULL) {
-        return HPy_NULL;
-    }
+
     PyBufferProcs* buffer_procs = create_buffer_procs(hpyspec);
     if (buffer_procs) {
         ((PyTypeObject*)result)->tp_as_buffer = buffer_procs;

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -871,7 +871,7 @@ _HPy_HIDDEN struct _typeobject *get_metatype(HPyType_SpecParam *params) {
             }
         }
     }
-    return &PyType_Type;
+    return NULL;
 }
 
 static PyObject *

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -1144,6 +1144,30 @@ class TestType(HPyTest):
             pass
         assert isinstance(Sub(), mod.Dummy)
 
+    def test_specparam_multiple_metaclass_fails(self):
+        import pytest
+        mod = self.make_module("""
+            static HPyType_Spec Dummy_spec = {
+                .name = "mytest.Dummy",
+            };
+            
+            HPyDef_METH(make_dummy, "make_dummy", make_dummy_impl, HPyFunc_NOARGS)
+            static HPy make_dummy_impl(HPyContext *ctx, HPy module)
+            {
+                HPyType_SpecParam param[] = {
+                    { HPyType_SpecParam_Metaclass, ctx->h_TypeType },
+                    { HPyType_SpecParam_Metaclass, ctx->h_LongType },
+                    { (HPyType_SpecParam_Kind)0 }
+                };
+                return HPyType_FromSpec(ctx, &Dummy_spec, param);
+            }
+            @EXPORT(make_dummy)
+            @INIT
+        """)
+
+        with pytest.raises(ValueError):
+            mod.make_dummy()
+
     def test_metaclass(self):
         import pytest
         mod = self.make_module("""

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -197,7 +197,7 @@ class PointTemplate(DefaultExtensionTemplate):
 
     def DEFINE_meta_data_accessors(self):
         return """
-            HPyDef_METH(set_meta_data, "set_meta_data", set_meta_data_impl, HPyFunc_O)
+            HPyDef_METH(set_meta_data, "set_meta_data", HPyFunc_O)
             static HPy set_meta_data_impl(HPyContext *ctx, HPy self, HPy arg)
             {
                 DummyMeta *data = DummyMeta_AsStruct(ctx, arg);
@@ -208,7 +208,7 @@ class PointTemplate(DefaultExtensionTemplate):
                 return HPy_Dup(ctx, ctx->h_None);
             }
 
-            HPyDef_METH(get_meta_data, "get_meta_data", get_meta_data_impl, HPyFunc_O)
+            HPyDef_METH(get_meta_data, "get_meta_data", HPyFunc_O)
             static HPy get_meta_data_impl(HPyContext *ctx, HPy self, HPy arg)
             {
                 DummyMeta *data = DummyMeta_AsStruct(ctx, arg);
@@ -221,7 +221,7 @@ class PointTemplate(DefaultExtensionTemplate):
                 return HPyLong_FromLong(ctx, data->meta_magic + data->meta_member);
             }
 
-            HPyDef_METH(set_member, "set_member", set_member_impl, HPyFunc_O)
+            HPyDef_METH(set_member, "set_member", HPyFunc_O)
             static HPy set_member_impl(HPyContext *ctx, HPy self, HPy arg)
             {
                 Dummy *data = Dummy_AsStruct(ctx, arg);
@@ -1151,7 +1151,7 @@ class TestType(HPyTest):
                 .name = "mytest.Dummy",
             };
             
-            HPyDef_METH(make_dummy, "make_dummy", make_dummy_impl, HPyFunc_NOARGS)
+            HPyDef_METH(make_dummy, "make_dummy", HPyFunc_NOARGS)
             static HPy make_dummy_impl(HPyContext *ctx, HPy module)
             {
                 HPyType_SpecParam param[] = {
@@ -1178,8 +1178,7 @@ class TestType(HPyTest):
             @DEFINE_Dummy
             @DEFINE_meta_data_accessors
 
-            HPyDef_METH(create_type, "create_type", create_type_impl, 
-                            HPyFunc_VARARGS)
+            HPyDef_METH(create_type, "create_type", HPyFunc_VARARGS)
             static HPy create_type_impl(HPyContext *ctx, HPy module, 
                                             HPy *args, HPy_ssize_t nargs)
             {

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -27,6 +27,15 @@ class PointTemplate(DefaultExtensionTemplate):
         {type_helpers}
     """
 
+    _METACLASS_STRUCT_BEGIN_FORMAT = """
+        typedef struct {{
+    """
+
+    _METACLASS_STRUCT_END_FORMAT = """
+        }} {struct_name};
+        HPyType_HELPERS({struct_name}, HPyType_BuiltinShape_Type)
+    """
+
     def TYPE_STRUCT_BEGIN(self, struct_name):
         assert self._CURRENT_STRUCT is None
         self._CURRENT_STRUCT = struct_name
@@ -96,6 +105,130 @@ class PointTemplate(DefaultExtensionTemplate):
                 .defines = Point_defines
             };
         """ % defines
+
+
+    def METACLASS_STRUCT_BEGIN(self, struct_name):
+        assert self._CURRENT_STRUCT is None
+        self._CURRENT_STRUCT = struct_name
+        return self._METACLASS_STRUCT_BEGIN_FORMAT.format(struct_name=struct_name)
+
+    def METACLASS_STRUCT_END(self):
+        assert self._CURRENT_STRUCT is not None
+        struct_name = self._CURRENT_STRUCT
+        self._CURRENT_STRUCT = None
+        return self._METACLASS_STRUCT_END_FORMAT.format(struct_name=struct_name)
+
+    def DEFINE_DummyMeta_struct(self):
+        type_begin = self.METACLASS_STRUCT_BEGIN("DummyMeta")
+        type_end = self.METACLASS_STRUCT_END()
+        return """
+            {type_begin}
+                int meta_magic;
+                int meta_member;
+                char some_more[64];
+            {type_end}
+        """.format(type_begin=type_begin, type_end=type_end)
+
+    def DEFINE_DummyMeta(self):
+        struct = self.DEFINE_DummyMeta_struct()
+        return """
+            {struct}
+
+            static HPyType_Spec DummyMeta_spec = {{
+                .name = "mytest.DummyMeta",
+                .basicsize = sizeof(DummyMeta),
+                .itemsize = 0,
+                .flags = HPy_TPFLAGS_DEFAULT | HPy_TPFLAGS_BASETYPE,
+                .builtin_shape = SHAPE(DummyMeta),
+            }};
+
+            static HPy make_DummyMeta(HPyContext *ctx)
+            {{
+                HPyType_SpecParam param[] = {{
+                    {{ HPyType_SpecParam_Base, ctx->h_TypeType }},
+                    {{ (HPyType_SpecParam_Kind)0 }}
+                }};
+                return HPyType_FromSpec(ctx, &DummyMeta_spec, param);
+            }}
+        """.format(struct=struct)
+
+    def EXPORT_DummyMeta(self):
+        self.EXTRA_INIT_FUNC("register_DummyMeta")
+        return """
+            static void register_DummyMeta(HPyContext *ctx, HPy module)
+            {
+                HPy h_DummyMeta = make_DummyMeta(ctx);
+                if (HPy_IsNull(h_DummyMeta))
+                    return;
+                HPy_SetAttr_s(ctx, module, "DummyMeta", h_DummyMeta);
+                HPy_Close(ctx, h_DummyMeta);
+            }
+        """
+
+    def DEFINE_Dummy_struct(self):
+        type_begin = self.TYPE_STRUCT_BEGIN("Dummy")
+        type_end = self.TYPE_STRUCT_END()
+        return """
+            {type_begin}
+                int member;
+            {type_end}
+            """.format(type_begin=type_begin, type_end=type_end)
+
+    def DEFINE_Dummy(self):
+        struct = self.DEFINE_Dummy_struct()
+        return """
+            {struct}
+
+            HPyDef_MEMBER(member, "member", HPyMember_INT, offsetof(Dummy, member))
+
+            static HPyDef *Dummy_defines[] = {{
+                &member,
+                NULL
+            }};
+
+            static HPyType_Spec Dummy_spec = {{
+                .name = "mytest.Dummy",
+                .basicsize = sizeof(Dummy),
+                .flags = HPy_TPFLAGS_DEFAULT | HPy_TPFLAGS_BASETYPE,
+                .builtin_shape = SHAPE(Dummy),
+                .defines = Dummy_defines,
+            }};
+            """.format(struct=struct)
+
+    def DEFINE_meta_data_accessors(self):
+        return """
+            HPyDef_METH(set_meta_data, "set_meta_data", set_meta_data_impl, HPyFunc_O)
+            static HPy set_meta_data_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                DummyMeta *data = DummyMeta_AsStruct(ctx, arg);
+                data->meta_magic = 42;
+                data->meta_member = 11;
+                for (size_t i = 0; i < 64; ++i)
+                    data->some_more[i] = (char) i;
+                return HPy_Dup(ctx, ctx->h_None);
+            }
+
+            HPyDef_METH(get_meta_data, "get_meta_data", get_meta_data_impl, HPyFunc_O)
+            static HPy get_meta_data_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                DummyMeta *data = DummyMeta_AsStruct(ctx, arg);
+                for (size_t i = 0; i < 64; ++i) {
+                    if (data->some_more[i] != (char) i) {
+                        HPyErr_SetString(ctx, ctx->h_RuntimeError, "some_more got mangled");
+                        return HPy_NULL;
+                    }
+                }
+                return HPyLong_FromLong(ctx, data->meta_magic + data->meta_member);
+            }
+
+            HPyDef_METH(set_member, "set_member", set_member_impl, HPyFunc_O)
+            static HPy set_member_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                Dummy *data = Dummy_AsStruct(ctx, arg);
+                data->member = 123614;
+                return HPy_Dup(ctx, ctx->h_None);
+            }
+            """
 
 
 class TestType(HPyTest):
@@ -1010,6 +1143,80 @@ class TestType(HPyTest):
         class Sub(mod.Dummy):
             pass
         assert isinstance(Sub(), mod.Dummy)
+
+    def test_metaclass(self):
+        import pytest
+        mod = self.make_module("""
+            #include <Python.h>
+            #include <structmember.h>
+
+            @DEFINE_DummyMeta
+            @DEFINE_Dummy
+            @DEFINE_meta_data_accessors
+
+            HPyDef_METH(create_type, "create_type", create_type_impl, 
+                            HPyFunc_VARARGS)
+            static HPy create_type_impl(HPyContext *ctx, HPy module, 
+                                            HPy *args, HPy_ssize_t nargs)
+            {
+                HPy metaclass;
+                if (!HPyArg_Parse(ctx, NULL, args, nargs, "sO", 
+                        &Dummy_spec.name, &metaclass))
+                    return HPy_NULL;
+
+                HPyType_SpecParam specparam[] = {
+                    { HPyType_SpecParam_Metaclass, metaclass },
+                    { 0 }
+                };
+
+                const char *bare_name = strrchr(Dummy_spec.name, '.');
+                if (bare_name == NULL)
+                    bare_name = Dummy_spec.name;
+                else
+                    bare_name++;
+
+                if (!HPyHelpers_AddType(ctx, module, bare_name,
+                                            &Dummy_spec, specparam))
+                    return HPy_NULL;
+
+                return HPy_Dup(ctx, ctx->h_None);
+            }
+
+            @EXPORT_DummyMeta
+            @EXPORT(set_meta_data)
+            @EXPORT(get_meta_data)
+            @EXPORT(set_member)
+            @EXPORT(create_type)
+            @INIT
+        """)
+
+        assert type(mod.DummyMeta) is type
+        mod.create_type("mytest.Dummy", mod.DummyMeta)
+        assert mod.DummyMeta is type(mod.Dummy), "type(mod.Dummy) == %r" % (type(mod.Dummy), )
+        assert isinstance(mod.Dummy, type)
+        assert mod.set_meta_data(mod.Dummy) is None
+        assert mod.get_meta_data(mod.Dummy) == 42 + 11
+
+        d = mod.Dummy()
+        mod.set_member(d)
+        assert d.member == 123614
+
+        # metaclasses must inherit from 'type'
+        with pytest.raises(TypeError):
+            mod.create_type("mytest.DummyFail0", "hello")
+
+        class WithCustomNew:
+            def __new__(self):
+                print("hello")
+
+        # types with custom 'tp_new' cannot be used as metaclass
+        with pytest.raises(TypeError):
+            mod.create_type("mytest.DummyFail1", WithCustomNew)
+
+        # type 'int' also has a custom new
+        with pytest.raises(TypeError):
+            mod.create_type("mytest.DummyIntMeta", int)
+
 
 class TestPureHPyType(HPyTest):
 

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -1166,7 +1166,7 @@ class TestType(HPyTest):
 
                 HPyType_SpecParam specparam[] = {
                     { HPyType_SpecParam_Metaclass, metaclass },
-                    { 0 }
+                    { (HPyType_SpecParam_Kind)0 }
                 };
 
                 const char *bare_name = strrchr(Dummy_spec.name, '.');

--- a/test/test_hpytype_legacy.py
+++ b/test/test_hpytype_legacy.py
@@ -22,8 +22,17 @@ class LegacyPointTemplate(PointTemplate):
         HPyType_LEGACY_HELPERS({struct_name})
     """
 
+    _TYPE_STRUCT_BEGIN_FORMAT = """
+        #include <Python.h>
+        typedef struct {{
+            PyHeapTypeObject super;
+    """
+
+    _TYPE_STRUCT_END_FORMAT = _STRUCT_END_FORMAT
+
     def DEFAULT_SHAPE(self):
         return ".builtin_shape = HPyType_BuiltinShape_Legacy,"
+
 
 class TestLegacyType(_TestType):
 
@@ -139,6 +148,178 @@ class TestLegacyType(_TestType):
             mod = self.make_module(mod_src)
         assert "legacy tp_dealloc" in str(err.value)
 
+    # Metaclass tests:
+    #
+    # Note: both the class (Dummy) and the metaclass (DummyMeta) must be at
+    # least legacy HPy types for now.
+    #
+    # The metaclass must inherit from PyType_Type, so it must embed in it
+    # PyHeapTypeObject, but HPyType_FromSpec assumes that the total size
+    # is ~ sizeof(PyObject) + spec->basicsize. HPy it could use base size
+    # instead of sizeof(PyObject), but that may be problematic w.r.t.
+    # the alignment of the result.
+    #
+    # The class itself must be legacy: The following seems to be CPython
+    # limitation/bug:
+    #
+    #   - (A) if we have custom metatype, then typeobject.c:mro_invoke checks:
+    #       assert(base->tp_basicsize < type->tp_basicsize)
+    #   - (B) if tp_basicsize == 0, then CPython fixes it by:
+    #       type->tp_basicsize = base->tp_basicsize // typeobject.c:inherit_special
+    #   - but (B) happens only after (A)
+    #
+    # Either the contract of PyType_Ready is such that if you have a metaclass,
+    # you must provide tp_basicsize (including sizeof(PyObject) for the trivial
+    # case), or this is a bug. With HPy pure types this could be also workaround
+    # by setting some basicsize, even just one byte.
+
+    def _metaclass_test(self, metatype_setup_code):
+        mod = self.make_module("""
+            #include <Python.h>
+            #include <structmember.h>
+
+            typedef struct {
+                PyHeapTypeObject super;
+                int meta_magic;
+                int meta_member;
+                char some_more[64];
+            } DummyMeta;
+            
+            typedef struct {
+                PyObject_HEAD
+                int member;
+            } DummyData;
+
+            static PyMemberDef members[] = {
+                    {"member", T_INT, offsetof(DummyData, member), 0, NULL},
+                    {NULL, 0, 0, 0, NULL},
+            };
+
+            static PyType_Slot DummySlots[] = {
+                {Py_tp_members, members},
+                {0, NULL},
+            };
+            
+            static HPyType_Spec Dummy_spec = {
+                .name = "mytest.Dummy",
+                .basicsize = sizeof(DummyData),
+                .flags = HPy_TPFLAGS_DEFAULT | HPy_TPFLAGS_BASETYPE,
+                .builtin_shape = HPyType_BuiltinShape_Legacy,
+                .legacy_slots = DummySlots,
+            };
+            
+            // Defined by each test:
+            bool setup_metatype(HPyContext *ctx, HPy module, HPy *h_DummyMeta);
+            
+            void setup_types(HPyContext *ctx, HPy module) {
+                HPy h_DummyMeta;
+                if (!setup_metatype(ctx, module, &h_DummyMeta))
+                    return;
+            
+                HPyType_SpecParam param[] = {
+                    { HPyType_SpecParam_Metaclass, h_DummyMeta },
+                    { 0 }
+                };
+                HPy h_Dummy = HPyType_FromSpec(ctx, &Dummy_spec, param);
+                if (!HPy_IsNull(h_Dummy)) {
+                    HPy_SetAttr_s(ctx, module, "Dummy", h_Dummy);
+                    HPy_SetAttr_s(ctx, module, "DummyMeta", h_DummyMeta);
+                }
+                
+                HPy_Close(ctx, h_Dummy);
+                HPy_Close(ctx, h_DummyMeta);
+            }
+        
+            HPyDef_METH(set_meta_data, "set_meta_data", set_meta_data_impl, HPyFunc_O)
+            static HPy set_meta_data_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                DummyMeta *data = (DummyMeta*) HPy_AsStructLegacy(ctx, arg);
+                data->meta_magic = 42;
+                data->meta_member = 11;
+                for (size_t i = 0; i < 64; ++i)
+                    data->some_more[i] = (char) i;
+                return HPy_Dup(ctx, ctx->h_None);
+            }
+
+            HPyDef_METH(get_meta_data, "get_meta_data", get_meta_data_impl, HPyFunc_O)
+            static HPy get_meta_data_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                DummyMeta *data = (DummyMeta*) HPy_AsStructLegacy(ctx, arg);
+                for (size_t i = 0; i < 64; ++i) {
+                    if (data->some_more[i] != (char) i) {
+                        HPyErr_SetString(ctx, ctx->h_RuntimeError, "some_more got mangled");
+                        return HPy_NULL;
+                    }
+                }
+                return HPyLong_FromLong(ctx, data->meta_magic + data->meta_member);
+            }
+
+            HPyDef_METH(set_member, "set_member", set_member_impl, HPyFunc_O)
+            static HPy set_member_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                DummyData *data = (DummyData*) HPy_AsStructLegacy(ctx, arg);
+                data->member = 123614;
+                return HPy_Dup(ctx, ctx->h_None);
+            }
+
+            @EXPORT(set_meta_data)
+            @EXPORT(get_meta_data)
+            @EXPORT(set_member)
+            @EXTRA_INIT_FUNC(setup_types)
+            @INIT
+        """ + metatype_setup_code)
+
+        assert isinstance(mod.Dummy, type)
+        assert mod.DummyMeta is type(mod.Dummy)
+        assert mod.set_meta_data(mod.Dummy) is None
+        assert mod.get_meta_data(mod.Dummy) == 42 + 11
+
+        d = mod.Dummy()
+        mod.set_member(d)
+        assert d.member == 123614
+
+    def test_metatype_as_legacy_static_type(self):
+        self._metaclass_test("""
+            static PyTypeObject DummyMetaType = {
+                PyVarObject_HEAD_INIT(&PyType_Type, 0)
+                .tp_base = &PyType_Type,
+                .tp_name = "mytest.DummyMeta",
+                .tp_basicsize = sizeof(DummyMeta),
+                .tp_flags = Py_TPFLAGS_DEFAULT,
+            };
+        
+            bool setup_metatype(HPyContext *ctx, HPy module, HPy *h_DummyMeta) {
+                if (PyType_Ready(&DummyMetaType))
+                    return false;
+                *h_DummyMeta = HPy_FromPyObject(ctx, (PyObject*) &DummyMetaType);
+                return true;
+            }
+        """)
+
+    # Ideally this test should be in the super class and parametrized by
+    # @IS_LEGACY for both the metatype and the class itself, but we cannot
+    # do pure HPy types in this scenario - see the comment above.
+    def test_metatype_as_legacy_hpy_type(self):
+        self._metaclass_test("""
+            static HPyType_Spec DummyMeta_spec = {
+                .name = "mytest.DummyMeta",
+                .basicsize = sizeof(DummyMeta),
+                .flags = HPy_TPFLAGS_DEFAULT,
+                .legacy = true,
+            };
+            
+            bool setup_metatype(HPyContext *ctx, HPy module, HPy *h_DummyMeta)
+            {
+                HPy h_py_type = HPy_FromPyObject(ctx, (PyObject*) &PyType_Type);                                
+                HPyType_SpecParam meta_param[] = {
+                    { HPyType_SpecParam_Base, h_py_type },
+                    { 0 }
+                };
+                *h_DummyMeta = HPyType_FromSpec(ctx, &DummyMeta_spec, meta_param);
+                HPy_Close(ctx, h_py_type);                
+                return !HPy_IsNull(*h_DummyMeta);
+            }
+        """)
 
 class TestCustomLegacyFeatures(HPyTest):
 

--- a/test/test_hpytype_legacy.py
+++ b/test/test_hpytype_legacy.py
@@ -184,7 +184,7 @@ class TestLegacyType(_TestType):
                 int meta_member;
                 char some_more[64];
             } DummyMeta;
-            
+
             typedef struct {
                 PyObject_HEAD
                 int member;
@@ -199,7 +199,7 @@ class TestLegacyType(_TestType):
                 {Py_tp_members, members},
                 {0, NULL},
             };
-            
+
             static HPyType_Spec Dummy_spec = {
                 .name = "mytest.Dummy",
                 .basicsize = sizeof(DummyData),
@@ -207,15 +207,15 @@ class TestLegacyType(_TestType):
                 .builtin_shape = HPyType_BuiltinShape_Legacy,
                 .legacy_slots = DummySlots,
             };
-            
+
             // Defined by each test:
             bool setup_metatype(HPyContext *ctx, HPy module, HPy *h_DummyMeta);
-            
+
             void setup_types(HPyContext *ctx, HPy module) {
                 HPy h_DummyMeta;
                 if (!setup_metatype(ctx, module, &h_DummyMeta))
                     return;
-            
+
                 HPyType_SpecParam param[] = {
                     { HPyType_SpecParam_Metaclass, h_DummyMeta },
                     { 0 }
@@ -225,11 +225,11 @@ class TestLegacyType(_TestType):
                     HPy_SetAttr_s(ctx, module, "Dummy", h_Dummy);
                     HPy_SetAttr_s(ctx, module, "DummyMeta", h_DummyMeta);
                 }
-                
+
                 HPy_Close(ctx, h_Dummy);
                 HPy_Close(ctx, h_DummyMeta);
             }
-        
+
             HPyDef_METH(set_meta_data, "set_meta_data", set_meta_data_impl, HPyFunc_O)
             static HPy set_meta_data_impl(HPyContext *ctx, HPy self, HPy arg)
             {
@@ -287,7 +287,7 @@ class TestLegacyType(_TestType):
                 .tp_basicsize = sizeof(DummyMeta),
                 .tp_flags = Py_TPFLAGS_DEFAULT,
             };
-        
+
             bool setup_metatype(HPyContext *ctx, HPy module, HPy *h_DummyMeta) {
                 if (PyType_Ready(&DummyMetaType))
                     return false;
@@ -307,16 +307,16 @@ class TestLegacyType(_TestType):
                 .flags = HPy_TPFLAGS_DEFAULT,
                 .legacy = true,
             };
-            
+
             bool setup_metatype(HPyContext *ctx, HPy module, HPy *h_DummyMeta)
             {
-                HPy h_py_type = HPy_FromPyObject(ctx, (PyObject*) &PyType_Type);                                
+                HPy h_py_type = HPy_FromPyObject(ctx, (PyObject*) &PyType_Type);
                 HPyType_SpecParam meta_param[] = {
                     { HPyType_SpecParam_Base, h_py_type },
                     { 0 }
                 };
                 *h_DummyMeta = HPyType_FromSpec(ctx, &DummyMeta_spec, meta_param);
-                HPy_Close(ctx, h_py_type);                
+                HPy_Close(ctx, h_py_type);
                 return !HPy_IsNull(*h_DummyMeta);
             }
         """)

--- a/test/test_hpytype_legacy.py
+++ b/test/test_hpytype_legacy.py
@@ -22,13 +22,13 @@ class LegacyPointTemplate(PointTemplate):
         HPyType_LEGACY_HELPERS({struct_name})
     """
 
-    _TYPE_STRUCT_BEGIN_FORMAT = """
+    _METACLASS_STRUCT_BEGIN_FORMAT = """
         #include <Python.h>
         typedef struct {{
             PyHeapTypeObject super;
     """
 
-    _TYPE_STRUCT_END_FORMAT = _STRUCT_END_FORMAT
+    _METACLASS_STRUCT_END_FORMAT = _STRUCT_END_FORMAT
 
     def DEFAULT_SHAPE(self):
         return ".builtin_shape = HPyType_BuiltinShape_Legacy,"
@@ -148,50 +148,25 @@ class TestLegacyType(_TestType):
             mod = self.make_module(mod_src)
         assert "legacy tp_dealloc" in str(err.value)
 
-    # Metaclass tests:
-    #
-    # Note: both the class (Dummy) and the metaclass (DummyMeta) must be at
-    # least legacy HPy types for now.
-    #
-    # The metaclass must inherit from PyType_Type, so it must embed in it
-    # PyHeapTypeObject, but HPyType_FromSpec assumes that the total size
-    # is ~ sizeof(PyObject) + spec->basicsize. HPy it could use base size
-    # instead of sizeof(PyObject), but that may be problematic w.r.t.
-    # the alignment of the result.
-    #
-    # The class itself must be legacy: The following seems to be CPython
-    # limitation/bug:
-    #
-    #   - (A) if we have custom metatype, then typeobject.c:mro_invoke checks:
-    #       assert(base->tp_basicsize < type->tp_basicsize)
-    #   - (B) if tp_basicsize == 0, then CPython fixes it by:
-    #       type->tp_basicsize = base->tp_basicsize // typeobject.c:inherit_special
-    #   - but (B) happens only after (A)
-    #
-    # Either the contract of PyType_Ready is such that if you have a metaclass,
-    # you must provide tp_basicsize (including sizeof(PyObject) for the trivial
-    # case), or this is a bug. With HPy pure types this could be also workaround
-    # by setting some basicsize, even just one byte.
-
-    def _metaclass_test(self, metatype_setup_code):
+    def test_metaclass_as_legacy_static_type(self):
         mod = self.make_module("""
             #include <Python.h>
             #include <structmember.h>
 
-            typedef struct {
-                PyHeapTypeObject super;
-                int meta_magic;
-                int meta_member;
-                char some_more[64];
-            } DummyMeta;
+            @DEFINE_DummyMeta_struct
 
-            typedef struct {
-                PyObject_HEAD
-                int member;
-            } DummyData;
+            static PyTypeObject DummyMetaType = {
+                PyVarObject_HEAD_INIT(&PyType_Type, 0)
+                .tp_base = &PyType_Type,
+                .tp_name = "mytest.DummyMeta",
+                .tp_basicsize = sizeof(DummyMeta),
+                .tp_flags = Py_TPFLAGS_DEFAULT,
+            };
+            
+            @DEFINE_Dummy_struct
 
             static PyMemberDef members[] = {
-                    {"member", T_INT, offsetof(DummyData, member), 0, NULL},
+                    {"member", T_INT, offsetof(Dummy, member), 0, NULL},
                     {NULL, 0, 0, 0, NULL},
             };
 
@@ -200,27 +175,25 @@ class TestLegacyType(_TestType):
                 {0, NULL},
             };
 
-            static HPyType_Spec Dummy_spec = {
+            static HPyType_Spec Dummy_legacy_spec = {
                 .name = "mytest.Dummy",
-                .basicsize = sizeof(DummyData),
+                .basicsize = sizeof(Dummy),
                 .flags = HPy_TPFLAGS_DEFAULT | HPy_TPFLAGS_BASETYPE,
                 .builtin_shape = HPyType_BuiltinShape_Legacy,
                 .legacy_slots = DummySlots,
             };
 
-            // Defined by each test:
-            bool setup_metatype(HPyContext *ctx, HPy module, HPy *h_DummyMeta);
-
             void setup_types(HPyContext *ctx, HPy module) {
                 HPy h_DummyMeta;
-                if (!setup_metatype(ctx, module, &h_DummyMeta))
+                if (PyType_Ready(&DummyMetaType))
                     return;
+                h_DummyMeta = HPy_FromPyObject(ctx, (PyObject*) &DummyMetaType);
 
                 HPyType_SpecParam param[] = {
                     { HPyType_SpecParam_Metaclass, h_DummyMeta },
                     { 0 }
                 };
-                HPy h_Dummy = HPyType_FromSpec(ctx, &Dummy_spec, param);
+                HPy h_Dummy = HPyType_FromSpec(ctx, &Dummy_legacy_spec, param);
                 if (!HPy_IsNull(h_Dummy)) {
                     HPy_SetAttr_s(ctx, module, "Dummy", h_Dummy);
                     HPy_SetAttr_s(ctx, module, "DummyMeta", h_DummyMeta);
@@ -230,44 +203,14 @@ class TestLegacyType(_TestType):
                 HPy_Close(ctx, h_DummyMeta);
             }
 
-            HPyDef_METH(set_meta_data, "set_meta_data", set_meta_data_impl, HPyFunc_O)
-            static HPy set_meta_data_impl(HPyContext *ctx, HPy self, HPy arg)
-            {
-                DummyMeta *data = (DummyMeta*) HPy_AsStructLegacy(ctx, arg);
-                data->meta_magic = 42;
-                data->meta_member = 11;
-                for (size_t i = 0; i < 64; ++i)
-                    data->some_more[i] = (char) i;
-                return HPy_Dup(ctx, ctx->h_None);
-            }
-
-            HPyDef_METH(get_meta_data, "get_meta_data", get_meta_data_impl, HPyFunc_O)
-            static HPy get_meta_data_impl(HPyContext *ctx, HPy self, HPy arg)
-            {
-                DummyMeta *data = (DummyMeta*) HPy_AsStructLegacy(ctx, arg);
-                for (size_t i = 0; i < 64; ++i) {
-                    if (data->some_more[i] != (char) i) {
-                        HPyErr_SetString(ctx, ctx->h_RuntimeError, "some_more got mangled");
-                        return HPy_NULL;
-                    }
-                }
-                return HPyLong_FromLong(ctx, data->meta_magic + data->meta_member);
-            }
-
-            HPyDef_METH(set_member, "set_member", set_member_impl, HPyFunc_O)
-            static HPy set_member_impl(HPyContext *ctx, HPy self, HPy arg)
-            {
-                DummyData *data = (DummyData*) HPy_AsStructLegacy(ctx, arg);
-                data->member = 123614;
-                return HPy_Dup(ctx, ctx->h_None);
-            }
+            @DEFINE_meta_data_accessors
 
             @EXPORT(set_meta_data)
             @EXPORT(get_meta_data)
             @EXPORT(set_member)
             @EXTRA_INIT_FUNC(setup_types)
             @INIT
-        """ + metatype_setup_code)
+        """)
 
         assert isinstance(mod.Dummy, type)
         assert mod.DummyMeta is type(mod.Dummy)
@@ -277,49 +220,6 @@ class TestLegacyType(_TestType):
         d = mod.Dummy()
         mod.set_member(d)
         assert d.member == 123614
-
-    def test_metatype_as_legacy_static_type(self):
-        self._metaclass_test("""
-            static PyTypeObject DummyMetaType = {
-                PyVarObject_HEAD_INIT(&PyType_Type, 0)
-                .tp_base = &PyType_Type,
-                .tp_name = "mytest.DummyMeta",
-                .tp_basicsize = sizeof(DummyMeta),
-                .tp_flags = Py_TPFLAGS_DEFAULT,
-            };
-
-            bool setup_metatype(HPyContext *ctx, HPy module, HPy *h_DummyMeta) {
-                if (PyType_Ready(&DummyMetaType))
-                    return false;
-                *h_DummyMeta = HPy_FromPyObject(ctx, (PyObject*) &DummyMetaType);
-                return true;
-            }
-        """)
-
-    # Ideally this test should be in the super class and parametrized by
-    # @IS_LEGACY for both the metatype and the class itself, but we cannot
-    # do pure HPy types in this scenario - see the comment above.
-    def test_metatype_as_legacy_hpy_type(self):
-        self._metaclass_test("""
-            static HPyType_Spec DummyMeta_spec = {
-                .name = "mytest.DummyMeta",
-                .basicsize = sizeof(DummyMeta),
-                .flags = HPy_TPFLAGS_DEFAULT,
-                .legacy = true,
-            };
-
-            bool setup_metatype(HPyContext *ctx, HPy module, HPy *h_DummyMeta)
-            {
-                HPy h_py_type = HPy_FromPyObject(ctx, (PyObject*) &PyType_Type);
-                HPyType_SpecParam meta_param[] = {
-                    { HPyType_SpecParam_Base, h_py_type },
-                    { 0 }
-                };
-                *h_DummyMeta = HPyType_FromSpec(ctx, &DummyMeta_spec, meta_param);
-                HPy_Close(ctx, h_py_type);
-                return !HPy_IsNull(*h_DummyMeta);
-            }
-        """)
 
 class TestCustomLegacyFeatures(HPyTest):
 

--- a/test/test_hpytype_legacy.py
+++ b/test/test_hpytype_legacy.py
@@ -157,10 +157,10 @@ class TestLegacyType(_TestType):
 
             static PyTypeObject DummyMetaType = {
                 PyVarObject_HEAD_INIT(&PyType_Type, 0)
-                .tp_base = &PyType_Type,
                 .tp_name = "mytest.DummyMeta",
                 .tp_basicsize = sizeof(DummyMeta),
                 .tp_flags = Py_TPFLAGS_DEFAULT,
+                .tp_base = &PyType_Type,
             };
             
             @DEFINE_Dummy_struct
@@ -191,7 +191,7 @@ class TestLegacyType(_TestType):
 
                 HPyType_SpecParam param[] = {
                     { HPyType_SpecParam_Metaclass, h_DummyMeta },
-                    { 0 }
+                    { (HPyType_SpecParam_Kind)0 }
                 };
                 HPy h_Dummy = HPyType_FromSpec(ctx, &Dummy_legacy_spec, param);
                 if (!HPy_IsNull(h_Dummy)) {


### PR DESCRIPTION
This PR resolves #296 and is one of the big pieces that is required for migration of NumPy.

Goal of this PR: Support metaclasses for HPy types.

Before version 3.12, CPython does not support specifying metaclasses for heap types but only for static types.
We can still support that by creating a temporary heap type using `PyType_FromSpecWithBases` and then we manually allocate another heap type using the provided metaclass' `tp_alloc`. We then copy everything from the temporary heap type to the final one, reset some carefully picked slots and initialize it with `PyType_Ready`.
The temporary heap type is then trashed.

However, making that work with pure HPy types wasn't that trivial because a metaclass usually embeds the heap type struct like this:

```
typedef struct {
    PyHeapTypeObject super; // sizeof(PyHeapTypeObject) == 880
    int x;
    int y;
    // ....
} LegacyMetaClass;
```

The problem is that if we specify a pure HPy type and use it as metaclass, we would still just have following struct:
```
typedef struct {
    int x;
    int y;
    // ...
} MetaClass;
```
Since from an HPy point of view, the runtime's heap type is opaque, you cannot embed that in your structure and HPy assumes that it's just a bare `PyObject` and so the used offset is just `sizeof(PyObject)`.

However, each metaclass needs to inherit from `PyType_Type` (directly or indirectly). I use that fact and iterate over the bases to determine the largest basicsize. That is then used as an offset.
Furthermore, we now don't have a fixed offset for the pure HPy data pointer and so we need to store that in the HPy type's extra info.
This makes the `*_AsStruct` calls slightly more expensive because we need to load the offset from the object type's extra info.
I think, this change is not only a fix for metaclasses but in general a fix to be able to inherit from any opaque type. For example, an HPy extension could define a type that inherits from a foreign HPy extension's type which also specifies a basicsize.
Furthermore, as far as I know, the situation is similar in the C API when using the limited API. The structs are opaque and if one wants to inherit from a type, he needs to add the base type's basicsize.