### PR TITLE
Verify HPy_TypeCheck's 2nd arg in debug mode only.

### DIFF
--- a/docs/api-reference/hpy-object.rst
+++ b/docs/api-reference/hpy-object.rst
@@ -1,0 +1,5 @@
+HPy Object
+==========
+
+.. autocmodule:: autogen/public_api.h
+   :members: HPy_IsTrue,HPy_GetAttr,HPy_GetAttr_s,HPy_HasAttr,HPy_HasAttr_s,HPy_SetAttr,HPy_SetAttr_s,HPy_GetItem,HPy_GetItem_s,HPy_GetItem_i,HPy_SetItem,HPy_SetItem_s,HPy_SetItem_i,HPy_DelItem,HPy_DelItem_s,HPy_DelItem_i,HPy_Type,HPy_TypeCheck,HPy_Is,HPy_Repr,HPy_Str,HPy_ASCII,HPy_Bytes,HPy_RichCompare,HPy_RichCompareBool,HPy_Hash

--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -26,6 +26,7 @@ between the modes.
 
    function-index
    hpy-ctx
+   hpy-object
    hpy-type
    hpy-field
    hpy-global

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -457,11 +457,6 @@ DHPy debug_ctx_Type(HPyContext *dctx, DHPy obj)
     return DHPy_open(dctx, HPy_Type(get_info(dctx)->uctx, DHPy_unwrap(dctx, obj)));
 }
 
-int debug_ctx_TypeCheck(HPyContext *dctx, DHPy obj, DHPy type)
-{
-    return HPy_TypeCheck(get_info(dctx)->uctx, DHPy_unwrap(dctx, obj), DHPy_unwrap(dctx, type));
-}
-
 int debug_ctx_Is(HPyContext *dctx, DHPy obj, DHPy other)
 {
     return HPy_Is(get_info(dctx)->uctx, DHPy_unwrap(dctx, obj), DHPy_unwrap(dctx, other));

--- a/hpy/debug/src/debug_ctx.c
+++ b/hpy/debug/src/debug_ctx.c
@@ -399,3 +399,21 @@ void debug_ctx_TupleBuilder_Cancel(HPyContext *dctx, HPyTupleBuilder dh_builder)
     DHPy_builder_handle_close(dctx, handle);
 }
 
+/*
+   However, we don't want to raise an exception if you pass a non-type,
+   because the CPython version (PyObject_TypeCheck) always succeed and it
+   would be too easy to forget to check the return value. We just raise a
+   fatal error instead.
+ */
+int debug_ctx_TypeCheck(HPyContext *dctx, DHPy obj, DHPy type)
+{
+    HPyContext *uctx = get_info(dctx)->uctx;
+    UHPy uh_obj = DHPy_unwrap(dctx, obj);
+    UHPy uh_type = DHPy_unwrap(dctx, type);
+    assert(!HPy_IsNull(uh_obj));
+    assert(!HPy_IsNull(uh_type));
+    if (!HPy_TypeCheck(uctx, uh_type, uctx->h_TypeType)) {
+        HPy_FatalError(uctx, "HPy_TypeCheck arg 2 must be a type");
+    }
+    return HPy_TypeCheck(uctx, uh_obj, uh_type);
+}

--- a/hpy/devel/src/runtime/ctx_object.c
+++ b/hpy/devel/src/runtime/ctx_object.c
@@ -15,28 +15,15 @@ ctx_Dump(HPyContext *ctx, HPy h)
     _PyObject_Dump(_h2py(h));
 }
 
-/* NOTE: contrarily to CPython, the HPy have to check that h_type is a
-   type. On CPython it's not necessarily because it passes a PyTypeObject*,
-   but here we can only receive an HPy.
-
-   However, we can't/don't want to raise an exception if you pass a non-type,
-   because the CPython version (PyObject_TypeCheck) always succeed and it
-   would be too easy to forget to check the return value. We just raise a
-   fatal error instead.
-
-   Hopefully the slowdown is not too much. If it proves to be too much, we
-   could say that the function is allowed to crash if you pass a non-type, and
-   do the check only in debug mode.
+/* NOTE: In contrast to CPython, HPy has to check that 'h_type' is a type. This
+   is not necessary on CPython because it requires C type 'PyTypeObject *' but
+   here we can only receive an HPy handle. Appropriate checking of the argument
+   will be done in the debug mode.
 */
 _HPy_HIDDEN int
 ctx_TypeCheck(HPyContext *ctx, HPy h_obj, HPy h_type)
 {
-    PyObject *type= _h2py(h_type);
-    assert(type != NULL);
-    if (!PyType_Check(type)) {
-        Py_FatalError("HPy_TypeCheck arg 2 must be a type");
-    }
-    return PyObject_TypeCheck(_h2py(h_obj), (PyTypeObject*)type);
+    return PyObject_TypeCheck(_h2py(h_obj), (PyTypeObject*)_h2py(h_type));
 }
 
 _HPy_HIDDEN int

--- a/hpy/tools/autogen/debug.py
+++ b/hpy/tools/autogen/debug.py
@@ -87,7 +87,8 @@ class autogen_debug_wrappers(AutoGenFile):
         'HPyListBuilder_New',
         'HPyListBuilder_Set',
         'HPyListBuilder_Build',
-        'HPyListBuilder_Cancel'
+        'HPyListBuilder_Cancel',
+        'HPy_TypeCheck'
     }
 
     def generate(self):

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -365,9 +365,40 @@ int HPy_DelItem_i(HPyContext *ctx, HPy obj, HPy_ssize_t idx);
 HPy_ID(237)
 int HPy_DelItem_s(HPyContext *ctx, HPy obj, const char *utf8_key);
 
+/**
+ * Returns the type of the given object ``obj``.
+ *
+ * On failure, raises ``SystemError`` and returns ``HPy_NULL``. This is
+ * equivalent to the Python expression``type(obj)``.
+ *
+ * :param ctx:
+ *     The execution context.
+ * :param obj:
+ *     a Python object (must not be ``HPy_NULL``)
+ *
+ * :returns:
+ *     The type of ``obj`` or ``HPy_NULL`` in case of errors.
+ */
 HPy_ID(165)
 HPy HPy_Type(HPyContext *ctx, HPy obj);
-// WARNING: HPy_TypeCheck could be tweaked/removed in the future, see issue #160
+
+/**
+ * Checks if ``ob`` is an instance of ``type`` or any subtype of ``type``.
+ *
+ * :param ctx:
+ *     The execution context.
+ * :param obj:
+ *     a Python object (must not be ``HPy_NULL``)
+ * :param type:
+ *     A Python type object. This argument must not be ``HPy_NULL`` and must be
+ *     a type (i.e. it must inherit from Python ``type``). If this is not the
+ *     case, the behavior is undefined (verification of the argument is only
+ *     done in debug mode).
+ *
+ * :returns:
+ *     Non-zero if object ``obj`` is an instance of type ``type`` or an instance
+ *     of a subtype of ``type``, and ``0`` otherwise.
+ */
 HPy_ID(166)
 int HPy_TypeCheck(HPyContext *ctx, HPy obj, HPy type);
 


### PR DESCRIPTION
Resolves #160 .

This was decided in [yesterday's dev call](https://github.com/hpyproject/hpy/wiki/dev-call-20230202#decisions-for-release). We do the check if the second argument passed to `HPy_TypeCheck` is a type, in the debug mode only.

I took the opportunity to write doc for `HPy_Type` (since closely related) and `HPy_TypeCheck`.