### PR TITLE
Autogen code also for HPyFunc_NOARGS and HPyFunc_NOARGS_O

### DIFF
--- a/hpy/debug/src/autogen_debug_ctx_call.i
+++ b/hpy/debug/src/autogen_debug_ctx_call.i
@@ -10,6 +10,40 @@
 
 */
 
+    case HPyFunc_NOARGS: {
+        HPyFunc_noargs f = (HPyFunc_noargs)func;
+        _HPyFunc_args_NOARGS *a = (_HPyFunc_args_NOARGS*)args;
+        DHPy dh_self = _py2dh(dctx, a->self);
+        HPyContext *next_dctx = _switch_to_next_dctx_from_cache(dctx);
+        if (next_dctx == NULL) {
+            a->result = NULL;
+            return;
+        }
+        DHPy dh_result = f(next_dctx, dh_self);
+        _switch_back_to_original_dctx(dctx, next_dctx);
+        DHPy_close_and_check(dctx, dh_self);
+        a->result = _dh2py(dctx, dh_result);
+        DHPy_close(dctx, dh_result);
+        return;
+    }
+    case HPyFunc_O: {
+        HPyFunc_o f = (HPyFunc_o)func;
+        _HPyFunc_args_O *a = (_HPyFunc_args_O*)args;
+        DHPy dh_self = _py2dh(dctx, a->self);
+        DHPy dh_arg = _py2dh(dctx, a->arg);
+        HPyContext *next_dctx = _switch_to_next_dctx_from_cache(dctx);
+        if (next_dctx == NULL) {
+            a->result = NULL;
+            return;
+        }
+        DHPy dh_result = f(next_dctx, dh_self, dh_arg);
+        _switch_back_to_original_dctx(dctx, next_dctx);
+        DHPy_close_and_check(dctx, dh_self);
+        DHPy_close_and_check(dctx, dh_arg);
+        a->result = _dh2py(dctx, dh_result);
+        DHPy_close(dctx, dh_result);
+        return;
+    }
     case HPyFunc_UNARYFUNC: {
         HPyFunc_unaryfunc f = (HPyFunc_unaryfunc)func;
         _HPyFunc_args_UNARYFUNC *a = (_HPyFunc_args_UNARYFUNC*)args;

--- a/hpy/debug/src/debug_ctx_cpython.c
+++ b/hpy/debug/src/debug_ctx_cpython.c
@@ -94,48 +94,6 @@ void debug_ctx_CallRealFunctionFromTrampoline(HPyContext *dctx,
                                               void *func, void *args)
 {
     switch (sig) {
-    case HPyFunc_NOARGS: {
-        HPyFunc_noargs f = (HPyFunc_noargs)func;
-        _HPyFunc_args_NOARGS *a = (_HPyFunc_args_NOARGS*)args;
-        DHPy dh_self = _py2dh(dctx, a->self);
-
-        HPyContext *next_dctx = _switch_to_next_dctx_from_cache(dctx);
-        if (next_dctx == NULL) {
-            a->result = NULL;
-            return;
-        }
-
-        DHPy dh_result = f(next_dctx, dh_self);
-
-        _switch_back_to_original_dctx(dctx, next_dctx);
-
-        DHPy_close_and_check(dctx, dh_self); 
-        a->result = _dh2py(dctx, dh_result);
-        DHPy_close(dctx, dh_result);
-        return;
-    }
-    case HPyFunc_O: {
-        HPyFunc_o f = (HPyFunc_o)func;
-        _HPyFunc_args_O *a = (_HPyFunc_args_O*)args;
-        DHPy dh_self = _py2dh(dctx, a->self);
-        DHPy dh_arg = _py2dh(dctx, a->arg);
-
-        HPyContext *next_dctx = _switch_to_next_dctx_from_cache(dctx);
-        if (next_dctx == NULL) {
-            a->result = NULL;
-            return;
-        }
-
-        DHPy dh_result = f(next_dctx, dh_self, dh_arg);
-
-        _switch_back_to_original_dctx(dctx, next_dctx);
-
-        DHPy_close_and_check(dctx, dh_self);
-        DHPy_close_and_check(dctx, dh_arg);
-        a->result = _dh2py(dctx, dh_result);
-        DHPy_close(dctx, dh_result);
-        return;
-    }
     case HPyFunc_VARARGS: {
         HPyFunc_varargs f = (HPyFunc_varargs)func;
         _HPyFunc_args_VARARGS *a = (_HPyFunc_args_VARARGS*)args;

--- a/hpy/devel/include/hpy/cpython/autogen_hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/cpython/autogen_hpyfunc_trampolines.h
@@ -10,6 +10,20 @@
 
 */
 
+typedef HPy (*_HPyCFunction_NOARGS)(HPyContext *, HPy);
+#define _HPyFunc_TRAMPOLINE_HPyFunc_NOARGS(SYM, IMPL) \
+    static cpy_PyObject *SYM(cpy_PyObject *self) \
+    { \
+        _HPyCFunction_NOARGS func = (_HPyCFunction_NOARGS)IMPL; \
+        return _h2py(func(_HPyGetContext(), _py2h(self))); \
+    }
+typedef HPy (*_HPyCFunction_O)(HPyContext *, HPy, HPy);
+#define _HPyFunc_TRAMPOLINE_HPyFunc_O(SYM, IMPL) \
+    static cpy_PyObject *SYM(cpy_PyObject *self, cpy_PyObject *arg) \
+    { \
+        _HPyCFunction_O func = (_HPyCFunction_O)IMPL; \
+        return _h2py(func(_HPyGetContext(), _py2h(self), _py2h(arg))); \
+    }
 typedef HPy (*_HPyCFunction_UNARYFUNC)(HPyContext *, HPy);
 #define _HPyFunc_TRAMPOLINE_HPyFunc_UNARYFUNC(SYM, IMPL) \
     static cpy_PyObject *SYM(cpy_PyObject *arg0) \

--- a/hpy/devel/include/hpy/cpython/hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/cpython/hpyfunc_trampolines.h
@@ -1,25 +1,6 @@
 #ifndef HPY_CPYTHON_HPYFUNC_TRAMPOLINES_H
 #define HPY_CPYTHON_HPYFUNC_TRAMPOLINES_H
 
-
-typedef HPy (*_HPyCFunction_NOARGS)(HPyContext*, HPy);
-#define _HPyFunc_TRAMPOLINE_HPyFunc_NOARGS(SYM, IMPL)                   \
-    static PyObject *                                                   \
-    SYM(PyObject *self, PyObject *noargs)                               \
-    {                                                                   \
-        _HPyCFunction_NOARGS func = (_HPyCFunction_NOARGS)IMPL; \
-        return _h2py(func(_HPyGetContext(), _py2h(self)));              \
-    }
-
-typedef HPy (*_HPyCFunction_O)(HPyContext*, HPy, HPy);
-#define _HPyFunc_TRAMPOLINE_HPyFunc_O(SYM, IMPL)                        \
-    static PyObject *                                                   \
-    SYM(PyObject *self, PyObject *arg)                                  \
-    {                                                                   \
-        _HPyCFunction_O func = (_HPyCFunction_O)IMPL; \
-        return _h2py(func(_HPyGetContext(), _py2h(self), _py2h(arg)));  \
-    }
-
 typedef HPy (*_HPyCFunction_VARARGS)(HPyContext*, HPy, HPy *, HPy_ssize_t);
 #define _HPyFunc_TRAMPOLINE_HPyFunc_VARARGS(SYM, IMPL)                  \
     static PyObject*                                                    \

--- a/hpy/devel/include/hpy/universal/autogen_hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_hpyfunc_trampolines.h
@@ -11,6 +11,35 @@
 */
 
 typedef struct {
+    cpy_PyObject *self;
+    cpy_PyObject * result;
+} _HPyFunc_args_NOARGS;
+
+#define _HPyFunc_TRAMPOLINE_HPyFunc_NOARGS(SYM, IMPL) \
+    static cpy_PyObject *SYM(cpy_PyObject *self) \
+    { \
+        _HPyFunc_args_NOARGS a = { self }; \
+        _HPy_CallRealFunctionFromTrampoline( \
+           _ctx_for_trampolines, HPyFunc_NOARGS, (HPyCFunction)IMPL, &a); \
+        return a.result; \
+    }
+
+typedef struct {
+    cpy_PyObject *self;
+    cpy_PyObject *arg;
+    cpy_PyObject * result;
+} _HPyFunc_args_O;
+
+#define _HPyFunc_TRAMPOLINE_HPyFunc_O(SYM, IMPL) \
+    static cpy_PyObject *SYM(cpy_PyObject *self, cpy_PyObject *arg) \
+    { \
+        _HPyFunc_args_O a = { self, arg }; \
+        _HPy_CallRealFunctionFromTrampoline( \
+           _ctx_for_trampolines, HPyFunc_O, (HPyCFunction)IMPL, &a); \
+        return a.result; \
+    }
+
+typedef struct {
     cpy_PyObject *arg0;
     cpy_PyObject * result;
 } _HPyFunc_args_UNARYFUNC;

--- a/hpy/devel/include/hpy/universal/hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/universal/hpyfunc_trampolines.h
@@ -5,17 +5,6 @@
 
 typedef struct {
     cpy_PyObject *self;
-    cpy_PyObject *result;
-} _HPyFunc_args_NOARGS;
-
-typedef struct {
-    cpy_PyObject *self;
-    cpy_PyObject *arg;
-    cpy_PyObject *result;
-} _HPyFunc_args_O;
-
-typedef struct {
-    cpy_PyObject *self;
     cpy_PyObject *const *args;
     HPy_ssize_t nargs;
     cpy_PyObject *result;
@@ -41,27 +30,6 @@ typedef struct {
     HPy_RichCmpOp arg2;
     cpy_PyObject * result;
 } _HPyFunc_args_RICHCMPFUNC;
-
-
-#define _HPyFunc_TRAMPOLINE_HPyFunc_NOARGS(SYM, IMPL)                   \
-    static cpy_PyObject *                                               \
-    SYM(cpy_PyObject *self, cpy_PyObject *noargs)                       \
-    {                                                                   \
-        _HPyFunc_args_NOARGS a = { self };                              \
-        _HPy_CallRealFunctionFromTrampoline(                            \
-            _ctx_for_trampolines, HPyFunc_NOARGS, (HPyCFunction)IMPL, &a);            \
-        return a.result;                                                \
-    }
-
-#define _HPyFunc_TRAMPOLINE_HPyFunc_O(SYM, IMPL)                        \
-    static cpy_PyObject *                                               \
-    SYM(cpy_PyObject *self, cpy_PyObject *arg)                          \
-    {                                                                   \
-        _HPyFunc_args_O a = { self, arg };                              \
-        _HPy_CallRealFunctionFromTrampoline(                            \
-            _ctx_for_trampolines, HPyFunc_O, (HPyCFunction)IMPL, &a);                 \
-        return a.result;                                                \
-    }
 
 
 #define _HPyFunc_TRAMPOLINE_HPyFunc_VARARGS(SYM, IMPL)                  \

--- a/hpy/tools/autogen/hpyfunc.py
+++ b/hpy/tools/autogen/hpyfunc.py
@@ -3,7 +3,7 @@ from pycparser import c_ast
 from .autogenfile import AutoGenFile
 from .parse import toC, find_typedecl
 
-NO_CALL = ('NOARGS', 'O', 'VARARGS', 'KEYWORDS', 'INITPROC', 'DESTROYFUNC',
+NO_CALL = ('VARARGS', 'KEYWORDS', 'INITPROC', 'DESTROYFUNC',
            'GETBUFFERPROC', 'RELEASEBUFFERPROC', 'TRAVERSEPROC', 'MOD_CREATE')
 NO_TRAMPOLINE = NO_CALL + ('RICHCMPFUNC',)
 

--- a/hpy/universal/src/autogen_ctx_call.i
+++ b/hpy/universal/src/autogen_ctx_call.i
@@ -10,6 +10,18 @@
 
 */
 
+    case HPyFunc_NOARGS: {
+        HPyFunc_noargs f = (HPyFunc_noargs)func;
+        _HPyFunc_args_NOARGS *a = (_HPyFunc_args_NOARGS*)args;
+        a->result = _h2py(f(ctx, _py2h(a->self)));
+        return;
+    }
+    case HPyFunc_O: {
+        HPyFunc_o f = (HPyFunc_o)func;
+        _HPyFunc_args_O *a = (_HPyFunc_args_O*)args;
+        a->result = _h2py(f(ctx, _py2h(a->self), _py2h(a->arg)));
+        return;
+    }
     case HPyFunc_UNARYFUNC: {
         HPyFunc_unaryfunc f = (HPyFunc_unaryfunc)func;
         _HPyFunc_args_UNARYFUNC *a = (_HPyFunc_args_UNARYFUNC*)args;

--- a/hpy/universal/src/ctx_meth.c
+++ b/hpy/universal/src/ctx_meth.c
@@ -39,18 +39,6 @@ ctx_CallRealFunctionFromTrampoline(HPyContext *ctx, HPyFunc_Signature sig,
                                    void* (*func)(), void *args)
 {
     switch (sig) {
-    case HPyFunc_NOARGS: {
-        HPyFunc_noargs f = (HPyFunc_noargs)func;
-        _HPyFunc_args_NOARGS *a = (_HPyFunc_args_NOARGS*)args;
-        a->result = _h2py(f(ctx, _py2h(a->self)));
-        return;
-    }
-    case HPyFunc_O: {
-        HPyFunc_o f = (HPyFunc_o)func;
-        _HPyFunc_args_O *a = (_HPyFunc_args_O*)args;
-        a->result = _h2py(f(ctx, _py2h(a->self), _py2h(a->arg)));
-        return;
-    }
     case HPyFunc_VARARGS: {
         HPyFunc_varargs f = (HPyFunc_varargs)func;
         _HPyFunc_args_VARARGS *a = (_HPyFunc_args_VARARGS*)args;


### PR DESCRIPTION
It seems that there is no reason to not autogenerate them? Maybe they were historically manually written and stayed that way when autogeneration was added? In any case, all tests seem to pass :-)