### PR TITLE
Add dump mode to HPy tests.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from .support import ExtensionCompiler, DefaultExtensionTemplate,\
     PythonSubprocessRunner, HPyDebugCapture
 from hpy.debug.leakdetector import LeakDetector
+from pathlib import Path
 
 IS_VALGRIND_RUN = False
 
@@ -11,8 +12,13 @@ def pytest_addoption(parser):
         help="Print to stdout the commands used to invoke the compiler")
     parser.addoption(
         "--subprocess-v", action="store_true",
-        help="Print to stdout the stdout and stderr of Python subprocesses"
+        help="Print to stdout the stdout and stderr of Python subprocesses "
              "executed via run_python_subprocess")
+    parser.addoption(
+        "--dump-dir",
+        help="Enables dump mode and specifies where to write generated test "
+             "sources. This will then only generate the sources and skip "
+             "evaluation of the tests.")
 
 
 @pytest.hookimpl(trylast=True)
@@ -45,8 +51,21 @@ def ExtensionTemplate():
 @pytest.fixture
 def compiler(request, tmpdir, hpy_devel, hpy_abi, ExtensionTemplate):
     compiler_verbose = request.config.getoption('--compiler-v')
+    dump_dir = request.config.getoption('--dump-dir')
+    if dump_dir:
+        # Test-specific dump dir in format: dump_dir/[mod_][cls_]func
+        qname_parts = []
+        if request.module:
+            qname_parts.append(request.module.__name__)
+        if request.cls:
+            qname_parts.append(request.cls.__name__)
+        qname_parts.append(request.function.__name__)
+        test_dump_dir = "_".join(qname_parts).replace(".", "_")
+        dump_dir = Path(dump_dir).joinpath(test_dump_dir)
+        dump_dir.mkdir(parents=True, exist_ok=True)
     return ExtensionCompiler(tmpdir, hpy_devel, hpy_abi,
                              compiler_verbose=compiler_verbose,
+                             dump_dir=dump_dir,
                              ExtensionTemplate=ExtensionTemplate)
 
 

--- a/test/test_support.py
+++ b/test/test_support.py
@@ -1,4 +1,12 @@
+import pytest
+from pathlib import Path
 from . import support
+
+
+@pytest.fixture
+def hpy_abi():
+    return "universal"
+
 
 def expand_template(template, name):
     return support.DefaultExtensionTemplate(template, name).expand()
@@ -26,3 +34,22 @@ def test_expand_template():
 some more C stuff
 {init_code}
 """.rstrip()
+
+
+TEST_DIR = Path(__file__).parent
+
+
+def test_source_dump(tmpdir):
+    import pytest
+    test_file = 'test_00_basic'
+    parts = ['TestBasic', 'test_noop_function']
+    rc = pytest.main(['--dump-dir=' + str(tmpdir), '::'.join([str(TEST_DIR.joinpath(test_file + ".py"))] + parts)])
+    assert rc == 0
+    expected_dir = '_'.join([test_file] + parts)
+    print("expected_dir = " + expected_dir)
+    test_dump_dir = None
+    for child in Path(tmpdir).iterdir():
+        if expected_dir in str(child):
+            test_dump_dir = Path(child)
+    assert test_dump_dir and test_dump_dir.exists()
+    assert test_dump_dir.joinpath('mytest.c').exists()


### PR DESCRIPTION
We've discussed that we could create examples out of HPy's unit tests.
Since I'm usually looking at tests if I don't exactly remember how to do things in HPy, I found it is time to have that feature.

How does it work:
You just need to specify `--dump-dir=<dir>` like this:
```
hpyproject/hpy$ python3 -m pytest --dump-dir=test_sources test/
```
This will write all test sources passed to the compiler (in particular, to function `test.support.compile_module`) and then skip the test.
This mode will create one folder per test function (since a test function may have several sources).
I plan to automatically add the generated test sources also to the docs as examples but I'll do that in a separate step.