### PR TITLE
Default to "python3" instead of "python" to run Python.

### DIFF
--- a/proof-of-concept/test_pof.sh
+++ b/proof-of-concept/test_pof.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -e
 ROOT=`pwd` # we expect this script to be run from the repo root
-if [ -z ${PYTHON+x} ]; then
-  # Allow the caller to override the Python runtime used
-  PYTHON=python
-fi
+
+# Allow the caller to override the Python runtime used
+PYTHON=${PYTHON:-python3}
 
 _install_hpy() {
     echo "Installing hpy"


### PR DESCRIPTION
"python" is often non-existant or points to Python 2.