### PR TITLE
[RFC] [WIP] Multi-phase module initialization

### DIFF
--- a/hpy/debug/src/_debugmod.c
+++ b/hpy/debug/src/_debugmod.c
@@ -387,17 +387,13 @@ static HPyModuleDef moduledef = {
 };
 
 
-HPy_MODINIT(_debug)
-static UHPy init__debug_impl(HPyContext *uctx)
+HPy_MODINIT(_debug, moduledef, init_debug_module)
+static int init_debug_module(HPyContext *uctx, HPy m)
 {
-    UHPy m = HPyModule_Create(uctx, &moduledef);
-    if (HPy_IsNull(m))
-        return HPy_NULL;
-
     UHPy h_DebugHandleType = HPyType_FromSpec(uctx, &DebugHandleType_spec, NULL);
     if (HPy_IsNull(h_DebugHandleType))
-        return HPy_NULL;
+        return -1;
     HPy_SetAttr_s(uctx, m, "DebugHandle", h_DebugHandleType);
     HPy_Close(uctx, h_DebugHandleType);
-    return m;
+    return 0;
 }

--- a/hpy/debug/src/include/hpy_debug.h
+++ b/hpy/debug/src/include/hpy_debug.h
@@ -54,6 +54,9 @@ void hpy_debug_close_handle(HPyContext *dctx, HPy dh);
 extern "C"
 #endif
 Py_EXPORTED_SYMBOL
-HPy HPyInit__debug(HPyContext *uctx);
+int HPyExec__debug(HPyContext *uctx, HPy mod);
+
+Py_EXPORTED_SYMBOL
+HPyModuleDef *HPyModDefGet__debug();
 
 #endif /* HPY_DEBUG_H */

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -165,7 +165,7 @@ def __bootstrap__():
             print("Loading {module_name!r} in HPy universal mode with a debug context")
         else:
             print("Loading {module_name!r} in HPy universal mode")
-    m = load({module_name!r}, ext_filepath, debug=is_debug)
+    m = load({module_name!r}, ext_filepath, debug=is_debug, loader=modules[__name__])
     m.__file__ = ext_filepath
     m.__loader__ = __loader__
     m.__name__ = __name__
@@ -363,9 +363,8 @@ class build_ext_hpy_mixin:
         module_name = ext_file.split(".")[0]
         if not self.dry_run:
             with open(stub_file, 'w') as f:
-                f.write(_HPY_UNIVERSAL_MODULE_STUB_TEMPLATE.format(
-                    ext_file=ext_file, module_name=module_name)
-                )
+                contents = _HPY_UNIVERSAL_MODULE_STUB_TEMPLATE.format(ext_file=ext_file, module_name=module_name)
+                f.write(contents)
 
     def copy_extensions_to_source(self):
         """Override from setuptools 64.0.0 to copy our stub instead of recreating it."""

--- a/hpy/devel/include/hpy/hpymodule.h
+++ b/hpy/devel/include/hpy/hpymodule.h
@@ -32,13 +32,11 @@ typedef struct {
 #endif /* __cplusplus */
 
 
-#define GET_MACRO(exec_or_create_name, exec_name, NAME, ...) NAME
-#define HPy_MODINIT(modname, ...) GET_MACRO(__VA_ARGS__, HPy_MODINIT_CREATE_EXEC, HPy_MODINIT_EXEC)(modname, __VA_ARGS__)
 
 #ifdef HPY_UNIVERSAL_ABI
 
 // module initialization in the universal case
-#define HPy_MODINIT(modname, exec_or_create_name, ...)         \
+#define HPy_MODINIT(modname)                                    \
     _HPy_HIDDEN HPyContext *_ctx_for_trampolines;              \
     static HPy init_##modname##_impl(HPyContext *ctx);         \
     HPyMODINIT_FUNC                                            \
@@ -50,26 +48,37 @@ typedef struct {
 
 #else // HPY_UNIVERSAL_ABI
 
-// module initialization in the CPython case
-#define HPy_MODINIT_EXEC(moddef, exec_name)     \
-    PyModuleDef *create_module_def(HPyModuleDef *hpydef, void *create_func, void *exec_func); \
-    static _hpy_##modname##_create_func(HPyContext *ctx, HPy *s, HPyModuleDef *d) \
-    {                                                                   \
-        return _py2h(PyModule_FromDefAndSpec(                           \
-                         create_module_def(&moddef),                    \
-                         _h2py(s)                                       \
-               ));                                                      \
-    }                                                                   \
-    HPy_MODINIT_CREATE_EXEC(moddef, _hpy_##modname##_create_func, exec_name)
+#define GET_MACRO(exec_or_create_name, exec_name, NAME, ...) NAME
+#define HPy_MODINIT(modname, moddef, ...) GET_MACRO(__VA_ARGS__, HPy_MODINIT_CREATE_EXEC, HPy_MODINIT_EXEC)(modname, moddef, __VA_ARGS__)
 
-#define HPy_MODINIT_CREATE_EXEC(moddef, create_name, exec_name)         \
-    PyModuleDef *create_module_def(HPyModuleDef *hpydef, void *create_func, void *exec_func); \
-    static HPy create_name(HPyContext *ctx, HPy spec, HPyModuleDef *def); \
+// module initialization in the CPython case
+// Note: create_module_def is an internal helper from ctx_module.c
+
+#define HPy_MODINIT_CREATE_EXEC(modname, moddef, create_name, exec_name)         \
+    PyModuleDef *create_module_def(HPyModuleDef *hpydef,                         \
+                                   void *create_func, void *exec_func);          \
+    static HPy create_name(HPyContext *ctx, HPy spec, HPyModuleDef *def);        \
+    static int exec_name(HPyContext *ctx, HPy module);                           \
+    static PyObject* _hpy_py_##modname##_create_func(PyObject *s, PyModuleDef *d)\
+    {                                                                            \
+        return _h2py(create_name(_HPyGetContext(), _py2h(s), &moddef));          \
+    }                                                                            \
+    static int _hpy_py_##modname##_exec_func(PyObject *mod)                      \
+    {                                                                            \
+        return exec_name(_HPyGetContext(), _py2h(mod));                          \
+    }                                                                            \
+    PyMODINIT_FUNC                                                               \
+    PyInit_##modname(void)                                                       \
+    {                                                                            \
+        return PyModuleDef_Init(create_module_def(&moddef,                       \
+                      _hpy_py_##modname##_create_func,                           \
+                      _hpy_py_##modname##_exec_func));                           \
+    }
+
+#define HPy_MODINIT_EXEC(modname, moddef, exec_name)                    \
+    PyModuleDef *create_module_def(HPyModuleDef *hpydef,                \
+                                   void *create_func, void *exec_func); \
     static int exec_name(HPyContext *ctx, HPy module);                  \
-    static PyObject* _hpy_py_##modname##_create_func(PyObject *s, PyModuleDef *d) \
-    {                                                                   \
-        return _h2py(create_name(_HPyGetContext(), _py2h(s), (HPyModuleDef*)d)); \
-    }                                                                   \
     static int _hpy_py_##modname##_exec_func(PyObject *mod)             \
     {                                                                   \
         return exec_name(_HPyGetContext(), _py2h(mod));                 \
@@ -77,7 +86,8 @@ typedef struct {
     PyMODINIT_FUNC                                                      \
     PyInit_##modname(void)                                              \
     {                                                                   \
-        return PyModuleDef_Init(create_module_def(&moddef, _hpy_py_##modname##_create_func, _hpy_py_##modname##_exec_func)); \
+        return PyModuleDef_Init(create_module_def(&moddef, NULL,        \
+                  _hpy_py_##modname##_exec_func));                      \
     }
 
 #endif // HPY_UNIVERSAL_ABI

--- a/hpy/devel/include/hpy/hpymodule.h
+++ b/hpy/devel/include/hpy/hpymodule.h
@@ -31,14 +31,18 @@ typedef struct {
 #  define HPyMODINIT_FUNC Py_EXPORTED_SYMBOL HPy
 #endif /* __cplusplus */
 
+
+#define GET_MACRO(exec_or_create_name, exec_name, NAME, ...) NAME
+#define HPy_MODINIT(modname, ...) GET_MACRO(__VA_ARGS__, HPy_MODINIT_CREATE_EXEC, HPy_MODINIT_EXEC)(modname, __VA_ARGS__)
+
 #ifdef HPY_UNIVERSAL_ABI
 
 // module initialization in the universal case
-#define HPy_MODINIT(modname)                                   \
+#define HPy_MODINIT(modname, exec_or_create_name, ...)         \
     _HPy_HIDDEN HPyContext *_ctx_for_trampolines;              \
     static HPy init_##modname##_impl(HPyContext *ctx);         \
-    HPyMODINIT_FUNC                                         \
-    HPyInit_##modname(HPyContext *ctx)                     \
+    HPyMODINIT_FUNC                                            \
+    HPyInit_##modname(HPyContext *ctx)                         \
     {                                                          \
         _ctx_for_trampolines = ctx;                            \
         return init_##modname##_impl(ctx);                     \
@@ -47,12 +51,33 @@ typedef struct {
 #else // HPY_UNIVERSAL_ABI
 
 // module initialization in the CPython case
-#define HPy_MODINIT(modname)                                   \
-    static HPy init_##modname##_impl(HPyContext *ctx);         \
-    PyMODINIT_FUNC                                             \
-    PyInit_##modname(void)                                     \
-    {                                                          \
-        return _h2py(init_##modname##_impl(_HPyGetContext())); \
+#define HPy_MODINIT_EXEC(moddef, exec_name)     \
+    PyModuleDef *create_module_def(HPyModuleDef *hpydef, void *create_func, void *exec_func); \
+    static _hpy_##modname##_create_func(HPyContext *ctx, HPy *s, HPyModuleDef *d) \
+    {                                                                   \
+        return _py2h(PyModule_FromDefAndSpec(                           \
+                         create_module_def(&moddef),                    \
+                         _h2py(s)                                       \
+               ));                                                      \
+    }                                                                   \
+    HPy_MODINIT_CREATE_EXEC(moddef, _hpy_##modname##_create_func, exec_name)
+
+#define HPy_MODINIT_CREATE_EXEC(moddef, create_name, exec_name)         \
+    PyModuleDef *create_module_def(HPyModuleDef *hpydef, void *create_func, void *exec_func); \
+    static HPy create_name(HPyContext *ctx, HPy spec, HPyModuleDef *def); \
+    static int exec_name(HPyContext *ctx, HPy module);                  \
+    static PyObject* _hpy_py_##modname##_create_func(PyObject *s, PyModuleDef *d) \
+    {                                                                   \
+        return _h2py(create_name(_HPyGetContext(), _py2h(s), (HPyModuleDef*)d)); \
+    }                                                                   \
+    static int _hpy_py_##modname##_exec_func(PyObject *mod)             \
+    {                                                                   \
+        return exec_name(_HPyGetContext(), _py2h(mod));                 \
+    }                                                                   \
+    PyMODINIT_FUNC                                                      \
+    PyInit_##modname(void)                                              \
+    {                                                                   \
+        return PyModuleDef_Init(create_module_def(&moddef, _hpy_py_##modname##_create_func, _hpy_py_##modname##_exec_func)); \
     }
 
 #endif // HPY_UNIVERSAL_ABI

--- a/hpy/devel/src/runtime/ctx_module.c
+++ b/hpy/devel/src/runtime/ctx_module.c
@@ -11,28 +11,46 @@ static PyModuleDef empty_moduledef = {
     PyModuleDef_HEAD_INIT
 };
 
-_HPy_HIDDEN HPy
-ctx_Module_Create(HPyContext *ctx, HPyModuleDef *hpydef)
+_HPy_HIDDEN PyModuleDef *create_module_def(HPyModuleDef *hpydef, void *create_func, void *exec_func)
 {
-    // create a new PyModuleDef
-
     // we can't free this memory because it is stitched into moduleobject. We
     // just make it immortal for now, eventually we should think whether or
     // not to free it if/when we unload the module
     PyModuleDef *def = (PyModuleDef*)PyMem_Malloc(sizeof(PyModuleDef));
     if (def == NULL) {
         PyErr_NoMemory();
-        return HPy_NULL;
+        return NULL;
     }
     memcpy(def, &empty_moduledef, sizeof(PyModuleDef));
     def->m_name = hpydef->name;
     def->m_doc = hpydef->doc;
     def->m_size = hpydef->size;
+    PyModuleDef_Slot slots[] = {
+        {0, NULL},
+        {0, NULL},
+        {0, NULL},
+    };
+    int slotidx = 0;
+    if (create_func) {
+        slots[slotidx++] = (PyModuleDef_Slot){Py_mod_create, create_func};
+    }
+    if (exec_func) {
+        slots[slotidx++] = (PyModuleDef_Slot){Py_mod_exec, exec_func};
+    }
+    def->m_slots = slots;
     def->m_methods = create_method_defs(hpydef->defines, hpydef->legacy_methods);
     if (def->m_methods == NULL) {
         PyMem_Free(def);
-        return HPy_NULL;
+        return NULL;
     }
+    return def;
+}
+
+_HPy_HIDDEN HPy
+ctx_Module_Create(HPyContext *ctx, HPyModuleDef *hpydef)
+{
+    // create a new PyModuleDef
+    PyModuleDef *def = create_module_def(hpydef, NULL, NULL);
     PyObject *result = PyModule_Create(def);
     return _py2h(result);
 }

--- a/test/test_hpymodule.py
+++ b/test/test_hpymodule.py
@@ -27,14 +27,9 @@ class TestModule(HPyTest):
 
     def test_HPyModule_ModuleInit_with_exec(self):
         mod = self.make_module("""
-        static HPyDef *moduledefs[] = {
-            NULL
-        };
-
         static HPyModuleDef moduledef = {
             .name = "mytest",
-            .doc = "some test for hpy",
-            .defines = moduledefs,
+            .doc = "some test for hpy"
         };
 
         HPy_MODINIT(mytest, moduledef, exec_foo)


### PR DESCRIPTION
* HPy uses multi-phase module initialization internally on CPython
* HPy interface to module initialization follows the CPython multi-phase module initialization interface, the previous way of initializing HPy modules is removed
* Please do not focus on the implementation too much, I'll polish it, but we need to agree on the interface

Examples:
```
// Previously:

HPy_MODINIT(my_module)
static HPy init_my_module_impl(HPyContext *ctx)
{
    HPy m = HPyModule_Create(ctx, &moduledef);
    if (HPy_IsNull(m))
        return HPy_NULL;
    // ... add types etc. to m
}

// Now:

HPy_MODINIT(my_module, moduledef, init_module)
static int init_module(HPyContext *ctx, HPy module) {
    // add types, etc. to module
}

// Optionally one can specify "create" slot for the module

HPy_MODINIT(my_module, moduledef, create_module, init_module)
static HPy create_module(HPyContext *ctx, HPy loader_spec, HPyModuleDef *def) {
    // Do something useful according to the loader_spec, use different HPyModuleDef, ...
    HPy m = HPyModule_Create(ctx, &moduledef);
    if (HPy_IsNull(m))
        return HPy_NULL;
    return m;      
}

static int init_module(HPyContext *ctx, HPy module) {
    // add types, etc. to module
}
```

Open issues:
* we need to duplicate the module name in `HPyModuleDef` and as a parameter of the `HPy_MODINIT` macro :(

After we are happy with the API, I'll update other tests, examples and documentation. For now, only the newly added tests work (in all three modes: cpython, universal, debug).