### PR TITLE
Support stacktrace on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m pip install pytest pytest-xdist
+          python -m pip install pytest pytest-xdist filelock
           python -m pytest --durations=16 -n auto test/
 
   main_tests_debug:
@@ -86,7 +86,7 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m pip install pytest pytest-xdist
+          python -m pip install pytest pytest-xdist filelock
           python -m pytest --durations=16 -n auto test/
 
   poc_tests:
@@ -172,7 +172,7 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m pip install pytest pytest-valgrind
+          python -m pip install pytest pytest-valgrind filelock
           make valgrind
 
   docs_examples_tests:
@@ -201,7 +201,7 @@ jobs:
 
       - name: Install pytest
         run: |
-          python -m pip install pytest
+          python -m pip install pytest pytest-xdist filelock
       - name: Run tests
         run: make docs-examples-tests
         shell: bash
@@ -300,7 +300,7 @@ jobs:
 
       - name: check_py27_compat.py
         run: |
-          python -m pip install pytest pathlib
+          python -m pip install pytest pytest-xdist filelock pathlib
           python test/check_py27_compat.py
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ test-output.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.hpy.lock
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/docs/examples/tests.py
+++ b/docs/examples/tests.py
@@ -66,7 +66,7 @@ def test_leak_detector_with_traces_output():
     assert 'hpy.debug.leakdetector.HPyLeakError: 1 unclosed handle:' in err
     assert re.search('<DebugHandle 0x[\\da-h]* for 42>', err)
     assert 'Allocation stacktrace:' in err
-    if sys.platform.startswith("linux"):
+    if sys.platform.startswith(("linux", "darwin")):
         assert 'snippets.hpy.so' in err  # Should be somewhere in the stack trace
     else:
         assert 'At the moment this is only supported on Linux with glibc' in err

--- a/hpy/debug/src/stacktrace.c
+++ b/hpy/debug/src/stacktrace.c
@@ -1,6 +1,6 @@
 #include "debug_internal.h"
 
-#if (__linux__ && __GNU_LIBRARY__)
+#if ((__linux__ && __GNU_LIBRARY__) || __APPLE__)
 
 // Basic implementation that uses backtrace from glibc
 
@@ -85,7 +85,8 @@ void create_stacktrace(char **target, HPy_ssize_t max_frames_count) {
 void create_stacktrace(char **target, HPy_ssize_t max_frames_count) {
     const char msg[] =
             "Current HPy build does not support getting C stack traces.\n"
-            "At the moment this is only supported on Linux with glibc.";
+            "At the moment this is only supported on Linux with glibc"
+            " and macOS.";
     *target = malloc(sizeof(msg));
     memcpy(*target, msg, sizeof(msg));
 }

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -28,7 +28,10 @@ import setuptools.command as cmd
 try:
     import setuptools.command.build
 except ImportError:
-    # this happens on py27, because the setuptools version is too old :(
+    print(
+        "warning: setuptools.command.build does not exist in setuptools",
+        setuptools.__version__, "on", sys.version
+    )
     setuptools.command.build = None
 import setuptools.command.build_ext
 import setuptools.command.bdist_egg

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -112,6 +112,8 @@ class HPyDevel:
             if resource.endswith(".hpy.so"):
                 log.info("stub file already created for %s", resource)
                 return
+            else:
+                log.info("stub resource didn't match for %s", resource)
             write_stub.super(resource, pyfile)
 
     def build_ext_sanity_check(self, build_ext):
@@ -364,6 +366,24 @@ class build_ext_hpy_mixin:
                 f.write(_HPY_UNIVERSAL_MODULE_STUB_TEMPLATE.format(
                     ext_file=ext_file, module_name=module_name)
                 )
+
+    def copy_extensions_to_source(self):
+        """Override from setuptools 64.0.0 to copy our stub instead of recreating it."""
+        build_py = self.get_finalized_command('build_py')
+        build_lib = build_py.build_lib
+        for ext in self.extensions:
+            inplace_file, regular_file = self._get_inplace_equivalent(build_py, ext)
+
+            # Always copy, even if source is older than destination, to ensure
+            # that the right extensions for the current Python/platform are
+            # used.
+            if os.path.exists(regular_file) or not ext.optional:
+                self.copy_file(regular_file, inplace_file, level=self.verbose)
+
+            if ext._needs_stub:
+                source_stub = os.path.join(build_lib, *ext._full_name.split('.')) + '.py'
+                inplace_stub = self._get_equivalent_stub(ext, inplace_file)
+                self.copy_file(source_stub, inplace_stub, level=self.verbose)
 
     def get_export_symbols(self, ext):
         """ Override .get_export_symbols to replace "PyInit_<module_name>"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = [ "setuptools>=40.6.0", "setuptools-scm[toml]>=6.0", "wheel>=0.34.2",]
+requires = [ "setuptools>=64.0", "setuptools-scm[toml]>=6.0", "wheel>=0.34.2",]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -162,5 +162,5 @@ setup(
     },
     use_scm_version=get_scm_config,
     setup_requires=['setuptools_scm'],
-    install_requires=['setuptools>=60.2'],
+    install_requires=['setuptools>=64.0'],
 )

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ EXT_MODULES = [
 DEV_REQUIREMENTS = [
     "pytest",
     "pytest-xdist",
+    "filelock",
 ]
 
 setup(

--- a/test/hpy_devel/test_distutils.py
+++ b/test/hpy_devel/test_distutils.py
@@ -7,17 +7,16 @@ files in this directory, which all inherit from HPyTest and test the API
 itself.
 """
 
-import sys
 import os
 import textwrap
 import subprocess
-from pathlib import Path
 import shutil
 import venv
 import py
 import pytest
 
-HPY_ROOT = Path(__file__).parent.parent.parent
+
+from test.support import atomic_run, HPY_ROOT
 
 # this is only for development: if we set it to true, we don't have to
 # recreate the venv_template between runs, it's much faster
@@ -46,12 +45,12 @@ def venv_template(tmpdir_factory):
         script.remove()
     #
     try:
-        subprocess.run(
+        atomic_run(
             [str(d.python), '-m', 'pip', 'install', '-U', 'pip', 'wheel', 'setuptools'],
             check=True,
             capture_output=True,
         )
-        subprocess.run(
+        atomic_run(
             [str(d.python), '-m', 'pip', 'install', str(HPY_ROOT)],
             check=True,
             capture_output=True,
@@ -73,7 +72,7 @@ def attach_python_to_venv(d):
 class TestDistutils:
 
     @pytest.fixture()
-    def initargs(self, tmpdir, venv_template):
+    def initargs(self, pytestconfig, tmpdir, venv_template):
         self.tmpdir = tmpdir
         # create a fresh venv by copying the template
         self.venv = tmpdir.join('venv')
@@ -95,10 +94,10 @@ class TestDistutils:
         cmd = [str(self.venv.python)] + list(args)
         print('[RUN]', ' '.join(cmd))
         if capture:
-            proc = subprocess.run(cmd, stdout=subprocess.PIPE)
+            proc = atomic_run(cmd, stdout=subprocess.PIPE)
             out = proc.stdout.decode('latin-1').strip()
         else:
-            proc = subprocess.run(cmd)
+            proc = atomic_run(cmd)
             out = None
         if proc.returncode != 0:
             raise Exception(f"Command {cmd} failed")

--- a/test/hpy_devel/test_distutils.py
+++ b/test/hpy_devel/test_distutils.py
@@ -46,7 +46,7 @@ def venv_template(tmpdir_factory):
         script.remove()
     #
     subprocess.run([str(d.python), '-m'
-                    'pip', 'install', '-U', 'pip', 'wheel'], check=True)
+                    'pip', 'install', '-U', 'pip==21.2.4', 'wheel'], check=True)
     subprocess.run([str(d.python), '-m'
                     'pip', 'install', '-e', str(HPY_ROOT)], check=True)
     return d
@@ -90,7 +90,7 @@ class TestDistutils:
             proc = subprocess.run(cmd)
             out = None
         if proc.returncode != 0:
-            raise Exception(f"Command {exe} failed")
+            raise Exception(f"Command {cmd} failed")
         return out
 
 

--- a/test/hpy_devel/test_distutils.py
+++ b/test/hpy_devel/test_distutils.py
@@ -45,10 +45,21 @@ def venv_template(tmpdir_factory):
             continue
         script.remove()
     #
-    subprocess.run([str(d.python), '-m'
-                    'pip', 'install', '-U', 'pip==21.2.4', 'wheel'], check=True)
-    subprocess.run([str(d.python), '-m'
-                    'pip', 'install', '-e', str(HPY_ROOT)], check=True)
+    try:
+        subprocess.run(
+            [str(d.python), '-m', 'pip', 'install', '-U', 'pip', 'wheel', 'setuptools'],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [str(d.python), '-m', 'pip', 'install', str(HPY_ROOT)],
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as cpe:
+        print(cpe.stdout.decode("utf8"))
+        print(cpe.stderr.decode("utf8"))
+        raise
     return d
 
 def attach_python_to_venv(d):


### PR DESCRIPTION
Turns out Darwin ships `backtrace()` since 10.5.

This change also makes HPy require setuptools 64.0.0+ and removes a flakiness of parallel (xdist) tests creating and deleting temporary wheels in the same directory.