### PR TITLE
Build static libraries of HPy devel sources for testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
         run: python -m pip install --upgrade pip wheel 'setuptools>=60.2'
 
       - name: Build
-        run: python -m pip install .
+        run: |
+          make
+          python -m pip install .
 
       - if: ${{ matrix.compiler }}
         # Only set the compiler for the tests, not for the build
@@ -79,7 +81,9 @@ jobs:
         run: python -m pip install --upgrade pip wheel
 
       - name: Build
-        run: python -m pip install .
+        run: |
+          make
+          python -m pip install .
 
       - name: Run tests
         run: |
@@ -401,7 +405,9 @@ jobs:
           python -m pip install pytest cffi
 
       - name: Build and install HPy
-        run: python -m pip install .
+        run: |
+          make
+          python -m pip install .
 
       - name: Run microbenchmarks
         run: |

--- a/.github/workflows/valgrind-tests.yml
+++ b/.github/workflows/valgrind-tests.yml
@@ -21,7 +21,9 @@ jobs:
         run: python -m pip install --upgrade pip wheel
 
       - name: Build
-        run: python -m pip install .
+        run: |
+          make
+          python -m pip install .
 
       - name: Run tests
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,11 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
+# C extensions and static libs
 *.so
 *.o
+*.a
+*.lib
 vc140.pdb
 c_test/test_debug_handles
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: hpy.universal
 
 .PHONY: hpy.universal
 hpy.universal:
-	python3 setup.py build_ext -if
+	python3 setup.py build_clib -f build_ext -if
 
 .PHONY: dist-info
 dist-info:

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -329,7 +329,7 @@ class build_ext_hpy_mixin:
         if static_libs:
             static_libs = self.hpydevel.get_static_libs(ext.hpy_abi)
             if static_libs is None or len(static_libs) != 1:
-                raise DistutilsError('Expected exactly one static library for'
+                raise DistutilsError('Expected exactly one static library for '
                                      'ABI "%s" but got: %r' %
                                      (ext.hpy_abi, static_libs))
 

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -178,7 +178,7 @@ def handle_hpy_ext_modules(dist, attr, hpy_ext_modules):
 
     # add a global option --hpy-abi to setup.py
     dist.__class__.hpy_abi = DEFAULT_HPY_ABI
-    dist.__class__.hpy_no_static_libs = False
+    dist.__class__.hpy_use_static_libs = False
     dist.__class__.global_options += [
         ('hpy-abi=', None, 'Specify the HPy ABI mode (default: %s)' % DEFAULT_HPY_ABI),
         ('hpy-no-static-libs', None, 'Compile context and extra sources with extension (default: False)')
@@ -322,11 +322,11 @@ class build_ext_hpy_mixin:
         ext.name = HPyExtensionName(ext.name)
         ext.hpy_abi = self.distribution.hpy_abi
         ext.include_dirs += self.hpydevel.get_extra_include_dirs()
-        # If we may use static libs (default), then add all available libs (for
+        # If static libs should be used, then add all available libs (for
         # the given ABI) to the extra objects. The libs will then just be added
         # in the linking phase but nothing will be compiled in addition.
-        use_static_libs = not self.distribution.hpy_no_static_libs
-        if use_static_libs:
+        static_libs = self.distribution.hpy_use_static_libs
+        if static_libs:
             static_libs = self.hpydevel.get_static_libs(ext.hpy_abi)
         else:
             static_libs = None

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -328,8 +328,10 @@ class build_ext_hpy_mixin:
         static_libs = self.distribution.hpy_use_static_libs
         if static_libs:
             static_libs = self.hpydevel.get_static_libs(ext.hpy_abi)
-        else:
-            static_libs = None
+            if static_libs is None or len(static_libs) != 1:
+                raise DistutilsError('Expected exactly one static library for'
+                                     'ABI "%s" but got: %r' %
+                                     (ext.hpy_abi, static_libs))
 
         if static_libs:
             ext.extra_objects += static_libs

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -94,16 +94,17 @@ class HPyDevel:
         return available_libs
 
     def get_static_libs(self, hpy_abi):
-        """ A list of extra static libraries to compile with. For example,
-            there is library 'hpyhelpers' which contains compiled HPy helper
-            functions like 'HPyArg_Parse' and such. Libraries are always
-            specific to an ABI. The list may be empty if no libraries are
-            available for a certain ABI.
+        """ The list of necessary static libraries an HPy extension needs to
+            link to or 'None' (if not available). The HPy ext needs to link to
+            all static libraries in the list otherwise some function may stay
+            unresolved. For example, there is library 'hpyextra' which contains
+            compiled HPy helper functions like 'HPyArg_Parse' and such.
+            Libraries are always specific to an ABI.
         """
         if not self._available_static_libs:
             # lazily initialize the dict of available (=shipped) static libs
             self._available_static_libs = self._scan_static_lib_dir()
-        return self._available_static_libs.get(hpy_abi, [])
+        return self._available_static_libs.get(hpy_abi, None)
 
     def get_ctx_sources(self):
         """ Extra sources needed only in the CPython ABI mode.

--- a/setup.py
+++ b/setup.py
@@ -128,9 +128,13 @@ HPY_CTX_LIB_NAME = "hpyctx"
 def get_hpy_runtime_includes():
     default_include = sysconfig.get_path("include")
     plat_include = sysconfig.get_path("platinclude")
+    config_h_dir = os.path.dirname(sysconfig.get_config_h_filename())
+    include_dirs = [default_include]
     if default_include != plat_include:
-        return [default_include, plat_include] + HPY_INCLUDE_DIRS
-    return [default_include] + HPY_INCLUDE_DIRS
+        include_dirs.append(plat_include)
+    if config_h_dir not in (default_include, plat_include):
+        include_dirs.append(config_h_dir)
+    return include_dirs + HPY_INCLUDE_DIRS
 
 
 class build_clib_hpy(build_clib):

--- a/setup.py
+++ b/setup.py
@@ -195,11 +195,12 @@ STATIC_LIBS = [(HPY_EXTRA_LIB_NAME,
                 {'sources': HPY_EXTRA_SOURCES,
                  'include_dirs': get_hpy_runtime_includes(),
                  'abi': 'universal',
-                 'macros': [('HPY_UNIVERSAL_ABI', None)]}),
+                 'macros': [('HPY_ABI_HYBRID', None)]}),
                (HPY_CTX_LIB_NAME,
                 {'sources': HPY_EXTRA_SOURCES + HPY_CTX_SOURCES,
                  'include_dirs': get_hpy_runtime_includes(),
-                 'abi': 'cpython'})]
+                 'abi': 'cpython',
+                 'macros': [('HPY_ABI_CPYTHON', None)]})]
 
 EXT_MODULES = [
     Extension('hpy.universal',

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ def get_hpy_runtime_includes():
         include_dirs.append(config_h_dir)
     return include_dirs + HPY_INCLUDE_DIRS
 
+HPY_BUILD_CLIB_ABI_ATTR = "hpy_abi"
 
 class build_clib_hpy(build_clib):
     """ Special build_clib command for building HPy's static libraries defined
@@ -177,7 +178,7 @@ class build_clib_hpy(build_clib):
 
         for lib in libraries:
             lib_name, build_info = lib
-            abi = build_info.get('abi')
+            abi = build_info.get(HPY_BUILD_CLIB_ABI_ATTR)
             # Call super's build_libraries with just one library in the list
             # such that we can temporarily change the 'build_temp'.
             orig_build_temp = self.build_temp
@@ -194,12 +195,12 @@ class build_clib_hpy(build_clib):
 STATIC_LIBS = [(HPY_EXTRA_LIB_NAME,
                 {'sources': HPY_EXTRA_SOURCES,
                  'include_dirs': get_hpy_runtime_includes(),
-                 'abi': 'universal',
+                 HPY_BUILD_CLIB_ABI_ATTR: 'universal',
                  'macros': [('HPY_ABI_HYBRID', None)]}),
                (HPY_CTX_LIB_NAME,
                 {'sources': HPY_EXTRA_SOURCES + HPY_CTX_SOURCES,
                  'include_dirs': get_hpy_runtime_includes(),
-                 'abi': 'cpython',
+                 HPY_BUILD_CLIB_ABI_ATTR: 'cpython',
                  'macros': [('HPY_ABI_CPYTHON', None)]})]
 
 EXT_MODULES = [

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,8 @@ HPY_INCLUDE_DIRS = [
     'hpy/trace/src/include',
 ]
 
-HPY_EXTRA_LIB_NAME = "hpy-extra-universal"
+HPY_EXTRA_UNIVERSAL_LIB_NAME = "hpy-extra-universal"
+HPY_EXTRA_HYBRID_LIB_NAME = "hpy-extra-hybrid"
 HPY_CTX_LIB_NAME = "hpy-ctx-cpython"
 
 HPY_BUILD_CLIB_ABI_ATTR = "hpy_abi"
@@ -183,9 +184,13 @@ class build_clib_hpy(build_clib):
                 self.build_clib = orig_build_clib
 
 
-STATIC_LIBS = [(HPY_EXTRA_LIB_NAME,
+STATIC_LIBS = [(HPY_EXTRA_UNIVERSAL_LIB_NAME,
                 {'sources': HPY_EXTRA_SOURCES,
                  HPY_BUILD_CLIB_ABI_ATTR: 'universal',
+                 'macros': [('HPY_ABI_UNIVERSAL', None)]}),
+               (HPY_EXTRA_HYBRID_LIB_NAME,
+                {'sources': HPY_EXTRA_SOURCES,
+                 HPY_BUILD_CLIB_ABI_ATTR: 'hybrid',
                  'macros': [('HPY_ABI_HYBRID', None)]}),
                (HPY_CTX_LIB_NAME,
                 {'sources': HPY_EXTRA_SOURCES + HPY_CTX_SOURCES,

--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,7 @@ class build_clib_hpy(build_clib):
         else:
             lib_dir = os.path.join(build.build_lib, 'hpy', 'devel')
 
+        import pathlib
         for lib in libraries:
             lib_name, build_info = lib
             abi = build_info.get(HPY_BUILD_CLIB_ABI_ATTR)
@@ -172,6 +173,8 @@ class build_clib_hpy(build_clib):
             orig_build_clib = self.build_clib
             self.build_temp = os.path.join(orig_build_temp, 'lib', abi)
             self.build_clib = os.path.join(lib_dir, 'lib', abi)
+            # ensure that 'build_clib' directory exists
+            pathlib.Path(self.build_clib).mkdir(parents=True, exist_ok=True)
             try:
                 super().build_libraries([lib])
             finally:

--- a/setup.py
+++ b/setup.py
@@ -142,23 +142,10 @@ class build_clib_hpy(build_clib):
         super().finalize_options()
         self.force = 1
 
-    def _filter_libraries(self, libraries):
-        filtered_libs = []
-        for lib in libraries:
-            lib_name, build_info = lib
-            if lib_name not in (HPY_EXTRA_LIB_NAME, HPY_CTX_LIB_NAME):
-                filtered_libs.append(lib)
-        return filtered_libs
-
     def get_library_names(self):
-        libraries = self._filter_libraries(self.libraries)
-        if not libraries:
-            return None
-
-        lib_names = []
-        for lib_name, build_info in libraries:
-            lib_names.append(lib_name)
-        return lib_names
+        # We only build static libraries for shipping. We don't want that our
+        # extensions (i.e. 'hpy.universal' etc) link to these libs.
+        return None
 
     def build_libraries(self, libraries):
         build = self.get_finalized_command('build')

--- a/setup.py
+++ b/setup.py
@@ -163,20 +163,14 @@ class build_clib_hpy(build_clib):
             abi = build_info.get('abi')
             # call super's build_libraries to build everything
             orig_build_temp = self.build_temp
-            self.build_temp = os.path.join(orig_build_temp, abi)
+            orig_build_clib = self.build_clib
+            self.build_temp = os.path.join(orig_build_temp, 'lib', abi)
+            self.build_clib = os.path.join(lib_dir, 'lib', abi)
             try:
                 super().build_libraries([lib])
             finally:
                 self.build_temp = orig_build_temp
-
-            # this is also what 'create_static_lib' uses
-            output_path = self.compiler.library_filename(lib_name, output_dir=self.build_clib)
-            output_filename = os.path.basename(output_path)
-            if abi:
-                dest_dir = os.path.join(lib_dir, 'lib', abi)
-                self.mkpath(dest_dir)
-                self.copy_file(output_path, os.path.join(dest_dir, output_filename))
-
+                self.build_clib = orig_build_clib
 
 
 STATIC_LIBS = [(HPY_EXTRA_LIB_NAME,

--- a/setup.py
+++ b/setup.py
@@ -120,8 +120,8 @@ HPY_INCLUDE_DIRS = [
     'hpy/trace/src/include',
 ]
 
-HPY_EXTRA_LIB_NAME = "hpyextra"
-HPY_CTX_LIB_NAME = "hpyctx"
+HPY_EXTRA_LIB_NAME = "hpy-extra-universal"
+HPY_CTX_LIB_NAME = "hpy-ctx-cpython"
 
 HPY_BUILD_CLIB_ABI_ATTR = "hpy_abi"
 

--- a/test/support.py
+++ b/test/support.py
@@ -542,6 +542,9 @@ def _build(tmpdir, ext, hpy_devel, hpy_abi, compiler_verbose=0, debug=None):
     dist.hpy_abi = hpy_abi
     dist.hpy_no_static_libs = False
     dist.hpy_ext_modules = [ext]
+    # We need to explicitly specify which Python modules we expect because some
+    # test cases create several distributions in the same temp directory.
+    dist.py_modules = [ext.name]
     hpy_devel.fix_distribution(dist)
 
     old_level = distutils.log.set_threshold(0) or 0

--- a/test/support.py
+++ b/test/support.py
@@ -540,6 +540,7 @@ def _build(tmpdir, ext, hpy_devel, hpy_abi, compiler_verbose=0, debug=None):
 
     # this is the equivalent of passing --hpy-abi from setup.py's command line
     dist.hpy_abi = hpy_abi
+    dist.hpy_no_static_libs = False
     dist.hpy_ext_modules = [ext]
     hpy_devel.fix_distribution(dist)
 

--- a/test/support.py
+++ b/test/support.py
@@ -540,7 +540,9 @@ def _build(tmpdir, ext, hpy_devel, hpy_abi, compiler_verbose=0, debug=None):
 
     # this is the equivalent of passing --hpy-abi from setup.py's command line
     dist.hpy_abi = hpy_abi
-    dist.hpy_no_static_libs = False
+    # For testing, we want to use static libs to avoid repeated compilation
+    # of the same sources which slows down testing.
+    dist.hpy_use_static_libs = True
     dist.hpy_ext_modules = [ext]
     # We need to explicitly specify which Python modules we expect because some
     # test cases create several distributions in the same temp directory.


### PR DESCRIPTION
This PR resolves issue #310.

As described in the linked issue, we are currently adding our sources (i.e. `argparse.c`, `buildvalue.c`, `helpers.c` for universal ABI and additionally all `hpy/devel/src/runtime/ctx_*.c` for CPython ABI) to every HPy extension.
This may cause problems for the extension author since he maybe wants to use compilation flags or even compilers that are not compatible with our source.

Further, our tests are also slowed down extremely because we compile those sources over and over for every single test case.

### Approach

With this PR, we will build static libraries in HPy's `setup.py` (for _universal_ and _cpython_ ABI). The main problem to do so was that setuptools doesn't really provide a facility to do that and I didn't want to use a lot of distutils internals since distutils is deprecated and subject to be removed.

I decided to build the static libraries using the `build_clib` command. This is actually what it is good for *BUT* with the assumption that such libraries are just temporary build aritfacts and that they will immediately after be used in `build_ext`.
I therefore customized `build_clib`and such that static libraries are emitted to the same output directory as `build_ext` uses but into sub-directory `lib/<abi>`.
I've defined two static libraries: `hpyextra` for _universal ABI_ and `hpyctx` for _ cpython ABI_ (see variables `HPY_EXTRA_SOURCES` and `HPY_CTX_SOURCES`, respectively).

I tried hard to minimize dependencies on deprecated distutils features. However, the introduced `build_clib_hpy` command overrides methods `get_library_names` and `build_libraries` which is not officially supported, I think (see https://setuptools.pypa.io/en/latest/userguide/extension.html#setuptools.command.build.SubCommand).

Unfortunately, we need some extra treatment to be able to use that for the HPy tests. Although we install HPy before we run the tests, we run them from the HPy source directory which means that we don't use the `hpy.devel` from the installed distribution but from the source tree.
I therefore also implemented an _inplace_ mode for `build_clib_hpy` (the option is _inherited_ from `build_ext`). That is used to output build artifacts into the source tree such that we can use them in the tests.

### Numbers

On my Linux box, this improves test duration a lot:
```
before: 8m 28s
after: 1m 23s
speedup: 6.12x
```
The numbers on my Windows VM were not that good (something like 30% faster) but let's see how this goes in the GitHub CI.