### PR TITLE
Make HPy compatible with Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             compiler: 'g++'
+          - os: ubuntu-latest
+            python-version: '3.11'
 
     steps:
       - uses: actions/checkout@v2
@@ -59,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10', '3.9', '3.8', '3.7']
+        python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
 
     steps:
       - uses: actions/checkout@v2
@@ -98,6 +100,8 @@ jobs:
             python-version: '3.8'
           - os: ubuntu-latest
             python-version: '3.9'
+          - os: ubuntu-latest
+            python-version: '3.11'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This resolves #288 .

Antonio's Hybrid-ABI PR #371, which is now merged, already solved the first problems we had with Python 3.11. However, that was not enough.
In particular, there was a subtle change in Python's `PyType_FromSpec....` They do now copy the name from the type spec into a fresh buffer such that the type object owns that buffer and can free it (see https://github.com/python/cpython/blob/b5b3904f05e77f044f158307bc6bdd2bc1b670a2/Objects/typeobject.c#L3723).
However, we use `tp_name` to attach our `HPyType_Extra` struct.

In future, we might consider to use meta classes to avoid this hack.

I've now also added Python 3.11 to the CI (for main tests and PoC).
