### PR TITLE
Backport changes needed to support PyPy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ docs/_build/
 
 # vscode
 .vscode
+
+# vim
+*.swp

--- a/hpy/devel/include/hpy/hpydef.h
+++ b/hpy/devel/include/hpy/hpydef.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "hpy/autogen_hpyslot.h"
 #include "hpy/cpy_types.h"
 
-typedef void* (*HPyCFunction)();
+typedef void* (*HPyCFunction)(void);
 
 typedef struct {
     HPySlot_Slot slot;     // The slot to fill

--- a/hpy/universal/src/ctx_meth.c
+++ b/hpy/universal/src/ctx_meth.c
@@ -35,7 +35,7 @@ static void _buffer_py2h(HPyContext *ctx, const Py_buffer *src, HPy_buffer *dest
 
 HPyAPI_IMPL void
 ctx_CallRealFunctionFromTrampoline(HPyContext *ctx, HPyFunc_Signature sig,
-                                   void* (*func)(), void *args)
+                                   void* (*func)(void), void *args)
 {
     switch (sig) {
     case HPyFunc_NOARGS: {

--- a/hpy/universal/src/ctx_meth.h
+++ b/hpy/universal/src/ctx_meth.h
@@ -3,4 +3,4 @@
 
 HPyAPI_IMPL void
 ctx_CallRealFunctionFromTrampoline(HPyContext *ctx, HPyFunc_Signature sig,
-                                   void* (*func)(), void *args);
+                                   void* (*func)(void), void *args);

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 from .support import ExtensionCompiler, DefaultExtensionTemplate,\
     PythonSubprocessRunner, HPyDebugCapture
 from hpy.debug.leakdetector import LeakDetector
@@ -52,7 +53,6 @@ def compiler(request, tmpdir, hpy_devel, hpy_abi, ExtensionTemplate):
 
 @pytest.fixture(scope="session")
 def fatal_exit_code(request):
-    import sys
     return {
         "linux": -6,  # SIGABRT
         # See https://bugs.python.org/issue36116#msg336782 -- the

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -73,6 +73,5 @@ def hpy_debug_capture(request, hpy_abi):
     assert hpy_abi == 'debug'
     if sys.implementation.name != "cpython":
         pytest.skip("'on_invalid_handle' hook usable on cpython only")
-    raise ValueError("don't do this")
     with HPyDebugCapture() as reporter:
         yield reporter

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -71,5 +71,8 @@ def python_subprocess(request, hpy_abi):
 @pytest.fixture()
 def hpy_debug_capture(request, hpy_abi):
     assert hpy_abi == 'debug'
+    if sys.implementation.name != "cpython":
+        pytest.skip("'on_invalid_handle' hook usable on cpython only")
+    raise ValueError("don't do this")
     with HPyDebugCapture() as reporter:
         yield reporter

--- a/test/debug/test_charptr.py
+++ b/test/debug/test_charptr.py
@@ -1,5 +1,6 @@
-from test.support import SUPPORTS_SYS_EXECUTABLE
+from ..support import SUPPORTS_SYS_EXECUTABLE
 import os
+import sys
 import pytest
 
 # Tests detection of usage of char pointers associated with invalid already
@@ -46,7 +47,9 @@ def test_charptr_use_after_implicit_arg_handle_close(compiler, python_subprocess
     result = python_subprocess.run(mod, code)
     assert result.returncode != 0
     assert result.stdout == b""
-    if SUPPORTS_MEM_PROTECTION:
+    if sys.implementation.name == 'pypy':
+        assert b"RPython" in result.stderr
+    elif SUPPORTS_MEM_PROTECTION:
         assert result.stderr == b""
     else:
         # The garbage we override the data with will cause this error
@@ -76,7 +79,9 @@ def test_charptr_use_after_handle_close(compiler, python_subprocess):
     result = python_subprocess.run(mod, code)
     assert result.returncode != 0
     assert result.stdout == b""
-    if SUPPORTS_MEM_PROTECTION:
+    if sys.implementation.name == 'pypy':
+        assert b"RPython" in result.stderr
+    elif SUPPORTS_MEM_PROTECTION:
         assert result.stderr == b""
     else:
         # The garbage we override the data with will cause this error
@@ -103,7 +108,10 @@ def test_charptr_write_ptr(compiler, python_subprocess):
         @INIT
     """)
     result = python_subprocess.run(mod, "mod.f('try writing me!');")
-    assert result.returncode != 0
+    if sys.implementation.name == 'pypy':
+        assert result.returncode == 0
+    else:
+        assert result.returncode != 0
     assert result.stdout == b""
     assert result.stderr == b""
 

--- a/test/debug/test_handles_invalid.py
+++ b/test/debug/test_handles_invalid.py
@@ -1,7 +1,7 @@
 import pytest
 from hpy.debug.leakdetector import LeakDetector
-from test.support import SUPPORTS_SYS_EXECUTABLE, IS_PYTHON_DEBUG_BUILD
-from test.conftest import IS_VALGRIND_RUN
+from ..support import SUPPORTS_SYS_EXECUTABLE, IS_PYTHON_DEBUG_BUILD
+from ..conftest import IS_VALGRIND_RUN
 
 @pytest.fixture
 def hpy_abi():

--- a/test/hpy_devel/test_distutils.py
+++ b/test/hpy_devel/test_distutils.py
@@ -90,7 +90,7 @@ class TestDistutils:
             proc = subprocess.run(cmd)
             out = None
         if proc.returncode != 0:
-            raise Exception(f"Command {exe} failed")
+            raise Exception(f"Command {cmd} failed")
         return out
 
 

--- a/test/test_slots.py
+++ b/test/test_slots.py
@@ -354,6 +354,7 @@ class TestSlots(HPyTest):
     def test_buffer(self):
         import pytest
         import sys
+        import gc
         mod = self.make_module("""
             @TYPE_STRUCT_BEGIN(FakeArrayObject)
                 int exports;
@@ -419,6 +420,7 @@ class TestSlots(HPyTest):
                 assert sys.getrefcount(arr) == init_refcount + 1
             for i in range(12):
                 assert mv[i] == i
+        gc.collect()
         if self.supports_refcounts():
             assert sys.getrefcount(arr) == init_refcount
         mv2 = memoryview(arr)  # doesn't raise


### PR DESCRIPTION
The changes are
- disallow setting `on_invalid_handle` hook in debug mode, since setting the hook will fail on non-cpython in accordance with [this comment](https://github.com/hpyproject/hpy/commit/51c3212), which should be in a more permanent place
- add a gc.collect in a test
- use relative imports to allow vendoring the test suite
- adapt the `SUPPORTS_MEM_PROTECTION` checks to PyPy