### PR TITLE
Improve API/implementation for HPyCapsule_Destructor

### DIFF
--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -150,7 +150,7 @@ DHPy debug_ctx_Dict_New(HPyContext *dctx);
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Tuple_FromArray(HPyContext *dctx, DHPy items[], HPy_ssize_t n);
 DHPy debug_ctx_Import_ImportModule(HPyContext *dctx, const char *name);
-DHPy debug_ctx_Capsule_New(HPyContext *dctx, void *pointer, const char *name, HPyCapsule_Destructor destructor);
+DHPy debug_ctx_Capsule_New(HPyContext *dctx, void *pointer, const char *name, HPyCapsule_Destructor *destructor);
 void *debug_ctx_Capsule_Get(HPyContext *dctx, DHPy capsule, _HPyCapsule_key key, const char *name);
 int debug_ctx_Capsule_IsValid(HPyContext *dctx, DHPy capsule, const char *name);
 int debug_ctx_Capsule_Set(HPyContext *dctx, DHPy capsule, _HPyCapsule_key key, void *value);

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -647,7 +647,7 @@ DHPy debug_ctx_Import_ImportModule(HPyContext *dctx, const char *name)
     return DHPy_open(dctx, HPyImport_ImportModule(get_info(dctx)->uctx, name));
 }
 
-DHPy debug_ctx_Capsule_New(HPyContext *dctx, void *pointer, const char *name, HPyCapsule_Destructor destructor)
+DHPy debug_ctx_Capsule_New(HPyContext *dctx, void *pointer, const char *name, HPyCapsule_Destructor *destructor)
 {
     return DHPy_open(dctx, HPyCapsule_New(get_info(dctx)->uctx, pointer, name, destructor));
 }

--- a/hpy/debug/src/debug_ctx_cpython.c
+++ b/hpy/debug/src/debug_ctx_cpython.c
@@ -186,6 +186,14 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
                                                       a->visit, a->arg);
         return;
     }
+    case HPyFunc_CAPSULE_DESTRUCTOR: {
+        HPyFunc_Capsule_Destructor f = (HPyFunc_Capsule_Destructor)func;
+        PyObject *capsule = (PyObject *)args;
+        const char *name = PyCapsule_GetName(capsule);
+        f(name, PyCapsule_GetPointer(capsule, name),
+                PyCapsule_GetContext(capsule));
+        return;
+    }
 #include "autogen_debug_ctx_call.i"
     default:
         Py_FatalError("Unsupported HPyFunc_Signature in debug_ctx_cpython.c");

--- a/hpy/devel/include/hpy.h
+++ b/hpy/devel/include/hpy.h
@@ -156,8 +156,6 @@ typedef struct _HPyContext_s HPyContext;
     typedef Py_UCS4 HPy_UCS4;
 #endif
 
-typedef void (*HPyCapsule_Destructor)(const char *name, void *pointer, void *context);
-
 
 /* ~~~~~~~~~~~~~~~~ Additional #includes ~~~~~~~~~~~~~~~~ */
 

--- a/hpy/devel/include/hpy/cpy_types.h
+++ b/hpy/devel/include/hpy/cpy_types.h
@@ -14,6 +14,7 @@ typedef int (*cpy_visitproc)(cpy_PyObject *, void *);
 typedef cpy_PyObject *(*cpy_PyCFunction)(cpy_PyObject *, cpy_PyObject *);
 typedef cpy_PyObject *(*cpy_getter)(cpy_PyObject *, void *);
 typedef int (*cpy_setter)(cpy_PyObject *, cpy_PyObject *, void *);
+typedef void (*cpy_PyCapsule_Destructor)(cpy_PyObject *);
 
 
 #endif /* HPY_UNIVERSAL_CPY_TYPES_H */

--- a/hpy/devel/include/hpy/cpython/hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/cpython/hpyfunc_trampolines.h
@@ -107,4 +107,12 @@ typedef int (*_HPyCFunction_RELEASEBUFFERPROC)(HPyContext *, HPy, HPy_buffer *);
                                                  visit, arg);           \
     }
 
+#define HPyCapsule_DESTRUCTOR_TRAMPOLINE(SYM, IMPL)                            \
+    static void SYM(PyObject *capsule)                                         \
+    {                                                                          \
+        const char *name = PyCapsule_GetName(capsule);                         \
+        IMPL(name, PyCapsule_GetPointer(capsule, name),                        \
+                PyCapsule_GetContext(capsule));                                \
+    }
+
 #endif // HPY_CPYTHON_HPYFUNC_TRAMPOLINES_H

--- a/hpy/devel/include/hpy/cpython/misc.h
+++ b/hpy/devel/include/hpy/cpython/misc.h
@@ -384,7 +384,7 @@ HPyAPI_FUNC int HPyErr_Occurred(HPyContext *ctx) {
     return ctx_Err_Occurred(ctx);
 }
 
-HPyAPI_FUNC HPy HPyCapsule_New(HPyContext *ctx, void *pointer, const char *name, HPyCapsule_Destructor destructor)
+HPyAPI_FUNC HPy HPyCapsule_New(HPyContext *ctx, void *pointer, const char *name, HPyCapsule_Destructor *destructor)
 {
     return ctx_Capsule_New(ctx, pointer, name, destructor);
 }
@@ -404,11 +404,6 @@ HPyAPI_FUNC void * HPyCapsule_GetContext(HPyContext *ctx, HPy capsule)
     return PyCapsule_GetContext(_h2py(capsule));
 }
 
-HPyAPI_FUNC HPyCapsule_Destructor HPyCapsule_GetDestructor(HPyContext *ctx, HPy capsule)
-{
-    return ctx_Capsule_GetDestructor(ctx, capsule);
-}
-
 HPyAPI_FUNC int HPyCapsule_SetPointer(HPyContext *ctx, HPy capsule, void *pointer)
 {
     return PyCapsule_SetPointer(_h2py(capsule), pointer);
@@ -424,7 +419,7 @@ HPyAPI_FUNC int HPyCapsule_SetContext(HPyContext *ctx, HPy capsule, void *contex
     return PyCapsule_SetContext(_h2py(capsule), context);
 }
 
-HPyAPI_FUNC int HPyCapsule_SetDestructor(HPyContext *ctx, HPy capsule, HPyCapsule_Destructor destructor)
+HPyAPI_FUNC int HPyCapsule_SetDestructor(HPyContext *ctx, HPy capsule, HPyCapsule_Destructor *destructor)
 {
     return ctx_Capsule_SetDestructor(ctx, capsule, destructor);
 }

--- a/hpy/devel/include/hpy/hpydef.h
+++ b/hpy/devel/include/hpy/hpydef.h
@@ -223,7 +223,7 @@ typedef struct {
 #define HPyDef_GETSET(SYM, NAME, ...) \
     HPyDef_GETSET_IMPL(SYM, NAME, SYM##_get, SYM##_set, __VA_ARGS__)
 
-#define HPyDef_CAPSULE_DESTRUCTOR(SYM)                                         \
+#define HPyCapsule_DESTRUCTOR(SYM)                                             \
     static void SYM##_impl(const char *name, void *pointer, void *context);    \
     HPyCapsule_DESTRUCTOR_TRAMPOLINE(SYM##_trampoline, SYM##_impl);            \
     static HPyCapsule_Destructor SYM = {                                       \

--- a/hpy/devel/include/hpy/hpyfunc.h
+++ b/hpy/devel/include/hpy/hpyfunc.h
@@ -39,6 +39,7 @@ typedef enum {
     HPyFunc_OBJOBJPROC,
     HPyFunc_TRAVERSEPROC,
     HPyFunc_DESTRUCTOR,
+    HPyFunc_CAPSULE_DESTRUCTOR,
 
 } HPyFunc_Signature;
 

--- a/hpy/devel/include/hpy/runtime/ctx_funcs.h
+++ b/hpy/devel/include/hpy/runtime/ctx_funcs.h
@@ -60,12 +60,10 @@ _HPy_HIDDEN HPy ctx_Tuple_FromArray(HPyContext *ctx, HPy items[], HPy_ssize_t n)
 _HPy_HIDDEN HPy ctx_Capsule_New(HPyContext *ctx,
                                 void *pointer,
                                 const char *name,
-                                HPyCapsule_Destructor destructor);
-_HPy_HIDDEN HPyCapsule_Destructor ctx_Capsule_GetDestructor(HPyContext *ctx,
-                                                            HPy h_capsule);
+                                HPyCapsule_Destructor *destructor);
 _HPy_HIDDEN int ctx_Capsule_SetDestructor(HPyContext *ctx,
                                           HPy h_capsule,
-                                          HPyCapsule_Destructor destructor);
+                                          HPyCapsule_Destructor *destructor);
 #ifdef HPY_UNIVERSAL_ABI
 _HPy_HIDDEN void* ctx_Capsule_Get(HPyContext *ctx,
                                   HPy capsule,

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -259,7 +259,7 @@ struct _HPyContext_s {
     HPy h_CapsuleType;
     HPy h_SliceType;
     HPy h_Builtins;
-    HPy (*ctx_Capsule_New)(HPyContext *ctx, void *pointer, const char *name, HPyCapsule_Destructor destructor);
+    HPy (*ctx_Capsule_New)(HPyContext *ctx, void *pointer, const char *name, HPyCapsule_Destructor *destructor);
     void *(*ctx_Capsule_Get)(HPyContext *ctx, HPy capsule, _HPyCapsule_key key, const char *name);
     int (*ctx_Capsule_IsValid)(HPyContext *ctx, HPy capsule, const char *name);
     int (*ctx_Capsule_Set)(HPyContext *ctx, HPy capsule, _HPyCapsule_key key, void *value);

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -562,7 +562,7 @@ HPyAPI_FUNC HPy HPyImport_ImportModule(HPyContext *ctx, const char *name) {
      return ctx->ctx_Import_ImportModule ( ctx, name ); 
 }
 
-HPyAPI_FUNC HPy HPyCapsule_New(HPyContext *ctx, void *pointer, const char *name, HPyCapsule_Destructor destructor) {
+HPyAPI_FUNC HPy HPyCapsule_New(HPyContext *ctx, void *pointer, const char *name, HPyCapsule_Destructor *destructor) {
      return ctx->ctx_Capsule_New ( ctx, pointer, name, destructor ); 
 }
 

--- a/hpy/devel/include/hpy/universal/hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/universal/hpyfunc_trampolines.h
@@ -160,6 +160,12 @@ typedef struct {
         return a.result; \
     }
 
+#define HPyCapsule_DESTRUCTOR_TRAMPOLINE(SYM, IMPL)                            \
+    static void SYM(cpy_PyObject *capsule)                                     \
+    {                                                                          \
+        _HPy_CallRealFunctionFromTrampoline(_ctx_for_trampolines,              \
+                HPyFunc_CAPSULE_DESTRUCTOR, (HPyCFunction)IMPL, capsule);      \
+    }
 
 
 #endif // HPY_UNIVERSAL_HPYFUNC_TRAMPOLINES_H

--- a/hpy/devel/include/hpy/universal/misc_trampolines.h
+++ b/hpy/devel/include/hpy/universal/misc_trampolines.h
@@ -54,13 +54,6 @@ HPyCapsule_GetContext(HPyContext *ctx, HPy capsule)
             ctx, capsule, HPyCapsule_key_Context, NULL);
 }
 
-static inline HPyCapsule_Destructor
-HPyCapsule_GetDestructor(HPyContext *ctx, HPy capsule)
-{
-    return (HPyCapsule_Destructor) ctx->ctx_Capsule_Get(
-            ctx, capsule, HPyCapsule_key_Destructor, NULL);
-}
-
 static inline int
 HPyCapsule_SetPointer(HPyContext *ctx, HPy capsule, void *pointer)
 {
@@ -84,7 +77,7 @@ HPyCapsule_SetContext(HPyContext *ctx, HPy capsule, void *context)
 
 static inline int
 HPyCapsule_SetDestructor(HPyContext *ctx, HPy capsule,
-        HPyCapsule_Destructor destructor)
+        HPyCapsule_Destructor *destructor)
 {
     return ctx->ctx_Capsule_Set(
             ctx, capsule, HPyCapsule_key_Destructor, (void *) destructor);

--- a/hpy/devel/src/runtime/ctx_capsule.c
+++ b/hpy/devel/src/runtime/ctx_capsule.c
@@ -7,238 +7,37 @@
 #   include "handles.h"
 #endif
 
-#define DESTRUCTOR_REGISTRY_KEY "_hpycapsule_destructors"
-
-static PyObject *
-hpy_get_destructor_registry(void)
-{
-    PyObject *res;
-
-#if PY_VERSION_HEX < 0x03080000
-    res = PySys_GetObject(DESTRUCTOR_REGISTRY_KEY); /* borrowed ref */
-    if (res == NULL) {
-        /* create the HPy capsule destructor registry on demand */
-        res = PyDict_New();
-        if (PySys_SetObject(DESTRUCTOR_REGISTRY_KEY, res) < 0) {
-            return NULL;
-        }
-
-        /* this function returns a borrowed ref */
-        Py_DECREF(res);
-    }
-#else
-    /* borrowed ref */
-    PyObject *interp_dict = 
-            PyInterpreterState_GetDict(PyThreadState_Get()->interp);
-    if (interp_dict == NULL) {
-        PyErr_SetString(PyExc_SystemError, 
-                "HPyCapsule destructor registry is not available");
-        return NULL;
-    }
-    PyObject *key = PyUnicode_InternFromString(DESTRUCTOR_REGISTRY_KEY);
-    if (key == NULL) {
-        return NULL;
-    }
-    res = PyDict_GetItem(interp_dict, key); /* borrowed ref */
-    if (res == NULL) {
-        /* create the HPy capsule destructor registry on demand */
-        res = PyDict_New();
-        if (res == NULL) {
-            return NULL;
-        }
-        if (PyDict_SetItem(interp_dict, key, res) < 0) {
-            return NULL;
-        }
-        /* this function returns a borrowed ref */
-        Py_DECREF(res);
-    }
-    Py_DECREF(key);
-#endif
-    return res;
-}
-
-/*
- * Fetch the HPyCapsule destructor function for a given capsule from the global
- * destructor function registry.
- * IMPORTANT: Only use this function if you are sure that the given capsule
- * is expected to have a destructor. This is determined by:
- * 'PyCapsule_GetDestructor(capsule) == hpy_capsule_destructor_trampoline'.
- */
-static HPyCapsule_Destructor
-get_hpy_destructor_function(PyObject *capsule, int remove)
-{
-    PyObject *hpy_destructor_registry;
-    PyObject *key;
-    PyObject *hpy_destructor_capsule;
-    void *ptr;
-
-    /* we only register this destructor if the user provided a destructor
-       function at creation time */
-    hpy_destructor_registry = hpy_get_destructor_registry();
-    if (hpy_destructor_registry == NULL) {
-        return NULL;
-    }
-
-    key = PyLong_FromVoidPtr(capsule);
-    if (key == NULL) {
-        return NULL;
-    }
-
-    /* borrowed ref */
-    hpy_destructor_capsule = PyDict_GetItem(hpy_destructor_registry, key);
-    if (hpy_destructor_capsule == NULL) {
-        PyErr_Format(PyExc_SystemError,
-                "could not get destructor for %R", capsule);
-        goto error;
-    }
-
-    ptr = PyCapsule_GetPointer(hpy_destructor_capsule, NULL);
-    if (ptr == NULL) {
-        goto error;
-    }
-
-    if (remove && PyDict_DelItem(hpy_destructor_registry, key) < 0) {
-        PyErr_Format(PyExc_SystemError,
-                "could not remove destructor for %R", capsule);
-        goto error;
-    }
-
-    Py_DECREF(key);
-    return (HPyCapsule_Destructor) ptr;
-
-error:
-    Py_DECREF(key);
-    return NULL;
-}
-
-static void hpy_capsule_destructor_trampoline(PyObject *capsule)
-{
-    HPyCapsule_Destructor hpy_destr = get_hpy_destructor_function(capsule, 1);
-    if (hpy_destr == NULL) {
-        PyErr_Clear();
-        return;
-    }
-
-    /* call the user-supplied destructor function */
-    const char *name = PyCapsule_GetName(capsule);
-    hpy_destr(name, PyCapsule_GetPointer(capsule, name),
-            PyCapsule_GetContext(capsule));
-}
-
 _HPy_HIDDEN HPy
 ctx_Capsule_New(HPyContext *ctx, void *pointer, const char *name,
-        HPyCapsule_Destructor destructor)
+        HPyCapsule_Destructor *destructor)
 {
-    PyObject *registry;
-    PyObject *destructor_capsule = NULL;
     PyObject *res;
-    PyObject *key;
-
     if (destructor) {
-        registry = hpy_get_destructor_registry(); /* borrowed ref */
-        if (registry == NULL) {
+        // If a destructor is given, it is not allowed to omit the functions
+        if ((destructor->cpy_trampoline == NULL || destructor->impl == NULL)) {
+            PyErr_SetString(PyExc_ValueError, "Invalid HPyCapsule destructor");
             return HPy_NULL;
         }
-
-        /* Now create the real capsule since we need it to create the key for
-           the registry */
-        res = PyCapsule_New(pointer, name,
-                (PyCapsule_Destructor) hpy_capsule_destructor_trampoline);
-        if (res == NULL) {
-            goto error;
-        }
-
-        key = PyLong_FromVoidPtr(res);
-        if (key == NULL) {
-            goto error;
-        }
-
-        /* We wrap the pointer to the user-supplied destructor function in a
-           a PyCapsule. */
-        destructor_capsule = PyCapsule_New((void *) destructor, NULL, NULL);
-        if (destructor_capsule == NULL) {
-            goto error;
-        }
-
-        if (PyDict_SetItem(registry, key, destructor_capsule) < 0) {
-            goto error;
-        }
-        Py_DECREF(key);
-        Py_DECREF(destructor_capsule);
+        res = PyCapsule_New(pointer, name, destructor->cpy_trampoline);
     } else {
         res = PyCapsule_New(pointer, name, NULL);
     }
-
     return _py2h(res);
-
-error:
-    /* Ensure that we don't run 'hpy_capsule_destructor_trampoline' in the
-       error case because the trampoline will fail since the registration
-       is not finised yet */
-    if (res) {
-        PyCapsule_SetDestructor(res, NULL);
-        Py_DECREF(res);
-        Py_XDECREF(key);
-        Py_XDECREF(destructor_capsule);
-    }
-    return HPy_NULL;
-}
-
-_HPy_HIDDEN HPyCapsule_Destructor
-ctx_Capsule_GetDestructor(HPyContext *ctx, HPy h_capsule)
-{
-    PyObject *capsule = _h2py(h_capsule);
-    PyCapsule_Destructor py_destructor = PyCapsule_GetDestructor(capsule);
-
-    if (py_destructor == hpy_capsule_destructor_trampoline)
-    {
-        return get_hpy_destructor_function(capsule, 0);
-    }
-
-    /* We do not expose foreign PyCapsule destructor functions since they have
-       a different signature. */
-    return NULL;
 }
 
 _HPy_HIDDEN int
 ctx_Capsule_SetDestructor(HPyContext *ctx, HPy h_capsule,
-        HPyCapsule_Destructor destructor)
+        HPyCapsule_Destructor *destructor)
 {
-    PyObject *capsule;
-    PyObject *registry;
-    PyObject *destructor_capsule;
-    PyObject *key;
-    int i;
-
-    capsule = _h2py(h_capsule);
-
-    registry = hpy_get_destructor_registry(); /* borrowed ref */
-    if (registry == NULL) {
-        return -1;
+    if (destructor) {
+        // If a destructor is given, it is not allowed to omit the functions
+        if ((destructor->cpy_trampoline == NULL || destructor->impl == NULL)) {
+            PyErr_SetString(PyExc_ValueError, "Invalid HPyCapsule destructor");
+            return -1;
+        }
+        return PyCapsule_SetDestructor(_h2py(h_capsule), destructor->cpy_trampoline);
     }
-    /* We wrap the pointer to the user-supplied destructor function in a
-       a PyCapsule. */
-    destructor_capsule = PyCapsule_New((void *) destructor, NULL, NULL);
-    if (destructor_capsule == NULL) {
-        return -1;
-    }
-
-    key = PyLong_FromVoidPtr(capsule);
-    if (key == NULL) {
-        Py_DECREF(destructor_capsule);
-        return -1;
-    }
-
-    i = PyDict_SetItem(registry, key, destructor_capsule);
-    Py_DECREF(key);
-    Py_DECREF(destructor_capsule);
-    if (i < 0) {
-        return -1;
-    }
-
-    PyCapsule_SetDestructor(capsule,
-            (PyCapsule_Destructor) hpy_capsule_destructor_trampoline);
-    return 0;
+    return PyCapsule_SetDestructor(_h2py(h_capsule), NULL);
 }
 
 #ifdef HPY_UNIVERSAL_ABI
@@ -254,7 +53,8 @@ ctx_Capsule_Get(HPyContext *ctx, HPy capsule, _HPyCapsule_key key, const char *n
     case HPyCapsule_key_Context:
         return PyCapsule_GetContext(_h2py(capsule));
     case HPyCapsule_key_Destructor:
-        return ctx_Capsule_GetDestructor(ctx, capsule);
+        PyErr_SetString(PyExc_ValueError, "Invalid operation: get HPyCapsule_key_Destructor");
+        return NULL;
     }
     /* unreachable */
     assert(0);
@@ -273,7 +73,7 @@ ctx_Capsule_Set(HPyContext *ctx, HPy capsule, _HPyCapsule_key key, void *value)
     case HPyCapsule_key_Context:
         return PyCapsule_SetContext(_h2py(capsule), value);
     case HPyCapsule_key_Destructor:
-        return ctx_Capsule_SetDestructor(ctx, capsule, (HPyCapsule_Destructor) value);
+        return ctx_Capsule_SetDestructor(ctx, capsule, (HPyCapsule_Destructor *) value);
     }
     /* unreachable */
     assert(0);

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -435,7 +435,7 @@ HPy HPyImport_ImportModule(HPyContext *ctx, const char *name);
 
 /* pycapsule.h */
 HPy_ID(245)
-HPy HPyCapsule_New(HPyContext *ctx, void *pointer, const char *name, HPyCapsule_Destructor destructor);
+HPy HPyCapsule_New(HPyContext *ctx, void *pointer, const char *name, HPyCapsule_Destructor *destructor);
 HPy_ID(246)
 void* HPyCapsule_Get(HPyContext *ctx, HPy capsule, _HPyCapsule_key key, const char *name);
 HPy_ID(247)

--- a/hpy/universal/src/ctx_meth.c
+++ b/hpy/universal/src/ctx_meth.c
@@ -113,6 +113,14 @@ ctx_CallRealFunctionFromTrampoline(HPyContext *ctx, HPyFunc_Signature sig,
                                                       a->visit, a->arg);
         return;
     }
+    case HPyFunc_CAPSULE_DESTRUCTOR: {
+        HPyFunc_Capsule_Destructor f = (HPyFunc_Capsule_Destructor)func;
+        PyObject *capsule = (PyObject *)args;
+        const char *name = PyCapsule_GetName(capsule);
+        f(name, PyCapsule_GetPointer(capsule, name),
+                PyCapsule_GetContext(capsule));
+        return;
+    }
 #include "autogen_ctx_call.i"
     default:
         Py_FatalError("Unsupported HPyFunc_Signature in ctx_meth.c");

--- a/test/test_capsule.py
+++ b/test/test_capsule.py
@@ -75,7 +75,7 @@ class CapsuleTemplate(DefaultExtensionTemplate):
                         HPyErr_SetString(ctx, ctx->h_MemoryError, "out of memory");
                         return HPy_NULL;
                     }
-                    return HPyCapsule_New(ctx, ptr, CAPSULE_NAME, (HPyCapsule_Destructor) %s);
+                    return HPyCapsule_New(ctx, ptr, CAPSULE_NAME, (HPyCapsule_Destructor *) %s);
                 }
                 /* just for error case testing */
                 return HPyCapsule_New(ctx, NULL, CAPSULE_NAME, NULL);
@@ -167,7 +167,6 @@ class TestHPyCapsule(HPyTest):
         try:
             assert mod.capsule_getname(p) == "some_capsule"
         finally:
-            # since HPy's capsule API does not allow a destructor, we need to
             # manually free the payload to avoid a memleak
             mod.payload_free(p)
         with pytest.raises(ValueError):
@@ -336,16 +335,15 @@ class TestHPyCapsule(HPyTest):
                 mod.capsule_setpointer(not_a_capsule, 0, "", True)
             with pytest.raises(ValueError):
                 mod.capsule_setpointer(p, 456, "lorem ipsum", False)
-            #with pytest.raises(ValueError):
-            #    mod.capsule_getcontext(not_a_capsule)
-            #with pytest.raises(ValueError):
-            #    mod.capsule_setcontext(not_a_capsule, 0, "")
-            #with pytest.raises(ValueError):
-            #    mod.capsule_getname(not_a_capsule)
-            #with pytest.raises(ValueError):
-            #    mod.capsule_setname(not_a_capsule, "")
+            with pytest.raises(ValueError):
+               mod.capsule_getcontext(not_a_capsule)
+            with pytest.raises(ValueError):
+               mod.capsule_setcontext(not_a_capsule, 0, "")
+            with pytest.raises(ValueError):
+               mod.capsule_getname(not_a_capsule)
+            with pytest.raises(ValueError):
+               mod.capsule_setname(not_a_capsule, "")
         finally:
-            # since HPy's capsule API does not allow a destructor, we need to
             # manually free the payload to avoid a memleak
             mod.payload_free(p)
             mod.capsule_freename(p)
@@ -389,20 +387,19 @@ class TestHPyCapsule(HPyTest):
     @pytest.mark.syncgc
     def test_capsule_new_with_destructor(self):
         mod = self.make_module("""
-            static void my_destructor(const char *name, void *pointer, void *context);
-
-            @DEFINE_SomeObject
-            @DEFINE_Capsule_New(my_destructor)
-            @DEFINE_Capsule_GetName
-            @DEFINE_Payload_Free
-
             static int pointer_freed = 0;
-
-            static void my_destructor(const char *name, void *pointer, void *context)
+            
+            HPyDef_CAPSULE_DESTRUCTOR(mydtor)
+            static void mydtor_impl(const char *name, void *pointer, void *context)
             {
                 free(pointer);
                 pointer_freed = 1;
             }
+
+            @DEFINE_SomeObject
+            @DEFINE_Capsule_New(&mydtor)
+            @DEFINE_Capsule_GetName
+            @DEFINE_Payload_Free
 
             HPyDef_METH(Pointer_freed, "pointer_freed", HPyFunc_NOARGS)
             static HPy Pointer_freed_impl(HPyContext *ctx, HPy self)
@@ -464,8 +461,6 @@ class TestHPyCapsuleLegacy(HPyTest):
             {
                 HPy res = HPy_NULL;
                 HPy h_value = HPy_NULL;
-                HPy has_destructor = HPy_NULL;
-                HPyCapsule_Destructor destr = NULL;
                 int *ptr = NULL;
 
                 const char *name = HPyCapsule_GetName(ctx, arg);
@@ -487,22 +482,11 @@ class TestHPyCapsuleLegacy(HPyTest):
                     goto finish;
                 }
 
-                destr = HPyCapsule_GetDestructor(ctx, arg);
-                if (destr == NULL && HPyErr_Occurred(ctx)) {
-                    goto finish;
-                }
-
-                has_destructor = HPyBool_FromLong(ctx, destr != NULL);
-                if (HPy_IsNull(has_destructor)) {
-                    goto finish;
-                }
-
-                res = HPyTuple_Pack(ctx, 3, h_name, h_value, has_destructor);
+                res = HPyTuple_Pack(ctx, 2, h_name, h_value);
 
             finish:
                 HPy_Close(ctx, h_name);
                 HPy_Close(ctx, h_value);
-                HPy_Close(ctx, has_destructor);
                 return res;
             }
 
@@ -513,4 +497,4 @@ class TestHPyCapsuleLegacy(HPyTest):
         """)
         name = "legacy_capsule"
         p = mod.create_pycapsule(name)
-        assert mod.get(p) == (name, 123, False)
+        assert mod.get(p) == (name, 123)

--- a/test/test_capsule.py
+++ b/test/test_capsule.py
@@ -76,7 +76,7 @@ class CapsuleTemplate(DefaultExtensionTemplate):
                         HPyErr_SetString(ctx, ctx->h_MemoryError, "out of memory");
                         return HPy_NULL;
                     }
-                    res = HPyCapsule_New(ctx, ptr, CAPSULE_NAME, (HPyCapsule_Destructor *) %s);
+                    res = HPyCapsule_New(ctx, ptr, CAPSULE_NAME, %s);
                     if (HPy_IsNull(res)) {
                         free(ptr);
                     }

--- a/test/test_capsule.py
+++ b/test/test_capsule.py
@@ -425,7 +425,7 @@ class TestHPyCapsule(HPyTest):
         mod = self.make_module("""
             static int pointer_freed = 0;
             
-            HPyDef_CAPSULE_DESTRUCTOR(mydtor)
+            HPyCapsule_DESTRUCTOR(mydtor)
             static void mydtor_impl(const char *name, void *pointer, void *context)
             {
                 free(pointer);

--- a/test/test_capsule.py
+++ b/test/test_capsule.py
@@ -61,6 +61,7 @@ class CapsuleTemplate(DefaultExtensionTemplate):
             HPyDef_METH(Capsule_New, "capsule_new", HPyFunc_VARARGS)
             static HPy Capsule_New_impl(HPyContext *ctx, HPy self, HPy *args, HPy_ssize_t nargs)
             {
+                HPy res;
                 int value;
                 char *message;
                 void *ptr;
@@ -75,7 +76,11 @@ class CapsuleTemplate(DefaultExtensionTemplate):
                         HPyErr_SetString(ctx, ctx->h_MemoryError, "out of memory");
                         return HPy_NULL;
                     }
-                    return HPyCapsule_New(ctx, ptr, CAPSULE_NAME, (HPyCapsule_Destructor *) %s);
+                    res = HPyCapsule_New(ctx, ptr, CAPSULE_NAME, (HPyCapsule_Destructor *) %s);
+                    if (HPy_IsNull(res)) {
+                        free(ptr);
+                    }
+                    return res;
                 }
                 /* just for error case testing */
                 return HPyCapsule_New(ctx, NULL, CAPSULE_NAME, NULL);


### PR DESCRIPTION
This resolved #377. 
In this PR, I'm introducing macro `HPyDef_CAPSULE_DESTRUCTOR` (much like `HPyDev_METH` macro) and removing `HPyCapsule_GetDestructor`. With this, we can significantly simplify our capsule implementation because we never need to hand out the HPy capsule destructor function while the new macro will generate an appropriate CPython trampoline.

Removing `HPyCapsule_GetDestructor` should be fine since I didn't find a single usage of `PyCapsule_GetDestructor` in the C code of the top4000 packages.