### PR TITLE
Split valgrind tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             python-version: '3.11'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # - template: azure-templates/ccache.yml
       #   parameters:
@@ -64,7 +64,7 @@ jobs:
         python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python from deadsnakes
         uses: deadsnakes/action@v2.1.1
@@ -104,7 +104,7 @@ jobs:
             python-version: '3.11'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # - template: azure-templates/ccache.yml
       #   parameters:
@@ -157,7 +157,7 @@ jobs:
         python-version: ['3.9']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -210,7 +210,7 @@ jobs:
         python-version: ['3.10']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -235,7 +235,7 @@ jobs:
     name: Build documentation
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # - template: azure-templates/python.yml
 
@@ -253,7 +253,7 @@ jobs:
           python -m sphinx -T -W -E -b html -d _build/doctrees -D language=en . _build/html
 
       - name: Upload built HTML files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: hpy_html_docs
           path: docs/_build/html/*
@@ -264,7 +264,7 @@ jobs:
     name: C tests
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: make -C c_test
 
 
@@ -272,7 +272,7 @@ jobs:
     name: Check autogen
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
     # - template: azure-templates/python.yml
 
@@ -309,7 +309,7 @@ jobs:
     name: Check Python 2.7 compatibility
     runs-on: 'ubuntu-20.04'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
     # - template: azure-templates/python.yml
     #   parameters:
@@ -333,7 +333,7 @@ jobs:
     name: Cppcheck static analysis
     runs-on: 'ubuntu-20.04'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -351,7 +351,7 @@ jobs:
     name: Infer static analysis
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # - template: azure-templates/python.yml
 
@@ -378,7 +378,7 @@ jobs:
     name: Check micro benchmarks
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,17 +188,24 @@ jobs:
 
 
   valgrind_tests_1:
-    name: 'Valgrind tests (1/2)'
+    name: 'Valgrind tests (1/3)'
     uses: ./.github/workflows/valgrind-tests.yml
     with:
-      portion: '1/2'
+      portion: '1/3'
 
 
   valgrind_tests_2:
-    name: 'Valgrind tests (2/2)'
+    name: 'Valgrind tests (2/3)'
     uses: ./.github/workflows/valgrind-tests.yml
     with:
-      portion: '2/2'
+      portion: '2/3'
+
+
+  valgrind_tests_3:
+    name: 'Valgrind tests (3/3)'
+    uses: ./.github/workflows/valgrind-tests.yml
+    with:
+      portion: '3/3'
 
 
   docs_examples_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,28 +187,19 @@ jobs:
         shell: bash
 
 
-  valgrind_tests:
-    name: Valgrind tests
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: actions/checkout@v2
+  valgrind_tests_1:
+    name: 'Valgrind tests (1/2)'
+    uses: ./.github/workflows/valgrind-tests.yml
+    with:
+      portion: '1/2'
 
-    # - template: azure-templates/ccache.yml
-    # - template: azure-templates/python.yml
 
-      - name: Install / Upgrade system dependencies
-        run: sudo apt update && sudo apt install -y valgrind
+  valgrind_tests_2:
+    name: 'Valgrind tests (2/2)'
+    uses: ./.github/workflows/valgrind-tests.yml
+    with:
+      portion: '2/2'
 
-      - name: Install / Upgrade Python dependencies
-        run: python -m pip install --upgrade pip wheel
-
-      - name: Build
-        run: python -m pip install .
-
-      - name: Run tests
-        run: |
-          python -m pip install pytest pytest-valgrind filelock
-          make valgrind
 
   docs_examples_tests:
     name: Documentation examples tests

--- a/.github/workflows/valgrind-tests.yml
+++ b/.github/workflows/valgrind-tests.yml
@@ -1,0 +1,29 @@
+on:
+  workflow_call:
+    inputs:
+      portion:
+        required: true
+        type: string
+
+jobs:
+  valgrind_tests:
+    # name: Valgrind tests
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install / Upgrade system dependencies
+        run: sudo apt update && sudo apt install -y valgrind
+
+      - name: Install / Upgrade Python dependencies
+        run: python -m pip install --upgrade pip wheel
+
+      - name: Build
+        run: python -m pip install .
+
+      - name: Run tests
+        env:
+          HPY_TEST_PORTION: ${{ inputs.portion }}
+        run: |
+          python -m pip install pytest pytest-valgrind pytest-portion filelock
+          make valgrind

--- a/.github/workflows/valgrind-tests.yml
+++ b/.github/workflows/valgrind-tests.yml
@@ -10,7 +10,7 @@ jobs:
     # name: Valgrind tests
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install / Upgrade system dependencies
         run: sudo apt update && sudo apt install -y valgrind

--- a/.github/workflows/valgrind-tests.yml
+++ b/.github/workflows/valgrind-tests.yml
@@ -2,8 +2,10 @@ on:
   workflow_call:
     inputs:
       portion:
-        required: true
+        description: 'Select portion of tests to run under Valgrind (default runs all)'
+        default: ''
         type: string
+        required: false
 
 jobs:
   valgrind_tests:

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,16 @@ infer:
 	# see commit cd8cd6e for why we need to ignore debug_ctx.c
 	@infer --fail-on-issue --compilation-database compile_commands.json --report-blacklist-path-regex "hpy/debug/src/debug_ctx.c"
 
+valgrind_args = --suppressions=hpy/tools/valgrind/python.supp --suppressions=hpy/tools/valgrind/hpy.supp --leak-check=full --show-leak-kinds=definite,indirect --log-file=/tmp/valgrind-output
+python_args = -m pytest --valgrind --valgrind-log=/tmp/valgrind-output
+
+.PHONY: valgrind
 valgrind:
-	PYTHONMALLOC=malloc valgrind --suppressions=hpy/tools/valgrind/python.supp --suppressions=hpy/tools/valgrind/hpy.supp --leak-check=full --show-leak-kinds=definite,indirect --log-file=/tmp/valgrind-output python3 -m pytest --valgrind --valgrind-log=/tmp/valgrind-output test/
+ifeq ($(HPY_TEST_PORTION),)
+	PYTHONMALLOC=malloc valgrind $(valgrind_args) python3 $(python_args) test/
+else
+	PYTHONMALLOC=malloc valgrind $(valgrind_args) python3 $(python_args) --portion $(HPY_TEST_PORTION) test/
+endif
 
 porting-example-tests:
 	cd docs/porting-example/steps && python3 setup00.py build_ext -i


### PR DESCRIPTION
This introduces a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) for the valgrind tests.
I'm using `pytest-portion` to split the tests. This is controlled by env variable `HPY_TEST_PORTION` which is honored by the Makefile.