### PR TITLE
Add HPyUnicode_FromFormat(v) and HPyErr_Format.

### DIFF
--- a/docs/api-reference/formatting.rst
+++ b/docs/api-reference/formatting.rst
@@ -1,0 +1,5 @@
+String Formatting Helpers
+=========================
+
+.. autocmodule:: runtime/format.c
+   :no-members:

--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -51,6 +51,7 @@ problems due to different compilers.
 
    argument-parsing
    build-value
+   formatting
    helpers
 
 

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -72,6 +72,7 @@ class HPyDevel:
         return list(map(str, [
             self.src_dir.joinpath('argparse.c'),
             self.src_dir.joinpath('buildvalue.c'),
+            self.src_dir.joinpath('format.c'),
             self.src_dir.joinpath('helpers.c'),
         ]))
 

--- a/hpy/devel/include/hpy.h
+++ b/hpy/devel/include/hpy.h
@@ -233,10 +233,17 @@ typedef enum {
     typedef Py_ssize_t HPy_ssize_t;
     typedef Py_hash_t HPy_hash_t;
     typedef Py_UCS4 HPy_UCS4;
+
+#   define HPY_SSIZE_T_MAX PY_SSIZE_T_MAX
+#   define HPY_SSIZE_T_MIN PY_SSIZE_T_MIN
+
 #else
     typedef intptr_t HPy_ssize_t;
     typedef intptr_t HPy_hash_t;
     typedef uint32_t HPy_UCS4;
+
+#   define HPY_SSIZE_T_MAX INTPTR_MAX
+#   define HPY_SSIZE_T_MIN (-HPY_SSIZE_T_MAX-1)
 
     /* HPyCapsule field keys */
     typedef enum {
@@ -259,6 +266,7 @@ typedef enum {
 #include "hpy/hpymodule.h"
 #include "hpy/runtime/argparse.h"
 #include "hpy/runtime/buildvalue.h"
+#include "hpy/runtime/format.h"
 #include "hpy/runtime/helpers.h"
 
 #ifdef HPY_ABI_CPYTHON

--- a/hpy/devel/include/hpy/runtime/format.h
+++ b/hpy/devel/include/hpy/runtime/format.h
@@ -1,0 +1,18 @@
+/**
+ * String formatting helpers. These functions are not part of HPy ABI. The implementation will be linked into HPy extensions.
+ */
+#ifndef HPY_COMMON_RUNTIME_FORMAT_H
+#define HPY_COMMON_RUNTIME_FORMAT_H
+
+#include "hpy.h"
+
+HPyAPI_HELPER HPy
+HPyUnicode_FromFormat(HPyContext *ctx, const char *fmt, ...);
+
+HPyAPI_HELPER HPy
+HPyUnicode_FromFormatV(HPyContext *ctx, const char *format, va_list vargs);
+
+HPyAPI_HELPER HPy
+HPyErr_Format(HPyContext *ctx, HPy h_type, const char *fmt, ...);
+
+#endif /* HPY_COMMON_RUNTIME_FORMAT_H */

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -150,7 +150,7 @@ static HPy_ssize_t count_items(HPyContext *ctx, const char *fmt, char end)
                     }
                     par_type = top_level_par;
                 }
-                snprintf(msg, MESSAGE_BUF_SIZE, "unmatched '%c' in the format string passed to HPy_BuildValue", par_type);
+                snprintf(msg, sizeof(msg), "unmatched '%c' in the format string passed to HPy_BuildValue", par_type);
                 HPyErr_SetString(ctx, ctx->h_SystemError, msg);
                 return -1;
             }
@@ -260,7 +260,7 @@ static HPy build_single(HPyContext *ctx, const char **fmt, va_list *values, int 
 
         default: {
             char message[MESSAGE_BUF_SIZE];
-            snprintf(message, MESSAGE_BUF_SIZE, "bad format char '%c' in the format string passed to HPy_BuildValue", format_char);
+            snprintf(message, sizeof(message), "bad format char '%c' in the format string passed to HPy_BuildValue", format_char);
             HPyErr_SetString(ctx, ctx->h_SystemError, message);
             return HPy_NULL;
         }

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -1119,7 +1119,7 @@ ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
 
 #if HAVE_FROM_METACLASS
     /* On Python 3.12 an newer, we can just use 'PyType_FromMetaclass'. */
-    PyObject *result = PyType_FromMetaclass(meta, NULL, spec, bases);
+    PyObject *result = PyType_FromMetaclass(metatype, NULL, spec, bases);
 #else
     /* On Python 3.11 an older, we need to use our own
        '_PyType_FromMetaclass'. */

--- a/hpy/devel/src/runtime/format.c
+++ b/hpy/devel/src/runtime/format.c
@@ -1,0 +1,731 @@
+/**
+ * HPy string formatting helpers.
+ *
+ * Note: these functions are runtime helper functions, i.e., they are not
+ * part of the HPy context ABI, but are available to HPy extensions to
+ * incorporate at compile time.
+ *
+ * The formatting helper functions are: ``HPyUnicode_FromFormat``,
+ * ``HPyUnicode_FromFormatV``, and ``HPyErr_Format``.
+ *
+ * Supported Formatting Units
+ * --------------------------
+ *
+ * ``%%`` - The literal % character.
+ *
+ * Compatible with C (s)printf:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * ``%c [int]``
+ *
+ * ``%d [int]``
+ *
+ * ``%u [unsigned int]``
+ *
+ * ``%ld [long]``
+ *
+ * ``%li [long]``
+ *
+ * ``%lu [unsigned long]``
+ *
+ * ``%lld [long long]``
+ *
+ * ``%lli [long long]``
+ *
+ * ``%llu [unsigned long long]``
+ *
+ * ``%zd [HPy_ssize_t]``
+ *
+ * ``%zi [HPy_ssize_t]``
+ *
+ * ``%zu [size_t]``
+ *
+ * ``%i [int]``
+ *
+ * ``%x [int]``
+ *
+ * ``%s [const char*]``
+ *
+ * ``%p [const void*]``
+ *      Guaranteed to start with the literal 0x regardless of what the platform’s printf yields.
+ *
+ * Python specific:
+ * ~~~~~~~~~~~~~~~~
+ *
+ * ``%A [HPy]``
+ *      The result of calling ``HPy_Ascii``.
+ *
+ * ``%U [HPy]``
+ *      A Unicode object.
+ *
+ * ``%V [HPy, const char*]``
+ *      A Unicode object (which may be ``HPy_NULL``) and a null-terminated C character
+ *      array as a second parameter (which will be used, if the first parameter
+ *      is ``HPy_NULL``).
+ *
+ * ``%S [HPy]``
+ *      The result of calling ``HPyObject_Str``.
+ *
+ * ``%R [HPy]``
+ *      The result of calling ``PyObject_Repr``.
+ *
+ * Additional flags:
+ * ~~~~~~~~~~~~~~~~~
+ *
+ * The format is ``%[0]{width}.{precision}{formatting-unit}``.
+ *
+ * The ``precision`` flag for numbers gives the minimal number of digits
+ * (i.e., excluding the minus sign). Shorter numbers are padded with zeros.
+ * For strings it gives the maximum number of characters, i.e., the string
+ * may be shortened if it is longer than ``precision``.
+ *
+ * The ``width`` determines how many characters should be output. If the
+ * formatting result with ``width`` flag applied is shorter, then it is
+ * padded from left with spaces. If it is longer, the result will
+ * *not* be shortened.
+ *
+ * The ``0`` flag is supported only for numeric units: if present, the
+ * number is padded to desired ``width`` with zeros instead of spaces.
+ * Unlike with spaces padding, the minus sign is shifted to the leftmost
+ * position with zero padding.
+ *
+ * The ``width`` formatter unit is number of characters rather than bytes.
+ * The precision formatter unit is number of bytes for ``%s`` and ``%V``
+ * (if the HPy argument is ``HPy_NULL``), and a number of characters for
+ * ``%A``, ``%U``, ``%S``, ``%R`` and ``%V`` (if the HPy argument is not
+ * ``HPy_NULL``).
+ *
+ * Compatibility with CPython API
+ * ------------------------------
+ *
+ * HPy is more strict in these cases:
+ *
+ * CPython API ignores width, precision, zero-padding flag for formatting
+ * units that do not support them: ``%c`` and ``%p``, but HPy raises a system
+ * error in such cases.
+ *
+ * CPython API ignores zero-padding for "string" formatting units, while HPy
+ * raises a system error in such cases.
+ *
+ * Note: users should not rely on these system errors, as HPy may choose
+ * to support some of those flags in the future.
+ */
+
+
+/* Implementation notes:
+ *
+ * The implementation was taken from CPython, but was adapted to be to operate
+ * only with utf-8 encoding, because that is how HPy exposes Python strings
+ * (i.e., HPyUnicode_AsUTF8AndSize). CPython starts with UCS1 and widens to
+ * UCS2,3,4 depending on the largest character encountered so far. We keep
+ * everything in utf-8, or in fact in ascii as long as we do not encounter any
+ * of the Python specific formatting units such as %S or %V. The only place where
+ * we actually need to have special handling for utf-8 variable width encoding
+ * is with the width and precision flags for Python specific formatting units.
+ *
+ * ------------------------------------------------------------------
+ * CPython copyrights:
+ *
+ * Unicode implementation based on original code by Fredrik Lundh,
+ * modified by Marc-Andre Lemburg <mal@lemburg.com>.
+ *
+ * Major speed upgrades to the method implementations at the Reykjavik
+ * NeedForSpeed sprint, by Fredrik Lundh and Andrew Dalke.
+ *
+ * Copyright (c) Corporation for National Research Initiatives.
+ *
+ * ---------
+ * The original string type implementation is:
+ * Copyright (c) 1999 by Secret Labs AB
+ * Copyright (c) 1999 by Fredrik Lundh
+ *
+ * ------------------------------------------------------------------
+ *
+ * Please see the git history of the following files from CPython source
+ * code for more authors:
+ *
+ *  - Objects/unicodeobject.c
+ *  - Modules/_testcapi/unicode.c
+ */
+
+
+
+#include "hpy.h"
+#include <string.h>
+#include <ctype.h>
+#include <stdio.h>
+
+// Maximum code point of Unicode 6.0: 0x10ffff (1,114,111).
+#define MAX_UNICODE 0x10ffff
+
+/* maximum number of characters required for output of %lld or %p.
+   We need at most ceil(log10(256)*SIZEOF_LONG_LONG) digits,
+   plus 1 for the sign.  53/22 is an upper bound for log10(256). */
+#define MAX_LONG_LONG_CHARS (2 + (sizeof(long long)*53-1) / 22)
+
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+#define OVERALLOCATE_FACTOR 4
+
+typedef struct {
+    char *data_utf8;
+    HPy_ssize_t size;
+    HPy_ssize_t pos;
+    bool memory_error;
+} StrWriter;
+
+static void StrWriter_Init(StrWriter *writer, HPy_ssize_t init_size)
+{
+    memset(writer, 0, sizeof(*writer));
+    init_size = init_size;
+    writer->data_utf8 = malloc(init_size);
+    writer->size = init_size;
+}
+
+static bool StrWriter_EnsureSpace(StrWriter *writer, HPy_ssize_t len)
+{
+    if (len < (writer->size - writer->pos))
+        return true;
+
+    HPy_ssize_t add = (writer->size / OVERALLOCATE_FACTOR);
+    if (len > add)
+        add = len;
+    writer->size += add;
+    if (writer->size < 0)
+        writer->size = HPY_SSIZE_T_MAX;
+    char *prev = writer->data_utf8;
+    writer->data_utf8 = realloc(writer->data_utf8, writer->size);
+    if (!writer->data_utf8) {
+        free(prev);
+        writer->memory_error = true;
+        return false;
+    }
+    return true;
+}
+
+static void StrWriter_WriteCharRaw(StrWriter *writer, const int c)
+{
+    assert((writer->size - writer->pos) > 0);
+    writer->data_utf8[writer->pos++] = c;
+}
+
+static bool StrWriter_WriteChar(StrWriter *writer, const int c)
+{
+    if (!StrWriter_EnsureSpace(writer, 1))
+        return false;
+    StrWriter_WriteCharRaw(writer, c);
+    return true;
+}
+
+static void StrWriter_WriteCharNRaw(StrWriter *writer, char c, HPy_ssize_t n)
+{
+    assert((writer->size - writer->pos) >= n);
+    memset(writer->data_utf8 + writer->pos, c, n);
+    writer->pos += n;
+}
+
+static void StrWriter_WriteRaw(StrWriter *writer, const char *utf8, HPy_ssize_t len)
+{
+    assert((writer->size - writer->pos) >= len);
+    memcpy(writer->data_utf8 + writer->pos, utf8, len);
+    writer->pos += len;
+}
+
+static bool StrWriter_Write(StrWriter *writer, const char *utf8, HPy_ssize_t len)
+{
+    if (!StrWriter_EnsureSpace(writer, len))
+        return false;
+    StrWriter_WriteRaw(writer, utf8, len);
+    return true;
+}
+
+static bool StrWriter_WriteWithWidth(StrWriter *writer, const char *utf8, HPy_ssize_t length,
+                                     HPy_ssize_t width, HPy_ssize_t precision)
+{
+    assert(utf8 != NULL);
+    if ((precision == -1 || precision >= length)
+        && width <= length) {
+        return StrWriter_Write(writer, utf8, length);
+    }
+
+    if (precision != -1)
+        length = MIN(precision, length);
+
+    HPy_ssize_t arglen = MAX(length, width);
+    if (!StrWriter_EnsureSpace(writer, arglen))
+        return false;
+
+    if (width > length) {
+        HPy_ssize_t fill = width - length;
+        StrWriter_WriteCharNRaw(writer, ' ', fill);
+    }
+
+    assert((writer->size - writer->pos) >= length);
+    memcpy(writer->data_utf8 + writer->pos, utf8, length);
+    writer->pos += length;
+    return true;
+}
+
+static bool StrWriter_WriteUnicode(HPyContext *ctx, StrWriter *writer, HPy h,
+                                   HPy_ssize_t width, HPy_ssize_t precision)
+{
+    assert(!HPy_IsNull(h) && HPyUnicode_Check(ctx, h));
+    HPy_ssize_t u_size;
+    const char *u_str = HPyUnicode_AsUTF8AndSize(ctx, h, &u_size);
+    if (!u_str)
+        return false;
+    // We cannot use strlen(u_str), this may not be ascii only string
+    HPy_ssize_t length = HPy_Length(ctx, h);
+
+    if ((precision == -1 || precision >= length)
+        && width <= length) {
+        return StrWriter_Write(writer, u_str, u_size);
+    }
+
+    if (precision != -1)
+        length = MIN(precision, length);
+
+    HPy_ssize_t extra = length - u_size;
+    HPy_ssize_t arglen = MAX(length, width) + extra;
+    if (!StrWriter_EnsureSpace(writer, arglen))
+        return false;
+
+    if (width > length) {
+        HPy_ssize_t fill = width - length;
+        StrWriter_WriteCharNRaw(writer, ' ', fill);
+    }
+
+    if (length == u_size || precision == -1) {
+        return StrWriter_Write(writer, u_str, u_size);
+    } else {
+        // we need to take "precision" many characters from the utf-8 string:
+        HPy_ssize_t chars_count = 0;
+        while (chars_count < precision) {
+            assert(chars_count < u_size);
+            assert((writer->size - writer->pos) > 0);
+            writer->data_utf8[writer->pos++] = *u_str;
+            if ((*u_str & 0xc0) != 0x80)
+                chars_count++;
+            u_str++;
+        }
+        return true;
+    }
+}
+
+static bool StrWriter_DupAndWriteUnicode(HPyContext *ctx, StrWriter *writer, HPy h_unicode,
+                                         HPy_ssize_t width, HPy_ssize_t precision)
+{
+    // We are dupping the handle, such that we can release the C string
+    // as soon as possible by closing the handle immediately here
+    HPy h = HPy_Dup(ctx, h_unicode);
+    bool u_result = StrWriter_WriteUnicode(ctx, writer, h, width, precision);
+    HPy_Close(ctx, h);
+    return u_result;
+}
+
+static bool StrWriter_WriteFunResult(HPyContext *ctx, StrWriter *writer, HPy (fun)(HPyContext*, HPy), HPy arg,
+                                     HPy_ssize_t width, HPy_ssize_t precision)
+{
+    if (HPy_IsNull(arg)) {
+        HPyErr_SetString(ctx, ctx->h_SystemError,
+         "HPy_NULL passed as value for formatting unit '%S' or '%R' or '%A'");
+        return false;
+    }
+    HPy h = fun(ctx, arg);
+    if (HPy_IsNull(h))
+        return false;
+    bool u_result = StrWriter_WriteUnicode(ctx, writer, h, width, precision);
+    HPy_Close(ctx, h);
+    return u_result;
+}
+
+static void StrWriter_Close(StrWriter *writer)
+{
+    free(writer->data_utf8);
+    writer->data_utf8 = NULL;
+}
+
+static HPy StrWriter_ToUnicode(HPyContext *ctx, StrWriter *writer)
+{
+    if (writer->data_utf8 == NULL && !writer->memory_error) {
+        return HPy_NULL;
+    }
+    if (writer->memory_error || !StrWriter_Write(writer, "\0", 1)) {
+        HPyErr_SetString(ctx, ctx->h_MemoryError, "cannot allocate memory for string format");
+        return HPy_NULL;
+    }
+    HPy result = HPyUnicode_FromString(ctx, writer->data_utf8);
+    StrWriter_Close(writer);
+    return result;
+}
+
+static const char*
+unicode_fromformat_arg(HPyContext *ctx, StrWriter *writer, const char *f, va_list *vargs)
+{
+    HPy_ssize_t len;
+    HPy_ssize_t width;
+    HPy_ssize_t precision;
+    int longflag;
+    int longlongflag;
+    int size_tflag;
+    HPy_ssize_t fill;
+
+    f++;
+    if (*f == '%') {
+        if (!StrWriter_WriteChar(writer, '%'))
+            return NULL;
+        f++;
+        return f;
+    }
+
+    bool zeropad = false;
+    if (*f == '0') {
+        zeropad = true;
+        f++;
+    }
+
+    /* parse the width.precision part, e.g. "%2.5s" => width=2, precision=5 */
+    width = -1;
+    if (isdigit(*f)) {
+        width = *f - '0';
+        f++;
+        while (isdigit((unsigned)*f)) {
+            if (width > (HPy_ssize_t) (HPY_SSIZE_T_MAX - ((int)*f - '0')) / 10) {
+                HPyErr_SetString(ctx, ctx->h_ValueError,
+                                "width too big");
+                return NULL;
+            }
+            width = (width * 10) + (*f - '0');
+            f++;
+        }
+    }
+    precision = -1;
+    if (*f == '.') {
+        f++;
+        if (isdigit((unsigned)*f)) {
+            precision = (*f - '0');
+            f++;
+            while (isdigit((unsigned)*f)) {
+                if (precision > (HPy_ssize_t) (HPY_SSIZE_T_MAX - ((int)*f - '0')) / 10) {
+                    HPyErr_SetString(ctx, ctx->h_ValueError,
+                                    "precision too big");
+                    return NULL;
+                }
+                precision = (precision * 10) + (*f - '0');
+                f++;
+            }
+        }
+        if (*f == '%') {
+            /* "%.3%s" => f points to "3" */
+            f--;
+        }
+    }
+    if (*f == '\0') {
+        /* bogus format "%.123" => go backward, f points to "3" */
+        f--;
+    }
+
+    /* Handle %ld, %lu, %lld and %llu. */
+    longflag = 0;
+    longlongflag = 0;
+    size_tflag = 0;
+    if (*f == 'l') {
+        if (f[1] == 'd' || f[1] == 'u' || f[1] == 'i') {
+            longflag = 1;
+            ++f;
+        }
+        else if (f[1] == 'l' &&
+                 (f[2] == 'd' || f[2] == 'u' || f[2] == 'i')) {
+            longlongflag = 1;
+            f += 2;
+        }
+    }
+    /* handle the size_t flag. */
+    else if (*f == 'z' && (f[1] == 'd' || f[1] == 'u' || f[1] == 'i')) {
+        size_tflag = 1;
+        ++f;
+    }
+
+    if (zeropad) {
+        switch (*f) {
+            case 's':
+            case 'U':
+            case 'V':
+            case 'S':
+            case 'R':
+            case 'A':
+            case 'p':
+            case 'c':
+                HPyErr_Format(ctx, ctx->h_SystemError, "formatting unit '%%%c' does not support 0-padding", *f);
+                return NULL;
+        }
+    }
+
+    switch (*f) {
+        case 'c':
+        {
+            if (precision != -1 || width != -1) {
+                HPyErr_SetString(ctx, ctx->h_SystemError,
+                                 "formatting unit '%c' does not support width nor precision");
+                return NULL;
+            }
+            int ordinal = va_arg(*vargs, int);
+            if (ordinal < 0 || ordinal > MAX_UNICODE) {
+                HPyErr_SetString(ctx, ctx->h_OverflowError,
+                                "character argument not in range(0x110000)");
+                return NULL;
+            }
+            if (!StrWriter_WriteChar(writer, ordinal))
+                return NULL;
+            break;
+        }
+
+        case 'i':
+        case 'd':
+        case 'u':
+        case 'x':
+        {
+            /* used by sprintf */
+            char buffer[MAX_LONG_LONG_CHARS];
+            // size_t arglen;
+
+            if (*f == 'u') {
+                if (longflag) {
+                    len = sprintf(buffer, "%lu", va_arg(*vargs, unsigned long));
+                }
+                else if (longlongflag) {
+                    len = sprintf(buffer, "%llu", va_arg(*vargs, unsigned long long));
+                }
+                else if (size_tflag) {
+                    len = sprintf(buffer, "%zu", va_arg(*vargs, size_t));
+                }
+                else {
+                    len = sprintf(buffer, "%u", va_arg(*vargs, unsigned int));
+                }
+            }
+            else if (*f == 'x') {
+                len = sprintf(buffer, "%x", va_arg(*vargs, int));
+            }
+            else {
+                if (longflag) {
+                    len = sprintf(buffer, "%li", va_arg(*vargs, long));
+                }
+                else if (longlongflag) {
+                    len = sprintf(buffer, "%lli", va_arg(*vargs, long long));
+                }
+                else if (size_tflag) {
+                    len = sprintf(buffer, "%zi", va_arg(*vargs, HPy_ssize_t));
+                }
+                else {
+                    len = sprintf(buffer, "%i", va_arg(*vargs, int));
+                }
+            }
+            assert(len >= 0);
+
+            int negative = (buffer[0] == '-');
+            len -= negative;
+
+            precision = MAX(precision, len);
+            width = MAX(width, precision + negative);
+
+            HPy_ssize_t arglen = MAX(precision, width);
+            if (!StrWriter_EnsureSpace(writer, arglen))
+                return NULL;
+
+            if (width > precision) {
+                if (negative && zeropad) {
+                    StrWriter_WriteCharRaw(writer, '-');
+                }
+
+                fill = width - precision - negative;
+                char fillchar = zeropad ? '0' : ' ';
+                StrWriter_WriteCharNRaw(writer, fillchar, fill);
+
+                if (negative && !zeropad) {
+                    StrWriter_WriteCharRaw(writer, '-');
+                }
+            }
+            if (precision > len) {
+                fill = precision - len;
+                StrWriter_WriteCharNRaw(writer, '0', fill);
+            }
+
+            StrWriter_WriteRaw(writer, &buffer[negative], len);
+            break;
+        }
+
+        case 'p':
+        {
+            if (precision != -1 || width != -1) {
+                HPyErr_SetString(ctx, ctx->h_SystemError,
+                                 "formatting unit '%p' does not support width nor precision");
+                return NULL;
+            }
+
+            char number[MAX_LONG_LONG_CHARS];
+
+            len = sprintf(number, "%p", va_arg(*vargs, void*));
+            assert(len >= 0);
+
+            /* %p is ill-defined:  ensure leading 0x. */
+            if (number[1] == 'X')
+                number[1] = 'x';
+            else if (number[1] != 'x') {
+                memmove(number + 2, number,
+                        strlen(number) + 1);
+                number[0] = '0';
+                number[1] = 'x';
+                len += 2;
+            }
+
+            if (!StrWriter_Write(writer, number, len))
+                return NULL;
+            break;
+        }
+
+        case 's':
+        {
+            /* UTF-8 */
+            const char *s = va_arg(*vargs, const char*);
+            if (!s) {
+                HPyErr_SetString(ctx, ctx->h_SystemError, "null c string passed as value for formatting unit '%s'");
+                return NULL;
+            }
+            if (!StrWriter_WriteWithWidth(writer, s, (HPy_ssize_t) strlen(s), width, precision))
+                return NULL;
+            break;
+        }
+
+        case 'U':
+        {
+            HPy h = va_arg(*vargs, HPy);
+            if (HPy_IsNull(h)) {
+                HPyErr_SetString(ctx, ctx->h_SystemError, "HPy_NULL passed as value for formatting unit '%U'");
+                return NULL;
+            }
+            if (!StrWriter_DupAndWriteUnicode(ctx, writer, h, width, precision))
+                return NULL;
+            break;
+        }
+
+        case 'V':
+        {
+            HPy h = va_arg(*vargs, HPy);
+            const char *str = va_arg(*vargs, const char *);
+            if (!HPy_IsNull(h)) {
+                assert(HPyUnicode_Check(ctx, h));
+                if (!StrWriter_DupAndWriteUnicode(ctx, writer, h, width, precision))
+                    return NULL;
+            } else {
+                assert(str != NULL);
+                if (!StrWriter_WriteWithWidth(writer, str,  (HPy_ssize_t) strlen(str), width, precision))
+                    return NULL;
+            }
+            break;
+        }
+
+        case 'S':
+        {
+            if (!StrWriter_WriteFunResult(ctx, writer, HPy_Str, va_arg(*vargs, HPy), width, precision))
+                return NULL;
+            break;
+        }
+
+        case 'R':
+        {
+            if (!StrWriter_WriteFunResult(ctx, writer, HPy_Repr, va_arg(*vargs, HPy), width, precision))
+                return NULL;
+            break;
+        }
+
+        case 'A':
+        {
+            if (!StrWriter_WriteFunResult(ctx, writer, HPy_ASCII, va_arg(*vargs, HPy), width, precision))
+                return NULL;
+            break;
+        }
+
+        default:
+            HPyErr_SetString(ctx, ctx->h_SystemError, "invalid format string");
+            return NULL;
+    }
+
+    f++;
+    return f;
+}
+
+HPyAPI_HELPER HPy
+HPyUnicode_FromFormatV(HPyContext *ctx, const char *format, va_list vargs)
+{
+    va_list vargs2;
+    const char *f;
+    StrWriter writer;
+
+    StrWriter_Init(&writer, (HPy_ssize_t) (strlen(format) + 100));
+
+    // Copy varags to be able to pass a reference to a subfunction.
+    va_copy(vargs2, vargs);
+
+    for (f = format; *f; ) {
+        if (*f == '%') {
+            f = unicode_fromformat_arg(ctx, &writer, f, &vargs2);
+            if (f == NULL) {
+                StrWriter_Close(&writer);
+                goto end;
+            }
+        }
+        else {
+            const char *p;
+            HPy_ssize_t len;
+
+            p = f;
+            do
+            {
+                if ((unsigned char)*p > 127) {
+                    HPyErr_Format(ctx, ctx->h_ValueError,
+                                 "expected an ASCII-encoded format "
+                                 "string, got a non-ASCII byte: 0x%02x",
+                                 (unsigned char)*p);
+                    StrWriter_Close(&writer);
+                    goto end;
+                }
+                p++;
+            }
+            while (*p != '\0' && *p != '%');
+            len = p - f;
+
+            if (!StrWriter_Write(&writer, f, len)) {
+                StrWriter_Close(&writer);
+                goto end;
+            }
+
+            f = p;
+        }
+    }
+end:
+    va_end(vargs2);
+    return StrWriter_ToUnicode(ctx, &writer);
+}
+
+HPyAPI_HELPER HPy
+HPyUnicode_FromFormat(HPyContext *ctx, const char *fmt, ...)
+{
+    va_list vargs;
+    va_start(vargs, fmt);
+    HPy ret = HPyUnicode_FromFormatV(ctx, fmt, vargs);
+    va_end(vargs);
+    return ret;
+}
+
+HPyAPI_HELPER HPy
+HPyErr_Format(HPyContext *ctx, HPy h_type, const char *fmt, ...)
+{
+    va_list vargs;
+    va_start(vargs, fmt);
+    HPy h_str = HPyUnicode_FromFormatV(ctx, fmt, vargs);
+    va_end(vargs);
+    HPyErr_SetObject(ctx, h_type, h_str);
+    HPy_Close(ctx, h_str);
+    return HPy_NULL;
+}

--- a/hpy/devel/src/runtime/format.c
+++ b/hpy/devel/src/runtime/format.c
@@ -492,36 +492,37 @@ unicode_fromformat_arg(HPyContext *ctx, StrWriter *writer, const char *f, va_lis
 
             if (*f == 'u') {
                 if (longflag) {
-                    len = sprintf(buffer, "%lu", va_arg(*vargs, unsigned long));
+                    len = snprintf(buffer, sizeof(buffer), "%lu", va_arg(*vargs, unsigned long));
                 }
                 else if (longlongflag) {
-                    len = sprintf(buffer, "%llu", va_arg(*vargs, unsigned long long));
+                    len = snprintf(buffer, sizeof(buffer), "%llu", va_arg(*vargs, unsigned long long));
                 }
                 else if (size_tflag) {
-                    len = sprintf(buffer, "%zu", va_arg(*vargs, size_t));
+                    len = snprintf(buffer, sizeof(buffer), "%zu", va_arg(*vargs, size_t));
                 }
                 else {
-                    len = sprintf(buffer, "%u", va_arg(*vargs, unsigned int));
+                    len = snprintf(buffer, sizeof(buffer), "%u", va_arg(*vargs, unsigned int));
                 }
             }
             else if (*f == 'x') {
-                len = sprintf(buffer, "%x", va_arg(*vargs, int));
+                len = snprintf(buffer, sizeof(buffer), "%x", va_arg(*vargs, int));
             }
             else {
                 if (longflag) {
-                    len = sprintf(buffer, "%li", va_arg(*vargs, long));
+                    len = snprintf(buffer, sizeof(buffer), "%li", va_arg(*vargs, long));
                 }
                 else if (longlongflag) {
-                    len = sprintf(buffer, "%lli", va_arg(*vargs, long long));
+                    len = snprintf(buffer, sizeof(buffer), "%lli", va_arg(*vargs, long long));
                 }
                 else if (size_tflag) {
-                    len = sprintf(buffer, "%zi", va_arg(*vargs, HPy_ssize_t));
+                    len = snprintf(buffer, sizeof(buffer), "%zi", va_arg(*vargs, HPy_ssize_t));
                 }
                 else {
-                    len = sprintf(buffer, "%i", va_arg(*vargs, int));
+                    len = snprintf(buffer, sizeof(buffer), "%i", va_arg(*vargs, int));
                 }
             }
             assert(len >= 0);
+            len = MIN((HPy_ssize_t) sizeof(buffer), len);
 
             int negative = (buffer[0] == '-');
             len -= negative;
@@ -565,7 +566,8 @@ unicode_fromformat_arg(HPyContext *ctx, StrWriter *writer, const char *f, va_lis
 
             char number[MAX_LONG_LONG_CHARS];
 
-            len = sprintf(number, "%p", va_arg(*vargs, void*));
+            len = snprintf(number, sizeof(number), "%p", va_arg(*vargs, void*));
+            len = MIN((HPy_ssize_t) sizeof(number), len);
             assert(len >= 0);
 
             /* %p is ill-defined:  ensure leading 0x. */

--- a/hpy/devel/src/runtime/format.c
+++ b/hpy/devel/src/runtime/format.c
@@ -178,7 +178,7 @@ typedef struct {
 static void StrWriter_Init(StrWriter *writer, HPy_ssize_t init_size)
 {
     memset(writer, 0, sizeof(*writer));
-    writer->data_utf8 = malloc(init_size);
+    writer->data_utf8 = (char*) malloc(init_size);
     writer->size = init_size;
 }
 
@@ -194,7 +194,7 @@ static bool StrWriter_EnsureSpace(StrWriter *writer, HPy_ssize_t len)
     if (writer->size < 0)
         writer->size = HPY_SSIZE_T_MAX;
     char *prev = writer->data_utf8;
-    writer->data_utf8 = realloc(writer->data_utf8, writer->size);
+    writer->data_utf8 = (char*) realloc(writer->data_utf8, writer->size);
     if (!writer->data_utf8) {
         free(prev);
         writer->memory_error = true;

--- a/hpy/devel/src/runtime/format.c
+++ b/hpy/devel/src/runtime/format.c
@@ -178,7 +178,6 @@ typedef struct {
 static void StrWriter_Init(StrWriter *writer, HPy_ssize_t init_size)
 {
     memset(writer, 0, sizeof(*writer));
-    init_size = init_size;
     writer->data_utf8 = malloc(init_size);
     writer->size = init_size;
 }

--- a/hpy/devel/src/runtime/format.c
+++ b/hpy/devel/src/runtime/format.c
@@ -47,7 +47,12 @@
  * ``%s [const char*]``
  *
  * ``%p [const void*]``
- *      Guaranteed to start with the literal 0x regardless of what the platform’s printf yields.
+ *      Guaranteed to start with the literal '0x' regardless of what the
+ *      platform’s printf yields. However, there is no guarantee for
+ *      zero-padding after the '0x' prefix. Some systems pad the pointer
+ *      to 32 or 64 digits depending on the architecture, some do not
+ *      zero pad at all. Moreover, there is no guarantee whether the letters
+ *      will be capitalized or not.
  *
  * Python specific:
  * ~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ def get_scm_config():
 HPY_EXTRA_SOURCES = [
     'hpy/devel/src/runtime/argparse.c',
     'hpy/devel/src/runtime/buildvalue.c',
+    'hpy/devel/src/runtime/format.c',
     'hpy/devel/src/runtime/helpers.c',
 ]
 

--- a/test/test_hpyerr.py
+++ b/test/test_hpyerr.py
@@ -692,3 +692,17 @@ class TestErr(HPyTest):
         result = python_subprocess.run(mod, "mod.f()")
         assert result.returncode == 0
 
+
+    def test_HPyErr_Format(self):
+        import pytest
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                return HPyErr_Format(ctx, ctx->h_ValueError, "Formatted '%S' and %d", arg, 42);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        with pytest.raises(ValueError, match="Formatted 'error message' and 42"):
+            mod.f("error message")

--- a/test/test_hpyunicode.py
+++ b/test/test_hpyunicode.py
@@ -1,4 +1,9 @@
 # -*- encoding: utf-8 -*-
+import itertools
+import re
+import sys
+
+import pytest
 
 from .support import HPyTest
 
@@ -102,7 +107,7 @@ class TestUnicode(HPyTest):
         mod = self.make_module("""
             #include <string.h>
 
-            static HPy as_utf8_and_size(HPyContext *ctx, HPy arg, HPy_ssize_t *size) 
+            static HPy as_utf8_and_size(HPyContext *ctx, HPy arg, HPy_ssize_t *size)
             {
                 HPy_ssize_t n;
                 const char* buf = HPyUnicode_AsUTF8AndSize(ctx, arg, size);
@@ -216,3 +221,618 @@ class TestUnicode(HPyTest):
         """)
         assert mod.f('ABC') == "ABC"
         assert mod.g().encode('ascii') == b'ab\0c'
+
+    def test_FromFormat(self, hpy_abi):
+        # Later we generate an HPy function for each case described below:
+        # Most of the test cases are taken from CPython:Modules/_testcapi/unicode.c
+        # Future work can improve this to add tests from Lib/test/test_capi/test_unicode.py
+        cases = [
+            # Unrecognized
+            (    "%y%d", (SystemError, "invalid format string"), "'w', 42"),
+            ("%04.2y%d", (SystemError, "invalid format string"), "'w', 42"),
+            ("%u %? %u", (SystemError, "invalid format string"), "1, 2"),
+
+            # "%%" (options are rejected)
+            (  "%%", "%", "0"),
+            ("%%%c", "%w", "'w'"),
+            ( "%0%", (SystemError, "invalid format string"), "0"),
+            ("%00%", (SystemError, "invalid format string"), "0"),
+            ( "%2%", (SystemError, "invalid format string"), "0"),
+            ("%02%", (SystemError, "invalid format string"), "0"),
+            ("%.0%", (SystemError, "invalid format string"), "0"),
+            ("%.2%", (SystemError, "invalid format string"), "0"),
+
+            # "%c"
+            (  "%c", "c", "'c'"),
+
+            # Integers
+            ("%d",            "123",               '(int)123'),
+            ("%i",            "123",               '(int)123'),
+            ("%u",            "123",      '(unsigned int)123'),
+            ("%ld",           "123",              '(long)123'),
+            ("%li",           "123",              '(long)123'),
+            ("%lu",           "123",     '(unsigned long)123'),
+            ("%lld",          "123",         '(long long)123'),
+            ("%lli",          "123",         '(long long)123'),
+            ("%llu",          "123",'(unsigned long long)123'),
+            ("%zd",           "123",       '(HPy_ssize_t)123'),
+            ("%zi",           "123",       '(HPy_ssize_t)123'),
+            ("%zu",           "123",            '(size_t)123'),
+            ("%x",             "7b",               '(int)123'),
+
+            ("%d",           "-123",              '(int)-123'),
+            ("%i",           "-123",              '(int)-123'),
+            ("%ld",          "-123",             '(long)-123'),
+            ("%li",          "-123",             '(long)-123'),
+            ("%lld",         "-123",        '(long long)-123'),
+            ("%lli",         "-123",        '(long long)-123'),
+            ("%zd",          "-123",      '(HPy_ssize_t)-123'),
+            ("%zi",          "-123",      '(HPy_ssize_t)-123'),
+            ("%x",       "ffffff85",              '(int)-123'),
+
+            # Integers: width < length
+            ("%1d",           "123",               '(int)123'),
+            ("%1i",           "123",               '(int)123'),
+            ("%1u",           "123",      '(unsigned int)123'),
+            ("%1ld",          "123",              '(long)123'),
+            ("%1li",          "123",              '(long)123'),
+            ("%1lu",          "123",     '(unsigned long)123'),
+            ("%1lld",         "123",         '(long long)123'),
+            ("%1lli",         "123",         '(long long)123'),
+            ("%1llu",         "123",'(unsigned long long)123'),
+            ("%1zd",          "123",       '(HPy_ssize_t)123'),
+            ("%1zi",          "123",       '(HPy_ssize_t)123'),
+            ("%1zu",          "123",            '(size_t)123'),
+            ("%1x",            "7b",               '(int)123'),
+
+            ("%1d",          "-123",              '(int)-123'),
+            ("%1i",          "-123",              '(int)-123'),
+            ("%1ld",         "-123",             '(long)-123'),
+            ("%1li",         "-123",             '(long)-123'),
+            ("%1lld",        "-123",        '(long long)-123'),
+            ("%1lli",        "-123",        '(long long)-123'),
+            ("%1zd",         "-123",      '(HPy_ssize_t)-123'),
+            ("%1zi",         "-123",      '(HPy_ssize_t)-123'),
+            ("%1x",      "ffffff85",              '(int)-123'),
+
+            # Integers: width > length
+            ("%5d",         "  123",               '(int)123'),
+            ("%5i",         "  123",               '(int)123'),
+            ("%5u",         "  123",      '(unsigned int)123'),
+            ("%5ld",        "  123",              '(long)123'),
+            ("%5li",        "  123",              '(long)123'),
+            ("%5lu",        "  123",     '(unsigned long)123'),
+            ("%5lld",       "  123",         '(long long)123'),
+            ("%5lli",       "  123",         '(long long)123'),
+            ("%5llu",       "  123",'(unsigned long long)123'),
+            ("%5zd",        "  123",       '(HPy_ssize_t)123'),
+            ("%5zi",        "  123",       '(HPy_ssize_t)123'),
+            ("%5zu",        "  123",            '(size_t)123'),
+            ("%5x",         "   7b",               '(int)123'),
+
+            ("%5d",         " -123",              '(int)-123'),
+            ("%5i",         " -123",              '(int)-123'),
+            ("%5ld",        " -123",             '(long)-123'),
+            ("%5li",        " -123",             '(long)-123'),
+            ("%5lld",       " -123",        '(long long)-123'),
+            ("%5lli",       " -123",        '(long long)-123'),
+            ("%5zd",        " -123",      '(HPy_ssize_t)-123'),
+            ("%5zi",        " -123",      '(HPy_ssize_t)-123'),
+            ("%9x",     " ffffff85",              '(int)-123'),
+
+            # Integers: width > length, 0-flag
+            ("%05d",        "00123",               '(int)123'),
+            ("%05i",        "00123",               '(int)123'),
+            ("%05u",        "00123",      '(unsigned int)123'),
+            ("%05ld",       "00123",              '(long)123'),
+            ("%05li",       "00123",              '(long)123'),
+            ("%05lu",       "00123",     '(unsigned long)123'),
+            ("%05lld",      "00123",         '(long long)123'),
+            ("%05lli",      "00123",         '(long long)123'),
+            ("%05llu",      "00123",'(unsigned long long)123'),
+            ("%05zd",       "00123",       '(HPy_ssize_t)123'),
+            ("%05zi",       "00123",       '(HPy_ssize_t)123'),
+            ("%05zu",       "00123",            '(size_t)123'),
+            ("%05x",        "0007b",               '(int)123'),
+
+            ("%05d",        "-0123",              '(int)-123'),
+            ("%05i",        "-0123",              '(int)-123'),
+            ("%05ld",       "-0123",             '(long)-123'),
+            ("%05li",       "-0123",             '(long)-123'),
+            ("%05lld",      "-0123",        '(long long)-123'),
+            ("%05lli",      "-0123",        '(long long)-123'),
+            ("%05zd",       "-0123",      '(HPy_ssize_t)-123'),
+            ("%05zi",       "-0123",      '(HPy_ssize_t)-123'),
+            ("%09x",    "0ffffff85",              '(int)-123'),
+
+            # Integers: precision < length
+            ("%.1d",          "123",               '(int)123'),
+            ("%.1i",          "123",               '(int)123'),
+            ("%.1u",          "123",      '(unsigned int)123'),
+            ("%.1ld",         "123",              '(long)123'),
+            ("%.1li",         "123",              '(long)123'),
+            ("%.1lu",         "123",     '(unsigned long)123'),
+            ("%.1lld",        "123",         '(long long)123'),
+            ("%.1lli",        "123",         '(long long)123'),
+            ("%.1llu",        "123",'(unsigned long long)123'),
+            ("%.1zd",         "123",       '(HPy_ssize_t)123'),
+            ("%.1zi",         "123",       '(HPy_ssize_t)123'),
+            ("%.1zu",         "123",            '(size_t)123'),
+            ("%.1x",           "7b",               '(int)123'),
+
+            ("%.1d",         "-123",              '(int)-123'),
+            ("%.1i",         "-123",              '(int)-123'),
+            ("%.1ld",        "-123",             '(long)-123'),
+            ("%.1li",        "-123",             '(long)-123'),
+            ("%.1lld",       "-123",        '(long long)-123'),
+            ("%.1lli",       "-123",        '(long long)-123'),
+            ("%.1zd",        "-123",      '(HPy_ssize_t)-123'),
+            ("%.1zi",        "-123",      '(HPy_ssize_t)-123'),
+            ("%.1x",     "ffffff85",              '(int)-123'),
+
+            # Integers: precision > length
+            ("%.5d",        "00123",               '(int)123'),
+            ("%.5i",        "00123",               '(int)123'),
+            ("%.5u",        "00123",      '(unsigned int)123'),
+            ("%.5ld",       "00123",              '(long)123'),
+            ("%.5li",       "00123",              '(long)123'),
+            ("%.5lu",       "00123",     '(unsigned long)123'),
+            ("%.5lld",      "00123",         '(long long)123'),
+            ("%.5lli",      "00123",         '(long long)123'),
+            ("%.5llu",      "00123",'(unsigned long long)123'),
+            ("%.5zd",       "00123",       '(HPy_ssize_t)123'),
+            ("%.5zi",       "00123",       '(HPy_ssize_t)123'),
+            ("%.5zu",       "00123",            '(size_t)123'),
+            ("%.5x",        "0007b",               '(int)123'),
+
+            ("%.5d",       "-00123",              '(int)-123'),
+            ("%.5i",       "-00123",              '(int)-123'),
+            ("%.5ld",      "-00123",             '(long)-123'),
+            ("%.5li",      "-00123",             '(long)-123'),
+            ("%.5lld",     "-00123",        '(long long)-123'),
+            ("%.5lli",     "-00123",        '(long long)-123'),
+            ("%.5zd",      "-00123",      '(HPy_ssize_t)-123'),
+            ("%.5zi",      "-00123",      '(HPy_ssize_t)-123'),
+            ("%.9x",    "0ffffff85",              '(int)-123'),
+
+            # Integers: width > precision > length
+            ("%7.5d",     "  00123",               '(int)123'),
+            ("%7.5i",     "  00123",               '(int)123'),
+            ("%7.5u",     "  00123",      '(unsigned int)123'),
+            ("%7.5ld",    "  00123",              '(long)123'),
+            ("%7.5li",    "  00123",              '(long)123'),
+            ("%7.5lu",    "  00123",     '(unsigned long)123'),
+            ("%7.5lld",   "  00123",         '(long long)123'),
+            ("%7.5lli",   "  00123",         '(long long)123'),
+            ("%7.5llu",   "  00123",'(unsigned long long)123'),
+            ("%7.5zd",    "  00123",       '(HPy_ssize_t)123'),
+            ("%7.5zi",    "  00123",       '(HPy_ssize_t)123'),
+            ("%7.5zu",    "  00123",            '(size_t)123'),
+            ("%7.5x",     "  0007b",               '(int)123'),
+
+            ("%7.5d",     " -00123",              '(int)-123'),
+            ("%7.5i",     " -00123",              '(int)-123'),
+            ("%7.5ld",    " -00123",             '(long)-123'),
+            ("%7.5li",    " -00123",             '(long)-123'),
+            ("%7.5lld",   " -00123",        '(long long)-123'),
+            ("%7.5lli",   " -00123",        '(long long)-123'),
+            ("%7.5zd",    " -00123",      '(HPy_ssize_t)-123'),
+            ("%7.5zi",    " -00123",      '(HPy_ssize_t)-123'),
+            ("%10.9x", " 0ffffff85",              '(int)-123'),
+
+            # Integers: width > precision > length, 0-flag
+            ("%07.5d",    "0000123",               '(int)123'),
+            ("%07.5i",    "0000123",               '(int)123'),
+            ("%07.5u",    "0000123",      '(unsigned int)123'),
+            ("%07.5ld",   "0000123",              '(long)123'),
+            ("%07.5li",   "0000123",              '(long)123'),
+            ("%07.5lu",   "0000123",     '(unsigned long)123'),
+            ("%07.5lld",  "0000123",         '(long long)123'),
+            ("%07.5lli",  "0000123",         '(long long)123'),
+            ("%07.5llu",  "0000123",'(unsigned long long)123'),
+            ("%07.5zd",   "0000123",       '(HPy_ssize_t)123'),
+            ("%07.5zi",   "0000123",       '(HPy_ssize_t)123'),
+            ("%07.5zu",   "0000123",            '(size_t)123'),
+            ("%07.5x",    "000007b",               '(int)123'),
+
+            ("%07.5d",    "-000123",              '(int)-123'),
+            ("%07.5i",    "-000123",              '(int)-123'),
+            ("%07.5ld",   "-000123",             '(long)-123'),
+            ("%07.5li",   "-000123",             '(long)-123'),
+            ("%07.5lld",  "-000123",        '(long long)-123'),
+            ("%07.5lli",  "-000123",        '(long long)-123'),
+            ("%07.5zd",   "-000123",      '(HPy_ssize_t)-123'),
+            ("%07.5zi",   "-000123",      '(HPy_ssize_t)-123'),
+            ("%010.9x","00ffffff85",              '(int)-123'),
+
+            # Integers: precision > width > length
+            ("%5.7d",     "0000123",               '(int)123'),
+            ("%5.7i",     "0000123",               '(int)123'),
+            ("%5.7u",     "0000123",      '(unsigned int)123'),
+            ("%5.7ld",    "0000123",              '(long)123'),
+            ("%5.7li",    "0000123",              '(long)123'),
+            ("%5.7lu",    "0000123",     '(unsigned long)123'),
+            ("%5.7lld",   "0000123",         '(long long)123'),
+            ("%5.7lli",   "0000123",         '(long long)123'),
+            ("%5.7llu",   "0000123",'(unsigned long long)123'),
+            ("%5.7zd",    "0000123",       '(HPy_ssize_t)123'),
+            ("%5.7zi",    "0000123",       '(HPy_ssize_t)123'),
+            ("%5.7zu",    "0000123",            '(size_t)123'),
+            ("%5.7x",     "000007b",               '(int)123'),
+
+            ("%5.7d",    "-0000123",              '(int)-123'),
+            ("%5.7i",    "-0000123",              '(int)-123'),
+            ("%5.7ld",   "-0000123",             '(long)-123'),
+            ("%5.7li",   "-0000123",             '(long)-123'),
+            ("%5.7lld",  "-0000123",        '(long long)-123'),
+            ("%5.7lli",  "-0000123",        '(long long)-123'),
+            ("%5.7zd",   "-0000123",      '(HPy_ssize_t)-123'),
+            ("%5.7zi",   "-0000123",      '(HPy_ssize_t)-123'),
+            ("%9.10x", "00ffffff85",              '(int)-123'),
+
+            # Integers: precision > width > length, 0-flag
+            ("%05.7d",    "0000123",               '(int)123'),
+            ("%05.7i",    "0000123",               '(int)123'),
+            ("%05.7u",    "0000123",      '(unsigned int)123'),
+            ("%05.7ld",   "0000123",              '(long)123'),
+            ("%05.7li",   "0000123",              '(long)123'),
+            ("%05.7lu",   "0000123",     '(unsigned long)123'),
+            ("%05.7lld",  "0000123",         '(long long)123'),
+            ("%05.7lli",  "0000123",         '(long long)123'),
+            ("%05.7llu",  "0000123",'(unsigned long long)123'),
+            ("%05.7zd",   "0000123",       '(HPy_ssize_t)123'),
+            ("%05.7zi",   "0000123",       '(HPy_ssize_t)123'),
+            ("%05.7zu",   "0000123",            '(size_t)123'),
+            ("%05.7x",    "000007b",               '(int)123'),
+
+            ("%05.7d",   "-0000123",              '(int)-123'),
+            ("%05.7i",   "-0000123",              '(int)-123'),
+            ("%05.7ld",  "-0000123",             '(long)-123'),
+            ("%05.7li",  "-0000123",             '(long)-123'),
+            ("%05.7lld", "-0000123",        '(long long)-123'),
+            ("%05.7lli", "-0000123",        '(long long)-123'),
+            ("%05.7zd",  "-0000123",      '(HPy_ssize_t)-123'),
+            ("%05.7zi",  "-0000123",      '(HPy_ssize_t)-123'),
+            ("%09.10x","00ffffff85",              '(int)-123'),
+
+            # Integers: precision = 0, arg = 0 (empty string in C)
+            ("%.0d",            "0",                 '(int)0'),
+            ("%.0i",            "0",                 '(int)0'),
+            ("%.0u",            "0",        '(unsigned int)0'),
+            ("%.0ld",           "0",                '(long)0'),
+            ("%.0li",           "0",                '(long)0'),
+            ("%.0lu",           "0",       '(unsigned long)0'),
+            ("%.0lld",          "0",           '(long long)0'),
+            ("%.0lli",          "0",           '(long long)0'),
+            ("%.0llu",          "0",  '(unsigned long long)0'),
+            ("%.0zd",           "0",         '(HPy_ssize_t)0'),
+            ("%.0zi",           "0",         '(HPy_ssize_t)0'),
+            ("%.0zu",           "0",              '(size_t)0'),
+            ("%.0x",            "0",                 '(int)0'),
+
+            # Strings
+            ("%s",     "None", ' "None"'),
+            ("%U",     "None", 'unicode'),
+            ("%A",     "None", 'ctx->h_None'),
+            ("%S",     "None", 'ctx->h_None'),
+            ("%R",     "None", 'ctx->h_None'),
+            ("%V",     "None", 'unicode, "ignored"'),
+            ("%V",     "None", '   NULL,    "None"'),
+
+            # Strings: width < length
+            ("%1s",    "None", ' "None"'),
+            ("%1U",    "None", 'unicode'),
+            ("%1A",    "None", 'ctx->h_None'),
+            ("%1S",    "None", 'ctx->h_None'),
+            ("%1R",    "None", 'ctx->h_None'),
+            ("%1V",    "None", 'unicode, "ignored"'),
+            ("%1V",    "None", '   NULL,    "None"'),
+
+            # Strings: width > length
+            ("%5s",   " None", ' "None"'),
+            ("%5U",   " None", 'unicode'),
+            ("%5A",   " None", 'ctx->h_None'),
+            ("%5S",   " None", 'ctx->h_None'),
+            ("%5R",   " None", 'ctx->h_None'),
+            ("%5V",   " None", 'unicode, "ignored"'),
+            ("%5V",   " None", '   NULL,    "None"'),
+
+            # Strings: precision < length
+            ("%.1s",      "N", ' "None"'),
+            ("%.1U",      "N", 'unicode'),
+            ("%.1A",      "N", 'ctx->h_None'),
+            ("%.1S",      "N", 'ctx->h_None'),
+            ("%.1R",      "N", 'ctx->h_None'),
+            ("%.1V",      "N", 'unicode, "ignored"'),
+            ("%.1V",      "N", '   NULL,    "None"'),
+
+            # Strings: precision > length
+            ("%.5s",   "None", ' "None"'),
+            ("%.5U",   "None", 'unicode'),
+            ("%.5A",   "None", 'ctx->h_None'),
+            ("%.5S",   "None", 'ctx->h_None'),
+            ("%.5R",   "None", 'ctx->h_None'),
+            ("%.5V",   "None", 'unicode, "ignored"'),
+            ("%.5V",   "None", '   NULL,    "None"'),
+
+            # Strings: precision < length, width > length
+            ("%5.1s", "    N", ' "None"'),
+            ("%5.1U", "    N", 'unicode'),
+            ("%5.1A", "    N", 'ctx->h_None'),
+            ("%5.1S", "    N", 'ctx->h_None'),
+            ("%5.1R", "    N", 'ctx->h_None'),
+            ("%5.1V", "    N", 'unicode, "ignored"'),
+            ("%5.1V", "    N", '   NULL,    "None"'),
+
+            # Strings: width < length, precision > length
+            ("%1.5s",  "None", ' "None"'),
+            ("%1.5U",  "None", 'unicode'),
+            ("%1.5A",  "None", 'ctx->h_None'),
+            ("%1.5S",  "None", 'ctx->h_None'),
+            ("%1.5R",  "None", 'ctx->h_None'),
+            ("%1.5V",  "None", 'unicode, "ignored"'),
+            ("%1.5V",  "None", '   NULL,    "None"'),
+
+            # Additional HPy tests:
+            ("%p", "0xbeef", "(void*)(0xbeef)"),
+            ("%c", (OverflowError, re.escape("character argument not in range(0x110000)")), "0x10ffff + 2"),
+
+            ("check if %5d %s %6.3d is %5S or %6.3S",
+             "check if    42 ==   -042 is  True or    Fal",
+             '42, "==", -42, ctx->h_True, ctx->h_False')
+        ]
+
+        cpython_incompatible_cases = [
+            (    "%s", (SystemError, "null c string passed as value for formatting unit '%s'"), "NULL"),
+
+            (   '%4p', (SystemError, "formatting unit '%p' does not support width nor precision"), "0"),
+            (  '%04p', (SystemError, "formatting unit '%p' does not support 0-padding"), "0"),
+            (  '%.4p', (SystemError, "formatting unit '%p' does not support width nor precision"), "0"),
+            ( '%8.4p', (SystemError, "formatting unit '%p' does not support width nor precision"), "0"),
+            ('%08.4p', (SystemError, "formatting unit '%p' does not support 0-padding"), "0"),
+
+            (   '%4c', (SystemError, "formatting unit '%c' does not support width nor precision"), "0"),
+            (  '%04c', (SystemError, "formatting unit '%c' does not support 0-padding"), "0"),
+            (  '%.4c', (SystemError, "formatting unit '%c' does not support width nor precision"), "0"),
+            ( '%8.4c', (SystemError, "formatting unit '%c' does not support width nor precision"), "0"),
+            ('%08.4c', (SystemError, "formatting unit '%c' does not support 0-padding"), "0"),
+
+            ("%U", (SystemError, ".*HPy_NULL passed.*"), "HPy_NULL"),
+            ("%S", (SystemError, ".*HPy_NULL passed.*"), "HPy_NULL"),
+            ("%R", (SystemError, ".*HPy_NULL passed.*"), "HPy_NULL"),
+            ("%A", (SystemError, ".*HPy_NULL passed.*"), "HPy_NULL"),
+
+            ("%0s", (SystemError, "formatting unit '%s' does not support 0-padding"), "0"),
+            ("%0p", (SystemError, "formatting unit '%p' does not support 0-padding"), "0"),
+            ("%0U", (SystemError, "formatting unit '%U' does not support 0-padding"), "0"),
+            ("%0V", (SystemError, "formatting unit '%V' does not support 0-padding"), "0"),
+            ("%0S", (SystemError, "formatting unit '%S' does not support 0-padding"), "0"),
+            ("%0R", (SystemError, "formatting unit '%R' does not support 0-padding"), "0"),
+            ("%0A", (SystemError, "formatting unit '%A' does not support 0-padding"), "0"),
+        ]
+
+        cases += cpython_incompatible_cases
+        cpython_incompatible_cases = set(cpython_incompatible_cases)
+
+        # Generate a unique name for each test that is also valid C identifier
+        names = ['a' + str(i) for i in range(0, len(cases))]
+        cases = {name:case for (name, case) in itertools.zip_longest(names, cases)}
+
+        # ---
+        # Generate the test code from the cases:
+        def makefun(name, fmt, arg):
+            return f"""
+                HPyDef_METH({name}, "{name}", HPyFunc_NOARGS)
+                static HPy {name}_impl(HPyContext *ctx, HPy self)
+                {{
+                    HPy unicode = HPyUnicode_FromString(ctx, "None");
+                    if (HPy_IsNull(unicode)) return HPy_NULL;
+                    HPy result = HPyUnicode_FromFormat(ctx, "{fmt}", {arg});
+                    HPy_Close(ctx, unicode);
+                    return result;
+                }}
+
+                #ifdef CPM_WITH_CPYTHON
+                HPyDef_METH({name}_cpython, "{name}_cpython", HPyFunc_NOARGS)
+                static HPy {name}_cpython_impl(HPyContext *ctx, HPy self)
+                {{
+                    PyObject *unicode = PyUnicode_FromString("None");
+                    PyObject *py = PyUnicode_FromFormat("{fmt}", {arg.replace("ctx->h_None", "Py_None").replace("HPy_ssize_t", "Py_ssize_t")});
+                    HPy hpy = HPy_NULL;
+                    if (py != NULL) {{
+                        hpy = HPy_FromPyObject(ctx, py);
+                        Py_DECREF(py);
+                    }}
+                    Py_DECREF(unicode);
+                    return hpy;
+                }}
+                #endif
+            """
+
+        # Change False->True to also check comparison with CPython.
+        # Works only for 3.12 or higher, lower versions have bugs that are
+        # fixed in HPy
+        compare_with_cpython = False and \
+                               hpy_abi == 'cpython' and \
+                               sys.implementation.name == 'cpython' and \
+                               sys.implementation.version.major >= 3 and \
+                               sys.implementation.version.minor >= 12
+
+        # Create functions for each case using the "makefun" template, export them
+        lines = ['#define CPM_WITH_CPYTHON'] if compare_with_cpython else []
+        lines += [makefun(name, fmt, arg) for (name, (fmt, _, arg)) in cases.items()]
+        lines += [f"@EXPORT({name})" for name in cases.keys()]
+        if compare_with_cpython:
+            lines += [f"@EXPORT({name}_cpython)" for name in cases.keys()]
+        lines += ["@INIT"]
+
+        mod = self.make_module("\n".join(lines))
+
+        def check_cpython_raises_any(name):
+            try:
+                getattr(mod, name + "_cpython")()
+                return False
+            except:
+                return True
+
+        for (name, case) in cases.items():
+            (_, expected, _) = case
+            if isinstance(expected, tuple):
+                (expected_type, expected_message) = expected
+                with pytest.raises(expected_type, match=expected_message):
+                    getattr(mod, name)()
+                if compare_with_cpython and case not in cpython_incompatible_cases:
+                    check_cpython_raises_any(name)
+                continue
+
+            assert getattr(mod, name)() == expected, name + ":" + repr(case)
+            if compare_with_cpython and case not in cpython_incompatible_cases:
+                assert getattr(mod, name)() == getattr(mod, name + "_cpython")(), \
+                    f"CPython check: {name}:" + repr(case)
+
+    def test_FromFormat_PyObjs(self):
+        mod = self.make_module("""
+            HPyDef_METH(S, "S", HPyFunc_O)
+            static HPy S_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                return HPyUnicode_FromFormat(ctx, "prefix-%S-suffix", arg);
+            }
+
+            HPyDef_METH(R, "R", HPyFunc_O)
+            static HPy R_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                return HPyUnicode_FromFormat(ctx, "prefix-%R-suffix", arg);
+            }
+
+            HPyDef_METH(A, "A", HPyFunc_O)
+            static HPy A_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                return HPyUnicode_FromFormat(ctx, "prefix-%A-suffix", arg);
+            }
+
+            @EXPORT(S)
+            @EXPORT(R)
+            @EXPORT(A)
+            @INIT
+        """)
+
+        class MyObj:
+            def __str__(self):
+                return "MyObj.__str__"
+
+            def __repr__(self):
+                return "MyObj.__repr__ü"
+
+        assert mod.S('ABC') == 'prefix-ABC-suffix'
+        assert mod.S(42) == 'prefix-42-suffix'
+        assert mod.S(MyObj()) == 'prefix-MyObj.__str__-suffix'
+
+        assert mod.R('ABC') == "prefix-'ABC'-suffix"
+        assert mod.R(42) == 'prefix-42-suffix'
+        assert mod.R(MyObj()) == 'prefix-MyObj.__repr__ü-suffix'
+
+        assert mod.A('ABC') == "prefix-'ABC'-suffix"
+        assert mod.A(42) == 'prefix-42-suffix'
+        assert mod.A(MyObj()) == 'prefix-MyObj.__repr__\\xfc-suffix'
+
+    def test_FromFormat_NoAsciiEncodedFmt(self):
+        mod = self.make_module("""
+            HPyDef_METH(no_ascii_fmt, "no_ascii_fmt", HPyFunc_O)
+            static HPy no_ascii_fmt_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                HPy_ssize_t s;
+                const char *fmt = HPyUnicode_AsUTF8AndSize(ctx, arg, &s);
+                return HPyUnicode_FromFormat(ctx, fmt);
+            }
+
+            @EXPORT(no_ascii_fmt)
+            @INIT
+        """)
+
+        with pytest.raises(ValueError, match="expected an ASCII-encoded format string, got a non-ASCII byte: 0xc3"):
+            mod.no_ascii_fmt("format ü")
+
+    def test_FromFormat_Unicode(self):
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                return HPyUnicode_FromFormat(ctx, "%10.5S", arg);
+            }
+
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f("€urΘpe") == "     €urΘp"
+
+    def test_FromFormat_LongFormat(self):
+        chunk_size = 1000
+        chunks_count = 5
+        args = ','.join([str(i) for i in range(1, chunks_count+1)])
+        mod = self.make_module(f"""
+            #include <string.h>
+
+            HPyDef_METH(f, "f", HPyFunc_NOARGS)
+            static HPy f_impl(HPyContext *ctx, HPy self)
+            {{
+                const size_t chunk_size = {chunk_size} + 1; // for the '%d'
+                const size_t total_size =
+                    chunk_size * {chunks_count} + 1; // for terminating null
+                char fmt[total_size];
+                memset(fmt, 'a', total_size);
+                fmt[total_size - 1] = '\\0';
+                for (size_t i = 0; i < {chunks_count}; i++) {{
+                    fmt[i * chunk_size] = '%';
+                    fmt[(i * chunk_size)+1] = 'd';
+                }}
+                return HPyUnicode_FromFormat(ctx, fmt, {args});
+            }}
+
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f() == ''.join([str(i) + ("a" * (chunk_size - 1)) for i in range(1,chunks_count+1)])
+
+    def test_FromFormat_Limits(self):
+        import sys
+        mod = self.make_module(f"""
+                #include <stdio.h>
+
+                HPyDef_METH(width, "width", HPyFunc_NOARGS)
+                static HPy width_impl(HPyContext *ctx, HPy self)
+                {{
+                    char fmt[512];
+                    sprintf(fmt, "%%%llud", ((unsigned long long) HPY_SSIZE_T_MAX) + 1ull);
+                    return HPyUnicode_FromFormat(ctx, fmt, 42);
+                }}
+
+                HPyDef_METH(precision, "precision", HPyFunc_NOARGS)
+                static HPy precision_impl(HPyContext *ctx, HPy self)
+                {{
+                    char fmt[512];
+                    sprintf(fmt, "%%.%llud", (unsigned long long) HPY_SSIZE_T_MAX + 1ull);
+                    return HPyUnicode_FromFormat(ctx, fmt, 42);
+                }}
+
+                HPyDef_METH(memory_err_width, "memory_err_width", HPyFunc_NOARGS)
+                static HPy memory_err_width_impl(HPyContext *ctx, HPy self)
+                {{
+                    return HPyUnicode_FromFormat(ctx, "%{sys.maxsize + 1}d", 42);
+                }}
+
+                HPyDef_METH(memory_err_precision, "memory_err_precision", HPyFunc_NOARGS)
+                static HPy memory_err_precision_impl(HPyContext *ctx, HPy self)
+                {{
+                    return HPyUnicode_FromFormat(ctx, "%.{sys.maxsize + 1}d", 42);
+                }}
+
+                @EXPORT(width)
+                @EXPORT(precision)
+                @INIT
+            """)
+        with pytest.raises(ValueError) as exc:
+            mod.width()
+        assert str(exc.value) == "width too big"
+        with pytest.raises(ValueError) as exc:
+            mod.precision()
+        assert str(exc.value) == "precision too big"

--- a/test/test_hpyunicode.py
+++ b/test/test_hpyunicode.py
@@ -782,6 +782,7 @@ class TestUnicode(HPyTest):
     def test_FromFormat_LongFormat(self):
         chunk_size = 1000
         chunks_count = 5
+        total_c_size = (chunk_size + 1) * chunks_count + 1
         args = ','.join([str(i) for i in range(1, chunks_count+1)])
         mod = self.make_module("""
             #include <string.h>
@@ -790,9 +791,8 @@ class TestUnicode(HPyTest):
             static HPy f_impl(HPyContext *ctx, HPy self)
             {{
                 const size_t chunk_size = {chunk_size} + 1; // for the '%d'
-                const size_t total_size =
-                    chunk_size * {chunks_count} + 1; // for terminating null
-                char fmt[total_size];
+                const size_t total_size = {total_size};
+                char fmt[{total_size}];
                 memset(fmt, 'a', total_size);
                 fmt[total_size - 1] = '\\0';
                 for (size_t i = 0; i < {chunks_count}; i++) {{
@@ -804,7 +804,7 @@ class TestUnicode(HPyTest):
 
             @EXPORT(f)
             @INIT
-        """.format(chunk_size=chunk_size, chunks_count=chunks_count, args=args))
+        """.format(chunk_size=chunk_size, chunks_count=chunks_count, total_size=total_c_size, args=args))
         assert mod.f() == ''.join([str(i) + ("a" * (chunk_size - 1)) for i in range(1,chunks_count+1)])
 
     def test_FromFormat_Limits(self):


### PR DESCRIPTION
Git log message:
```
 Implement API helper functions  HPyUnicode_FromFormat(V) and HPyErr_Format
    
    The HPy implementation was taken from CPython, but was adapted to be to operate
    only with utf-8 encoding, because that is how HPy exposes Python strings
    (i.e., HPyUnicode_AsUTF8AndSize). CPython starts with UCS1 and widens to
    UCS2,3,4 depending on the largest character encountered so far. We keep
    everything in utf-8, or in fact in ascii as long as we do not encounter any of
    the Python specific formatting units such as %S or %V. The only place where
    we actually need to have special handling for wider characters is with the width
    and precision flags for Python specific formatting units.
    
    The contract is bit stricter than CPython, for example: width/precision are not
    just ignored for %c and %p, but cause an error. NULL and HPy_NULL values are
    not just asserted, but cause a Python level system error. From quick check of
    the top 4000 packages it seems that this should not cause any compatibility
    issues.
    
    We chose to not expose HPyErr_FormatV yet, because it does not seem necessary:
    no usages in top 4000 packages.
```