### PR TITLE
Fix GitHub actions: fix Ubuntu version for py27 compat and cpp-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
 
   check_py27_compat:
     name: Check Python 2.7 compatibility
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v2
 
@@ -340,7 +340,7 @@ jobs:
 
   cpp_check:
     name: Cppcheck static analysis
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The latest Ubuntu does not provide Python 2.7 and also cpp-check seems to have some issues with it (runs, but fails with some preprocessor configuration issues).

From https://github.com/actions/setup-python/issues/543 it seems that we need to stick to older Ubuntu.

Note: EOL of Ubuntu 20.04 should be in 2025