### PR TITLE
Support object members

### DIFF
--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -361,7 +361,7 @@ create_member_defs(HPyDef *hpydefs[], PyMemberDef *legacy_members, HPy_ssize_t b
                 while ((*getsets)[getsetcnt].name) {
                     getsetcnt++;
                 }
-                *getsets = (PyGetSetDef*)PyMem_Realloc(*getsets, (getsetcnt + 1) * sizeof(PyGetSetDef));
+                *getsets = (PyGetSetDef*)PyMem_Realloc(*getsets, (getsetcnt + 2) * sizeof(PyGetSetDef));
                 if (!*getsets) {
                     return NULL;
                 }

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -282,8 +282,31 @@ create_method_defs(HPyDef *hpydefs[], PyMethodDef *legacy_methods)
     return result;
 }
 
+// see the comment in create_member_defs below
+#ifdef HPY_UNIVERSAL_ABI
+static PyObject *member_object_get(PyObject *self, void *closure)
+{
+    intptr_t offset = (intptr_t)closure;
+    HPyField *field = (HPyField *)(((char *)self) + offset);
+    PyObject *value = _hf2py(*field);
+    Py_INCREF(value);
+    return value;
+}
+
+static int member_object_set(PyObject *self, PyObject *value, void *closure)
+{
+    intptr_t offset = (intptr_t)closure;
+    HPyField *field = (HPyField *)(((char *)self) + offset);
+    PyObject *old_value = _hf2py(*field);
+    Py_XINCREF(value);
+    *field = _py2hf(value);
+    Py_XDECREF(old_value);
+    return 0;
+}
+#endif
+
 static PyMemberDef *
-create_member_defs(HPyDef *hpydefs[], PyMemberDef *legacy_members, HPy_ssize_t base_member_offset)
+create_member_defs(HPyDef *hpydefs[], PyMemberDef *legacy_members, HPy_ssize_t base_member_offset, PyGetSetDef **getsets)
 {
     HPy_ssize_t hpymember_count = HPyDef_count(hpydefs, HPyDef_Kind_Member);
     // count the legacy members
@@ -307,6 +330,27 @@ create_member_defs(HPyDef *hpydefs[], PyMemberDef *legacy_members, HPy_ssize_t b
             HPyDef *src = hpydefs[i];
             if (src->kind != HPyDef_Kind_Member)
                 continue;
+#ifdef HPY_UNIVERSAL_ABI
+            // for the universal mode, we need to do load the HPyField that is
+            // stored in the object properly. In CPython ABI mode, these can be
+            // safely read as PyObject* directly without the overhead of getset.
+            if (src->member.type == HPyMember_OBJECT) {
+                int getsetcnt = 0;
+                while ((*getsets)[getsetcnt].name) {
+                    getsetcnt++;
+                }
+                *getsets = (PyGetSetDef*)PyMem_Realloc(*getsets, (getsetcnt + 1) * sizeof(PyGetSetDef));
+                PyGetSetDef *dst = &(*getsets)[getsetcnt++];
+                dst->name = src->member.name;
+                dst->get = member_object_get;
+                dst->set = member_object_set;
+                dst->doc = src->member.doc;
+                dst->closure = (void *)(src->member.offset + base_member_offset);
+                memset(&(*getsets)[getsetcnt], 0, sizeof(PyGetSetDef));
+                total_count--;
+                continue;
+            }
+#endif
             PyMemberDef *dst = &result[dst_idx++];
             dst->name = src->member.name;
             dst->type = src->member.type;
@@ -449,23 +493,25 @@ create_slot_defs(HPyType_Spec *hpyspec, HPy_ssize_t base_member_offset,
     }
     result[dst_idx++] = (PyType_Slot){Py_tp_methods, pymethods};
 
-    // add the "real" members
-    PyMemberDef *pymembers = create_member_defs(hpyspec->defines, legacy_member_defs, base_member_offset);
-    if (pymembers == NULL) {
-        PyMem_Free(pymethods);
-        PyMem_Free(result);
-        return NULL;
-    }
-    result[dst_idx++] = (PyType_Slot){Py_tp_members, pymembers};
-
-    // add the "real" getsets
+    // prepare the "real" getsets
     PyGetSetDef *pygetsets = create_getset_defs(hpyspec->defines, legacy_getset_defs);
     if (pygetsets == NULL) {
-        PyMem_Free(pymembers);
         PyMem_Free(pymethods);
         PyMem_Free(result);
         return NULL;
     }
+
+    // prepare the "real" members, which may introduce getsetdefs in universal mode
+    PyMemberDef *pymembers = create_member_defs(hpyspec->defines, legacy_member_defs, base_member_offset, &pygetsets);
+    if (pymembers == NULL) {
+        PyMem_Free(pygetsets);
+        PyMem_Free(pymethods);
+        PyMem_Free(result);
+        return NULL;
+    }
+
+    // add both members and getsets
+    result[dst_idx++] = (PyType_Slot){Py_tp_members, pymembers};
     result[dst_idx++] = (PyType_Slot){Py_tp_getset, pygetsets};
 
     // add a dealloc function, if needed

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -362,6 +362,9 @@ create_member_defs(HPyDef *hpydefs[], PyMemberDef *legacy_members, HPy_ssize_t b
                     getsetcnt++;
                 }
                 *getsets = (PyGetSetDef*)PyMem_Realloc(*getsets, (getsetcnt + 1) * sizeof(PyGetSetDef));
+                if (!*getsets) {
+                    return NULL;
+                }
                 PyGetSetDef *dst = &(*getsets)[getsetcnt++];
                 dst->name = src->member.name;
                 if (src->member.type == HPyMember_OBJECT_EX) {
@@ -371,11 +374,13 @@ create_member_defs(HPyDef *hpydefs[], PyMemberDef *legacy_members, HPy_ssize_t b
                 }
                 if (!src->member.readonly) {
                     dst->set = member_object_set;
+                } else {
+                    dst->set = NULL;
                 }
                 dst->doc = src->member.doc;
                 src->member.offset = src->member.offset + base_member_offset;
                 dst->closure = (void *)&src->member;
-                memset(&(*getsets)[getsetcnt], 0, sizeof(PyGetSetDef));
+                (*getsets)[getsetcnt] = (PyGetSetDef){NULL};
                 total_count--;
                 continue;
             }

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -431,6 +431,7 @@ class TestType(HPyTest):
                 char CHAR_member;
                 char ISTRING_member[6];
                 char BOOL_member;
+                HPyField OBJECT_member;
             @TYPE_STRUCT_END
 
             HPyDef_SLOT(Foo_new, Foo_new_impl, HPy_tp_new)
@@ -449,6 +450,7 @@ class TestType(HPyTest):
                 foo->CHAR_member = 'A';
                 strncpy(foo->ISTRING_member, "Hello", 6);
                 foo->BOOL_member = 0;
+                HPyField_Store(ctx, h_obj, &foo->OBJECT_member, ctx->h_Ellipsis);
                 return h_obj;
             }
 
@@ -459,6 +461,7 @@ class TestType(HPyTest):
             HPyDef_MEMBER(Foo_CHAR_member, "CHAR_member", HPyMember_CHAR, offsetof(FooObject, CHAR_member))
             HPyDef_MEMBER(Foo_ISTRING_member, "ISTRING_member", HPyMember_STRING_INPLACE, offsetof(FooObject, ISTRING_member))
             HPyDef_MEMBER(Foo_BOOL_member, "BOOL_member", HPyMember_BOOL, offsetof(FooObject, BOOL_member))
+            HPyDef_MEMBER(Foo_OBJECT_member, "OBJECT_member", HPyMember_OBJECT, offsetof(FooObject, OBJECT_member))
             HPyDef_MEMBER(Foo_NONE_member, "NONE_member", HPyMember_NONE, offsetof(FooObject, FLOAT_member))
 
             static HPyDef *Foo_defines[] = {
@@ -470,6 +473,7 @@ class TestType(HPyTest):
                     &Foo_CHAR_member,
                     &Foo_ISTRING_member,
                     &Foo_BOOL_member,
+                    &Foo_OBJECT_member,
                     &Foo_NONE_member,
                     NULL
             };
@@ -526,6 +530,10 @@ class TestType(HPyTest):
             foo.BOOL_member = 1
         with pytest.raises(TypeError):
             del foo.BOOL_member
+
+        assert foo.OBJECT_member is ...
+        foo.OBJECT_member = 1
+        assert foo.OBJECT_member == 1
 
         assert foo.NONE_member is None
         with pytest.raises((SystemError, TypeError)):  # CPython quirk/bug

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -432,6 +432,8 @@ class TestType(HPyTest):
                 char ISTRING_member[6];
                 char BOOL_member;
                 HPyField OBJECT_member;
+                HPyField OBJECT_NULL_member;
+                HPyField OBJECT_EX_member;
             @TYPE_STRUCT_END
 
             HPyDef_SLOT(Foo_new, Foo_new_impl, HPy_tp_new)
@@ -451,6 +453,8 @@ class TestType(HPyTest):
                 strncpy(foo->ISTRING_member, "Hello", 6);
                 foo->BOOL_member = 0;
                 HPyField_Store(ctx, h_obj, &foo->OBJECT_member, ctx->h_Ellipsis);
+                foo->OBJECT_NULL_member = HPyField_NULL;
+                foo->OBJECT_EX_member = HPyField_NULL;
                 return h_obj;
             }
 
@@ -462,6 +466,8 @@ class TestType(HPyTest):
             HPyDef_MEMBER(Foo_ISTRING_member, "ISTRING_member", HPyMember_STRING_INPLACE, offsetof(FooObject, ISTRING_member))
             HPyDef_MEMBER(Foo_BOOL_member, "BOOL_member", HPyMember_BOOL, offsetof(FooObject, BOOL_member))
             HPyDef_MEMBER(Foo_OBJECT_member, "OBJECT_member", HPyMember_OBJECT, offsetof(FooObject, OBJECT_member))
+            HPyDef_MEMBER(Foo_OBJECT_NULL_member, "OBJECT_NULL_member", HPyMember_OBJECT, offsetof(FooObject, OBJECT_NULL_member))
+            HPyDef_MEMBER(Foo_OBJECT_EX_member, "OBJECT_EX_member", HPyMember_OBJECT_EX, offsetof(FooObject, OBJECT_EX_member))
             HPyDef_MEMBER(Foo_NONE_member, "NONE_member", HPyMember_NONE, offsetof(FooObject, FLOAT_member))
 
             static HPyDef *Foo_defines[] = {
@@ -474,6 +480,8 @@ class TestType(HPyTest):
                     &Foo_ISTRING_member,
                     &Foo_BOOL_member,
                     &Foo_OBJECT_member,
+                    &Foo_OBJECT_NULL_member,
+                    &Foo_OBJECT_EX_member,
                     &Foo_NONE_member,
                     NULL
             };
@@ -534,6 +542,15 @@ class TestType(HPyTest):
         assert foo.OBJECT_member is ...
         foo.OBJECT_member = 1
         assert foo.OBJECT_member == 1
+
+        assert foo.OBJECT_NULL_member is None
+        foo.OBJECT_NULL_member = 1
+        assert foo.OBJECT_NULL_member == 1
+
+        with pytest.raises(AttributeError):
+            foo.OBJECT_EX_member
+        foo.OBJECT_EX_member = 1
+        assert foo.OBJECT_EX_member == 1
 
         assert foo.NONE_member is None
         with pytest.raises((SystemError, TypeError)):  # CPython quirk/bug

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -546,11 +546,16 @@ class TestType(HPyTest):
         assert foo.OBJECT_NULL_member is None
         foo.OBJECT_NULL_member = 1
         assert foo.OBJECT_NULL_member == 1
+        del foo.OBJECT_NULL_member
+        assert foo.OBJECT_NULL_member is None
 
         with pytest.raises(AttributeError):
             foo.OBJECT_EX_member
         foo.OBJECT_EX_member = 1
         assert foo.OBJECT_EX_member == 1
+        del foo.OBJECT_EX_member
+        with pytest.raises(AttributeError):
+            foo.OBJECT_EX_member
 
         assert foo.NONE_member is None
         with pytest.raises((SystemError, TypeError)):  # CPython quirk/bug

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -569,6 +569,7 @@ class TestType(HPyTest):
                 char CHAR_member;
                 char ISTRING_member[6];
                 char BOOL_member;
+                HPyField OBJECT_member;
             @TYPE_STRUCT_END
 
             HPyDef_SLOT(Foo_new, Foo_new_impl, HPy_tp_new)
@@ -586,6 +587,7 @@ class TestType(HPyTest):
                 foo->CHAR_member = 'A';
                 strncpy(foo->ISTRING_member, "Hello", 6);
                 foo->BOOL_member = 0;
+                foo->OBJECT_member = HPyField_NULL;
                 return h_obj;
             }
 
@@ -595,6 +597,7 @@ class TestType(HPyTest):
             HPyDef_MEMBER(Foo_CHAR_member, "CHAR_member", HPyMember_CHAR, offsetof(FooObject, CHAR_member), .readonly=1)
             HPyDef_MEMBER(Foo_ISTRING_member, "ISTRING_member", HPyMember_STRING_INPLACE, offsetof(FooObject, ISTRING_member), .readonly=1)
             HPyDef_MEMBER(Foo_BOOL_member, "BOOL_member", HPyMember_BOOL, offsetof(FooObject, BOOL_member), .readonly=1)
+            HPyDef_MEMBER(Foo_OBJECT_member, "OBJECT_member", HPyMember_OBJECT, offsetof(FooObject, OBJECT_member), .readonly=1)
             HPyDef_MEMBER(Foo_NONE_member, "NONE_member", HPyMember_NONE, offsetof(FooObject, FLOAT_member), .readonly=1)
 
             static HPyDef *Foo_defines[] = {
@@ -605,6 +608,7 @@ class TestType(HPyTest):
                     &Foo_CHAR_member,
                     &Foo_ISTRING_member,
                     &Foo_BOOL_member,
+                    &Foo_OBJECT_member,
                     &Foo_NONE_member,
                     NULL
             };
@@ -654,6 +658,12 @@ class TestType(HPyTest):
             foo.BOOL_member = 1
         with pytest.raises(AttributeError):
             del foo.BOOL_member
+
+        assert foo.OBJECT_member is None
+        with pytest.raises(AttributeError):
+            foo.OBJECT_member = 1
+        with pytest.raises(AttributeError):
+            del foo.OBJECT_member
 
         assert foo.NONE_member is None
         with pytest.raises(AttributeError):

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -470,6 +470,16 @@ class TestType(HPyTest):
             HPyDef_MEMBER(Foo_OBJECT_EX_member, "OBJECT_EX_member", HPyMember_OBJECT_EX, offsetof(FooObject, OBJECT_EX_member))
             HPyDef_MEMBER(Foo_NONE_member, "NONE_member", HPyMember_NONE, offsetof(FooObject, FLOAT_member))
 
+            HPyDef_SLOT(Foo_traverse, Foo_traverse_impl, HPy_tp_traverse)
+            static int Foo_traverse_impl(void *self, HPyFunc_visitproc visit, void *arg)
+            {
+                FooObject *p = (FooObject *)self;
+                HPy_VISIT(&p->OBJECT_member);
+                HPy_VISIT(&p->OBJECT_NULL_member);
+                HPy_VISIT(&p->OBJECT_EX_member);
+                return 0;
+            }
+
             static HPyDef *Foo_defines[] = {
                     &Foo_new,
                     &Foo_FLOAT_member,
@@ -483,6 +493,7 @@ class TestType(HPyTest):
                     &Foo_OBJECT_NULL_member,
                     &Foo_OBJECT_EX_member,
                     &Foo_NONE_member,
+                    &Foo_traverse,
                     NULL
             };
 
@@ -608,6 +619,14 @@ class TestType(HPyTest):
             HPyDef_MEMBER(Foo_OBJECT_member, "OBJECT_member", HPyMember_OBJECT, offsetof(FooObject, OBJECT_member), .readonly=1)
             HPyDef_MEMBER(Foo_NONE_member, "NONE_member", HPyMember_NONE, offsetof(FooObject, FLOAT_member), .readonly=1)
 
+            HPyDef_SLOT(Foo_traverse, Foo_traverse_impl, HPy_tp_traverse)
+            static int Foo_traverse_impl(void *self, HPyFunc_visitproc visit, void *arg)
+            {
+                FooObject *p = (FooObject *)self;
+                HPy_VISIT(&p->OBJECT_member);
+                return 0;
+            }
+
             static HPyDef *Foo_defines[] = {
                     &Foo_new,
                     &Foo_FLOAT_member,
@@ -618,6 +637,7 @@ class TestType(HPyTest):
                     &Foo_BOOL_member,
                     &Foo_OBJECT_member,
                     &Foo_NONE_member,
+                    &Foo_traverse,
                     NULL
             };
 

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -452,7 +452,7 @@ class TestType(HPyTest):
                 foo->CHAR_member = 'A';
                 strncpy(foo->ISTRING_member, "Hello", 6);
                 foo->BOOL_member = 0;
-                HPyField_Store(ctx, h_obj, &foo->OBJECT_member, ctx->h_Ellipsis);
+                HPyField_Store(ctx, h_obj, &foo->OBJECT_member, ctx->h_NotImplemented);
                 foo->OBJECT_NULL_member = HPyField_NULL;
                 foo->OBJECT_EX_member = HPyField_NULL;
                 return h_obj;
@@ -550,7 +550,7 @@ class TestType(HPyTest):
         with pytest.raises(TypeError):
             del foo.BOOL_member
 
-        assert foo.OBJECT_member is ...
+        assert foo.OBJECT_member is NotImplemented
         foo.OBJECT_member = 1
         assert foo.OBJECT_member == 1
 
@@ -560,10 +560,7 @@ class TestType(HPyTest):
         del foo.OBJECT_NULL_member
         assert foo.OBJECT_NULL_member is None
 
-        with pytest.raises(
-                AttributeError,
-                match="'mytest.Foo' object has no attribute 'OBJECT_EX_member'"
-        ):
+        with pytest.raises(AttributeError, match="OBJECT_EX_member"):
             foo.OBJECT_EX_member
         foo.OBJECT_EX_member = 1
         assert foo.OBJECT_EX_member == 1

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -549,7 +549,10 @@ class TestType(HPyTest):
         del foo.OBJECT_NULL_member
         assert foo.OBJECT_NULL_member is None
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+                AttributeError,
+                match="'mytest.Foo' object has no attribute 'OBJECT_EX_member'"
+        ):
             foo.OBJECT_EX_member
         foo.OBJECT_EX_member = 1
         assert foo.OBJECT_EX_member == 1


### PR DESCRIPTION
We already define `HPyMember_OBJECT`, but using it in
```c
HPyDef_MEMBER(Foo_OBJECT_member, "OBJECT_member", HPyMember_OBJECT, offsetof(FooObject, OBJECT_member))
```
fails in universal mode, as the included test demonstrates, since the embedded member must an `HPyField` in this mode. This should work, since it's annoying to have to define getters/setters manually here.