### PR TITLE
Fix and re-enable cppcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,8 +344,6 @@ jobs:
     name: Cppcheck static analysis
     runs-on: 'ubuntu-20.04'
     continue-on-error: true
-    # Skip it, see issue gh-188
-    if: false
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
 
   cpp_check:
     name: Cppcheck static analysis
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
@@ -353,7 +353,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install Cppcheck
-        run: sudo apt-get -qq -y install cppcheck
+        run: sudo apt-get -qq -y install cppcheck=2.7-1
 
       - name: Run Cppcheck
         run: make cppcheck

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ cppcheck-build-dir:
 cppcheck: cppcheck-build-dir
 	# azure pipelines doesn't show stderr, so we write the errors to a file and cat it later :(
 	$(eval PYTHON_INC = $(shell python3 -q -c "from sysconfig import get_paths as gp; print(gp()['include'])"))
+	$(eval PYTHON_PLATINC = $(shell python3 -q -c "from sysconfig import get_paths as gp; print(gp()['platinclude'])"))
 	cppcheck --version
 	cppcheck \
 		-v \
@@ -31,9 +32,11 @@ cppcheck: cppcheck-build-dir
 		--enable=warning,performance,portability,information,missingInclude \
 		--inline-suppr \
 		--suppress=allocaCalled \
-		-I /usr/local/include \
-		-I /usr/include \
+		-I /usr/local/include/ \
+		-I /usr/include/ \
 		-I ${PYTHON_INC} \
+		-I ${PYTHON_PLATINC} \
+		-I . \
 		-I hpy/devel/include/ \
 		-I hpy/devel/include/hpy/ \
 		-I hpy/devel/include/hpy/cpython/ \
@@ -41,6 +44,9 @@ cppcheck: cppcheck-build-dir
 		-I hpy/devel/include/hpy/runtime/ \
 		-I hpy/universal/src/ \
 		-I hpy/debug/src/ \
+		-I hpy/debug/src/include \
+		-I hpy/trace/src/ \
+		-I hpy/trace/src/include \
 		--force \
 		-D NULL=0 \
 		-D HPY_ABI_CPYTHON \

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,9 @@ cppcheck: cppcheck-build-dir
 		-v \
 		--error-exitcode=1 \
 		--cppcheck-build-dir=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck) \
-		--output-file=$(or ${CPPCHECK_BUILD_DIR}, .cppcheck)/output.txt \
 		--enable=warning,performance,portability,information,missingInclude \
 		--inline-suppr \
-		--suppress=allocaCalled \
+		--suppress=syntaxError \
 		-I /usr/local/include/ \
 		-I /usr/include/ \
 		-I ${PYTHON_INC} \
@@ -50,7 +49,10 @@ cppcheck: cppcheck-build-dir
 		--force \
 		-D NULL=0 \
 		-D HPY_ABI_CPYTHON \
-		. || (cat $(or ${CPPCHECK_BUILD_DIR}, .cppcheck)/output.txt && false)
+		-D __linux__=1 \
+		-D __x86_64__=1 \
+		-D __LP64__=1 \
+		.
 
 infer:
 	python3 setup.py build_ext -if -U NDEBUG | compiledb

--- a/hpy/devel/src/runtime/ctx_tracker.c
+++ b/hpy/devel/src/runtime/ctx_tracker.c
@@ -98,11 +98,6 @@ ctx_Tracker_New(HPyContext *ctx, HPy_ssize_t capacity)
     }
     hp->capacity = capacity;
     hp->length = 0;
-    // cppcheck thinks that hp->handles is a memory leak because we cast the
-    // pointer to an int (and thus the pointer is "lost" from its POV, I
-    // suppose). But it's not a real leak because we free it in
-    // ctx_Tracker_Close:
-    // cppcheck-suppress memleak
     return _hp2ht(hp);
 }
 


### PR DESCRIPTION
Resolves #188 .

This fixes and re-enables the `cppcheck` job.
I think the main reason why it broke before is that there was an update of the Ubuntu runner image (`ubuntu-latest` was updated to `ubuntu-22.04`) which also includes a newer cppcheck version.

Funnily, I first tried to reproduce the problem on Ubuntu 20.04 with cppcheck 1.90 and did fixes to make that run. Without changing HPy's source code, this did not pass on cppcheck 2.7 (which is available in Ubuntu 22.04). 
Long story short: the cppcheck job broke because of cppcheck. 

I therefore pinned the versions to Ubuntu 22.04 and cppcheck 2.7-1. This should work for a while (a few years).