### PR TITLE
Enable slots HPy_tp_str and HPy_tp_hash.

### DIFF
--- a/hpy/devel/include/hpy/autogen_hpyslot.h
+++ b/hpy/devel/include/hpy/autogen_hpyslot.h
@@ -57,10 +57,12 @@ typedef enum {
     HPy_sq_item = 44,
     HPy_sq_length = 45,
     HPy_sq_repeat = 46,
+    HPy_tp_hash = 59,
     HPy_tp_init = 60,
     HPy_tp_new = 65,
     HPy_tp_repr = 66,
     HPy_tp_richcompare = 67,
+    HPy_tp_str = 70,
     HPy_tp_traverse = 71,
     HPy_nb_matrix_multiply = 75,
     HPy_nb_inplace_matrix_multiply = 76,
@@ -114,10 +116,12 @@ typedef enum {
 #define _HPySlot_SIG__HPy_sq_item HPyFunc_SSIZEARGFUNC
 #define _HPySlot_SIG__HPy_sq_length HPyFunc_LENFUNC
 #define _HPySlot_SIG__HPy_sq_repeat HPyFunc_SSIZEARGFUNC
+#define _HPySlot_SIG__HPy_tp_hash HPyFunc_HASHFUNC
 #define _HPySlot_SIG__HPy_tp_init HPyFunc_INITPROC
 #define _HPySlot_SIG__HPy_tp_new HPyFunc_KEYWORDS
 #define _HPySlot_SIG__HPy_tp_repr HPyFunc_REPRFUNC
 #define _HPySlot_SIG__HPy_tp_richcompare HPyFunc_RICHCMPFUNC
+#define _HPySlot_SIG__HPy_tp_str HPyFunc_REPRFUNC
 #define _HPySlot_SIG__HPy_tp_traverse HPyFunc_TRAVERSEPROC
 #define _HPySlot_SIG__HPy_nb_matrix_multiply HPyFunc_BINARYFUNC
 #define _HPySlot_SIG__HPy_nb_inplace_matrix_multiply HPyFunc_BINARYFUNC

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -738,7 +738,7 @@ typedef enum {
     //HPy_tp_doc = SLOT(56, HPyFunc_X),
     //HPy_tp_getattr = SLOT(57, HPyFunc_X),
     //HPy_tp_getattro = SLOT(58, HPyFunc_X),
-    //HPy_tp_hash = SLOT(59, HPyFunc_X),
+    HPy_tp_hash = SLOT(59, HPyFunc_HASHFUNC),
     HPy_tp_init = SLOT(60, HPyFunc_INITPROC),
     //HPy_tp_is_gc = SLOT(61, HPyFunc_X),
     //HPy_tp_iter = SLOT(62, HPyFunc_X),
@@ -749,7 +749,7 @@ typedef enum {
     HPy_tp_richcompare = SLOT(67, HPyFunc_RICHCMPFUNC),
     //HPy_tp_setattr = SLOT(68, HPyFunc_X),
     //HPy_tp_setattro = SLOT(69, HPyFunc_X),
-    //HPy_tp_str = SLOT(70, HPyFunc_X),
+    HPy_tp_str = SLOT(70, HPyFunc_REPRFUNC),
     HPy_tp_traverse = SLOT(71, HPyFunc_TRAVERSEPROC),
     //HPy_tp_members = SLOT(72, HPyFunc_X),    NOT SUPPORTED
     //HPy_tp_getset = SLOT(73, HPyFunc_X),     NOT SUPPORTED


### PR DESCRIPTION
Resolves #384 .

Slots `HPy_tp_str` and `HPy_tp_hash` are required for the NumPy/HPy port.