### PR TITLE
Add HPy ABI version in the ABI and check it when loading a module

### DIFF
--- a/hpy/devel/include/hpy.h
+++ b/hpy/devel/include/hpy.h
@@ -6,7 +6,15 @@ extern "C" {
 
 /* ~~~~~~~~~~~~~~~~ HPy ABI version ~~~~~~~~~~~~~~~ */
 // NOTE: these must be kept on sync with the equivalent variables in hpy/devel/abitag.py
+/**
+ * The ABI version.
+ *
+ * Minor version N+1 is binary compatible to minor version N. Major versions
+ * are not binary compatible (note: HPy can run several binary incompatible
+ * versions in one process).
+ */
 #define HPY_ABI_VERSION 0
+#define HPY_ABI_VERSION_MINOR 0
 #define HPY_ABI_TAG "hpy0"
 
 

--- a/hpy/devel/include/hpy/hpymodule.h
+++ b/hpy/devel/include/hpy/hpymodule.h
@@ -40,25 +40,29 @@ typedef struct {
 #ifdef HPY_ABI_CPYTHON
 
 // module initialization in the CPython case
-#define HPy_MODINIT(modname)                                   \
-    static HPy init_##modname##_impl(HPyContext *ctx);         \
-    PyMODINIT_FUNC                                             \
-    PyInit_##modname(void)                                     \
-    {                                                          \
-        return _h2py(init_##modname##_impl(_HPyGetContext())); \
+#define HPy_MODINIT(modname)                                      \
+    static HPy init_##modname##_impl(HPyContext *ctx);            \
+    PyMODINIT_FUNC                                                \
+    PyInit_##modname(void)                                        \
+    {                                                             \
+        return _h2py(init_##modname##_impl(_HPyGetContext()));    \
     }
 
 #else // HPY_ABI_CPYTHON
 
 // module initialization in the universal and hybrid case
-#define HPy_MODINIT(modname)                                   \
-    _HPy_CTX_MODIFIER HPyContext *_ctx_for_trampolines;        \
-    static HPy init_##modname##_impl(HPyContext *ctx);         \
-    HPyMODINIT_FUNC                                            \
-    HPyInit_##modname(HPyContext *ctx)                         \
-    {                                                          \
-        _ctx_for_trampolines = ctx;                            \
-        return init_##modname##_impl(ctx);                     \
+#define HPy_MODINIT(modname)                                      \
+    HPy_EXPORTED_SYMBOL uint32_t                                  \
+    required_hpy_major_version_##modname = HPY_ABI_VERSION;       \
+    HPy_EXPORTED_SYMBOL uint32_t                                  \
+    required_hpy_minor_version_##modname = HPY_ABI_VERSION_MINOR; \
+    _HPy_CTX_MODIFIER HPyContext *_ctx_for_trampolines;           \
+    static HPy init_##modname##_impl(HPyContext *ctx);            \
+    HPyMODINIT_FUNC                                               \
+    HPyInit_##modname(HPyContext *ctx)                            \
+    {                                                             \
+        _ctx_for_trampolines = ctx;                               \
+        return init_##modname##_impl(ctx);                        \
     }
 
 #endif // HPY_ABI_CPYTHON


### PR DESCRIPTION
Fixes #374 

The loader now looks up two new symbols when loading an extension ([link to the code](https://github.com/hpyproject/hpy/pull/356#discussion_r1036943570)):
* `required_hpy_major_version_##modname`
* `required_hpy_minor_version_##modname`

These capture the HPy ABI versions of the HPy that was used to compile the module. The HPy that is loading the module is going to check them and:
* create the right version/layout of `HPyContext` for the ABI major version or fail if given major version is not supported
* check that it can support the requested minor version

The idea is that major ABI versions have different layout/semantics. Minor ABI versions are only ABI compatible additions at the end of the `HPyContext` structure (and other structures that are part of the ABI). The changes in major versions are not expected for now, but this makes the ABI future proof for forward compatibility. 

This feature duplicates the ABI version tag added in https://github.com/hpyproject/hpy/pull/371

Note: the ABI version is not meant to be used by humans. I suggest we still use `HPY_VERSION` macro that provides human friendly version. Maybe we can/should enforce some consistency between the two.