### PR TITLE
Use CPython FASTCALL to optimise hpy function call

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -288,10 +288,10 @@ which adds two integers:
 There are a few things to note:
 
   * The C signature is different than the corresponding ``Python.h``
-    ``METH_VARARGS``: in particular, instead of taking a ``PyObject *args``,
-    we take an array of ``HPy`` and its size.  This allows e.g. PyPy to do a
-    call more efficiently, because you don't need to create a tuple just to
-    pass the arguments.
+    ``METH_VARARGS``: in particular, instead of taking a tuple ``PyObject *args``,
+    we take an array of ``HPy`` and its size. This allows the call to happen
+    more efficiently, because you don't need to create a tuple just to pass the
+    arguments.
 
   * We call ``HPyArg_Parse`` to parse the arguments. Contrarily to almost all
     the other HPy functions, this is **not** a thin wrapper around

--- a/hpy/debug/src/debug_ctx_cpython.c
+++ b/hpy/debug/src/debug_ctx_cpython.c
@@ -100,14 +100,13 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
         HPyFunc_varargs f = (HPyFunc_varargs)func;
         _HPyFunc_args_VARARGS *a = (_HPyFunc_args_VARARGS*)args;
         DHPy dh_self = _py2dh(dctx, a->self);
-        Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-        DHPy *dh_args = (DHPy *)alloca(nargs * sizeof(DHPy));
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            dh_args[i] = _py2dh(dctx, PyTuple_GET_ITEM(a->args, i));
+        DHPy *dh_args = (DHPy *)alloca(a->nargs * sizeof(DHPy));
+        for (HPy_ssize_t i = 0; i < a->nargs; i++) {
+            dh_args[i] = _py2dh(dctx, a->args[i]);
         }
-        DHPy dh_result = f(dctx, dh_self, dh_args, nargs);
+        DHPy dh_result = f(dctx, dh_self, dh_args, a->nargs);
         DHPy_close_and_check(dctx, dh_self);
-        for (Py_ssize_t i = 0; i < nargs; i++) {
+        for (HPy_ssize_t i = 0; i < a->nargs; i++) {
             DHPy_close_and_check(dctx, dh_args[i]);
         }
         a->result = _dh2py(dctx, dh_result);

--- a/hpy/devel/include/hpy/cpy_types.h
+++ b/hpy/devel/include/hpy/cpy_types.h
@@ -36,12 +36,10 @@ typedef Py_buffer cpy_Py_buffer;
 #endif /* HPY_ABI_UNIVERSAL */
 
 
-typedef cpy_PyObject *(*cpy_PyCFunction)(cpy_PyObject *, cpy_PyObject *);
+typedef cpy_PyObject *(*cpy_PyCFunction)(cpy_PyObject *, cpy_PyObject *const *, HPy_ssize_t);
 typedef int (*cpy_visitproc)(cpy_PyObject *, void *);
-typedef cpy_PyObject *(*cpy_PyCFunction)(cpy_PyObject *, cpy_PyObject *);
 typedef cpy_PyObject *(*cpy_getter)(cpy_PyObject *, void *);
 typedef int (*cpy_setter)(cpy_PyObject *, cpy_PyObject *, void *);
 typedef void (*cpy_PyCapsule_Destructor)(cpy_PyObject *);
-
 
 #endif /* HPY_UNIVERSAL_CPY_TYPES_H */

--- a/hpy/devel/include/hpy/cpython/hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/cpython/hpyfunc_trampolines.h
@@ -23,15 +23,11 @@ typedef HPy (*_HPyCFunction_O)(HPyContext*, HPy, HPy);
 typedef HPy (*_HPyCFunction_VARARGS)(HPyContext*, HPy, HPy *, HPy_ssize_t);
 #define _HPyFunc_TRAMPOLINE_HPyFunc_VARARGS(SYM, IMPL)                  \
     static PyObject*                                                    \
-    SYM(PyObject *self, PyObject *args)                                 \
+    SYM(PyObject *self, PyObject *const *args, Py_ssize_t nargs)        \
     {                                                                   \
-        /* get the tuple elements as an array of "PyObject *", which */ \
-        /* is equivalent to an array of "HPy" with enough casting... */ \
-        HPy *items = (HPy *)&PyTuple_GET_ITEM(args, 0);                 \
-        Py_ssize_t nargs = PyTuple_GET_SIZE(args);                      \
         _HPyCFunction_VARARGS func = (_HPyCFunction_VARARGS)IMPL; \
         return _h2py(func(_HPyGetContext(),                             \
-                                 _py2h(self), items, nargs));           \
+                                 _py2h(self), (HPy *)args, nargs));     \
     }
 
 typedef HPy (*_HPyCFunction_KEYWORDS)(HPyContext*, HPy, HPy *, HPy_ssize_t, HPy);

--- a/hpy/devel/include/hpy/universal/hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/universal/hpyfunc_trampolines.h
@@ -16,7 +16,8 @@ typedef struct {
 
 typedef struct {
     cpy_PyObject *self;
-    cpy_PyObject *args;
+    cpy_PyObject *const *args;
+    HPy_ssize_t nargs;
     cpy_PyObject *result;
 } _HPyFunc_args_VARARGS;
 
@@ -65,9 +66,9 @@ typedef struct {
 
 #define _HPyFunc_TRAMPOLINE_HPyFunc_VARARGS(SYM, IMPL)                  \
     static cpy_PyObject *                                               \
-    SYM(cpy_PyObject *self, cpy_PyObject *args)                         \
+    SYM(cpy_PyObject *self, cpy_PyObject *const *args, HPy_ssize_t nargs)\
     {                                                                   \
-        _HPyFunc_args_VARARGS a = { self, args };                       \
+        _HPyFunc_args_VARARGS a = { self, args, nargs };                \
         _HPy_CallRealFunctionFromTrampoline(                            \
             _ctx_for_trampolines, HPyFunc_VARARGS, (HPyCFunction)IMPL, &a);           \
         return a.result;                                                \

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -236,7 +236,7 @@ static int
 sig2flags(HPyFunc_Signature sig)
 {
     switch(sig) {
-        case HPyFunc_VARARGS:  return METH_VARARGS;
+        case HPyFunc_VARARGS:  return METH_FASTCALL;
         case HPyFunc_KEYWORDS: return METH_VARARGS | METH_KEYWORDS;
         case HPyFunc_NOARGS:   return METH_NOARGS;
         case HPyFunc_O:        return METH_O;
@@ -349,7 +349,7 @@ create_method_defs(HPyDef *hpydefs[], PyMethodDef *legacy_methods)
                 continue;
             PyMethodDef *dst = &result[dst_idx++];
             dst->ml_name = src->meth.name;
-            dst->ml_meth = src->meth.cpy_trampoline;
+            dst->ml_meth = (PyCFunction)src->meth.cpy_trampoline;
             dst->ml_flags = sig2flags(src->meth.signature);
             if (dst->ml_flags == -1) {
                 PyMem_Free(result);

--- a/hpy/universal/src/ctx_meth.c
+++ b/hpy/universal/src/ctx_meth.c
@@ -53,12 +53,11 @@ ctx_CallRealFunctionFromTrampoline(HPyContext *ctx, HPyFunc_Signature sig,
     case HPyFunc_VARARGS: {
         HPyFunc_varargs f = (HPyFunc_varargs)func;
         _HPyFunc_args_VARARGS *a = (_HPyFunc_args_VARARGS*)args;
-        Py_ssize_t nargs = PyTuple_GET_SIZE(a->args);
-        HPy *h_args = (HPy *)alloca(nargs * sizeof(HPy));
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            h_args[i] = _py2h(PyTuple_GET_ITEM(a->args, i));
+        HPy *h_args = (HPy *)alloca(a->nargs * sizeof(HPy));
+        for (HPy_ssize_t i = 0; i < a->nargs; i++) {
+            h_args[i] = _py2h(a->args[i]);
         }
-        a->result = _h2py(f(ctx, _py2h(a->self), h_args, nargs));
+        a->result = _h2py(f(ctx, _py2h(a->self), h_args, a->nargs));
         return;
     }
     case HPyFunc_KEYWORDS: {


### PR DESCRIPTION
Hello!
I'm new to the project and just want to experiment with using FASTCALL internally when HPy is running under cpython. In my understanding, this should give a decent performance boost while calling functions implemented in HPy from the python end, especially for short-running functions called many times the internal tuple creation overhead is not very negligible.

Currently I've only implemented `FASTCALL` for `VARARGS` and not `KEYWORDS` since the former is comparatively easier. The latter is not technically impossible, but would need larger changes (The main issue here is that HPy takes in the keywords as a dict, while python FASTCALL with KEYWORDS gives a tuple of keyword names, and the actual arguments still come via the first argument)

This PR should probably be postponed to when HPy drops CPython 3.6 support, because FASTCALL was an internal CPython implementation detail back then and not public API