### PR TITLE
Introduce HPyUnicode_FromEncodedObject and HPyUnicode_Substring.

### DIFF
--- a/docs/api-reference/function-index.rst
+++ b/docs/api-reference/function-index.rst
@@ -26,6 +26,7 @@ HPy Core API Function Index
 * :c:func:`HPyContextVar_New`
 * :c:func:`HPyContextVar_Set`
 * :c:func:`HPyDict_Check`
+* :c:func:`HPyDict_Keys`
 * :c:func:`HPyDict_New`
 * :c:func:`HPyErr_Clear`
 * :c:func:`HPyErr_ExceptionMatches`

--- a/docs/api-reference/function-index.rst
+++ b/docs/api-reference/function-index.rst
@@ -94,6 +94,7 @@ HPy Core API Function Index
 * :c:func:`HPyUnicode_DecodeFSDefaultAndSize`
 * :c:func:`HPyUnicode_DecodeLatin1`
 * :c:func:`HPyUnicode_EncodeFSDefault`
+* :c:func:`HPyUnicode_FromEncodedObject`
 * :c:func:`HPyUnicode_FromString`
 * :c:func:`HPyUnicode_FromWideChar`
 * :c:func:`HPyUnicode_ReadChar`

--- a/docs/api-reference/function-index.rst
+++ b/docs/api-reference/function-index.rst
@@ -98,6 +98,7 @@ HPy Core API Function Index
 * :c:func:`HPyUnicode_FromString`
 * :c:func:`HPyUnicode_FromWideChar`
 * :c:func:`HPyUnicode_ReadChar`
+* :c:func:`HPyUnicode_Substring`
 * :c:func:`HPy_ASCII`
 * :c:func:`HPy_Absolute`
 * :c:func:`HPy_Add`

--- a/docs/api-reference/function-index.rst
+++ b/docs/api-reference/function-index.rst
@@ -26,6 +26,7 @@ HPy Core API Function Index
 * :c:func:`HPyContextVar_New`
 * :c:func:`HPyContextVar_Set`
 * :c:func:`HPyDict_Check`
+* :c:func:`HPyDict_Copy`
 * :c:func:`HPyDict_Keys`
 * :c:func:`HPyDict_New`
 * :c:func:`HPyErr_Clear`

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -273,6 +273,7 @@ with the code for the :term:`CPython ABI` mode, so it is guaranteed to be correc
     `PyUnicode_FromString <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromString>`_                                      :c:func:`HPyUnicode_FromString`
     `PyUnicode_FromWideChar <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromWideChar>`_                                  :c:func:`HPyUnicode_FromWideChar`
     `PyUnicode_ReadChar <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_ReadChar>`_                                          :c:func:`HPyUnicode_ReadChar`
+    `PyUnicode_Substring <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_Substring>`_                                        :c:func:`HPyUnicode_Substring`
     ================================================================================================================================== ================================================
 
 

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -269,6 +269,7 @@ with the code for the :term:`CPython ABI` mode, so it is guaranteed to be correc
     `PyUnicode_DecodeFSDefaultAndSize <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_DecodeFSDefaultAndSize>`_              :c:func:`HPyUnicode_DecodeFSDefaultAndSize`
     `PyUnicode_DecodeLatin1 <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_DecodeLatin1>`_                                  :c:func:`HPyUnicode_DecodeLatin1`
     `PyUnicode_EncodeFSDefault <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_EncodeFSDefault>`_                            :c:func:`HPyUnicode_EncodeFSDefault`
+    `PyUnicode_FromEncodedObject <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromEncodedObject>`_                        :c:func:`HPyUnicode_FromEncodedObject`
     `PyUnicode_FromString <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromString>`_                                      :c:func:`HPyUnicode_FromString`
     `PyUnicode_FromWideChar <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromWideChar>`_                                  :c:func:`HPyUnicode_FromWideChar`
     `PyUnicode_ReadChar <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_ReadChar>`_                                          :c:func:`HPyUnicode_ReadChar`

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -170,6 +170,7 @@ with the code for the :term:`CPython ABI` mode, so it is guaranteed to be correc
     `PyContextVar_New <https://docs.python.org/3/c-api/contextvars.html#c.PyContextVar_New>`_                                          :c:func:`HPyContextVar_New`
     `PyContextVar_Set <https://docs.python.org/3/c-api/contextvars.html#c.PyContextVar_Set>`_                                          :c:func:`HPyContextVar_Set`
     `PyDict_Check <https://docs.python.org/3/c-api/dict.html#c.PyDict_Check>`_                                                         :c:func:`HPyDict_Check`
+    `PyDict_Copy <https://docs.python.org/3/c-api/dict.html#c.PyDict_Copy>`_                                                           :c:func:`HPyDict_Copy`
     `PyDict_Keys <https://docs.python.org/3/c-api/dict.html#c.PyDict_Keys>`_                                                           :c:func:`HPyDict_Keys`
     `PyDict_New <https://docs.python.org/3/c-api/dict.html#c.PyDict_New>`_                                                             :c:func:`HPyDict_New`
     `PyErr_Clear <https://docs.python.org/3/c-api/exceptions.html#c.PyErr_Clear>`_                                                     :c:func:`HPyErr_Clear`

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -170,6 +170,7 @@ with the code for the :term:`CPython ABI` mode, so it is guaranteed to be correc
     `PyContextVar_New <https://docs.python.org/3/c-api/contextvars.html#c.PyContextVar_New>`_                                          :c:func:`HPyContextVar_New`
     `PyContextVar_Set <https://docs.python.org/3/c-api/contextvars.html#c.PyContextVar_Set>`_                                          :c:func:`HPyContextVar_Set`
     `PyDict_Check <https://docs.python.org/3/c-api/dict.html#c.PyDict_Check>`_                                                         :c:func:`HPyDict_Check`
+    `PyDict_Keys <https://docs.python.org/3/c-api/dict.html#c.PyDict_Keys>`_                                                           :c:func:`HPyDict_Keys`
     `PyDict_New <https://docs.python.org/3/c-api/dict.html#c.PyDict_New>`_                                                             :c:func:`HPyDict_New`
     `PyErr_Clear <https://docs.python.org/3/c-api/exceptions.html#c.PyErr_Clear>`_                                                     :c:func:`HPyErr_Clear`
     `PyErr_ExceptionMatches <https://docs.python.org/3/c-api/exceptions.html#c.PyErr_ExceptionMatches>`_                               :c:func:`HPyErr_ExceptionMatches`

--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -144,6 +144,7 @@ HPy_UCS4 debug_ctx_Unicode_ReadChar(HPyContext *dctx, DHPy h, HPy_ssize_t index)
 DHPy debug_ctx_Unicode_DecodeASCII(HPyContext *dctx, const char *ascii, HPy_ssize_t size, const char *errors);
 DHPy debug_ctx_Unicode_DecodeLatin1(HPyContext *dctx, const char *latin1, HPy_ssize_t size, const char *errors);
 DHPy debug_ctx_Unicode_FromEncodedObject(HPyContext *dctx, DHPy obj, const char *encoding, const char *errors);
+DHPy debug_ctx_Unicode_Substring(HPyContext *dctx, DHPy str, HPy_ssize_t start, HPy_ssize_t end);
 int debug_ctx_List_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_List_New(HPyContext *dctx, HPy_ssize_t len);
 int debug_ctx_List_Append(HPyContext *dctx, DHPy h_list, DHPy h_item);
@@ -403,6 +404,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_Unicode_DecodeASCII = &debug_ctx_Unicode_DecodeASCII;
     dctx->ctx_Unicode_DecodeLatin1 = &debug_ctx_Unicode_DecodeLatin1;
     dctx->ctx_Unicode_FromEncodedObject = &debug_ctx_Unicode_FromEncodedObject;
+    dctx->ctx_Unicode_Substring = &debug_ctx_Unicode_Substring;
     dctx->ctx_List_Check = &debug_ctx_List_Check;
     dctx->ctx_List_New = &debug_ctx_List_New;
     dctx->ctx_List_Append = &debug_ctx_List_Append;

--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -150,6 +150,7 @@ DHPy debug_ctx_List_New(HPyContext *dctx, HPy_ssize_t len);
 int debug_ctx_List_Append(HPyContext *dctx, DHPy h_list, DHPy h_item);
 int debug_ctx_Dict_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Dict_New(HPyContext *dctx);
+DHPy debug_ctx_Dict_Keys(HPyContext *dctx, DHPy h);
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Tuple_FromArray(HPyContext *dctx, DHPy items[], HPy_ssize_t n);
 DHPy debug_ctx_Import_ImportModule(HPyContext *dctx, const char *utf8_name);
@@ -410,6 +411,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_List_Append = &debug_ctx_List_Append;
     dctx->ctx_Dict_Check = &debug_ctx_Dict_Check;
     dctx->ctx_Dict_New = &debug_ctx_Dict_New;
+    dctx->ctx_Dict_Keys = &debug_ctx_Dict_Keys;
     dctx->ctx_Tuple_Check = &debug_ctx_Tuple_Check;
     dctx->ctx_Tuple_FromArray = &debug_ctx_Tuple_FromArray;
     dctx->ctx_Import_ImportModule = &debug_ctx_Import_ImportModule;

--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -143,6 +143,7 @@ DHPy debug_ctx_Unicode_EncodeFSDefault(HPyContext *dctx, DHPy h);
 HPy_UCS4 debug_ctx_Unicode_ReadChar(HPyContext *dctx, DHPy h, HPy_ssize_t index);
 DHPy debug_ctx_Unicode_DecodeASCII(HPyContext *dctx, const char *ascii, HPy_ssize_t size, const char *errors);
 DHPy debug_ctx_Unicode_DecodeLatin1(HPyContext *dctx, const char *latin1, HPy_ssize_t size, const char *errors);
+DHPy debug_ctx_Unicode_FromEncodedObject(HPyContext *dctx, DHPy obj, const char *encoding, const char *errors);
 int debug_ctx_List_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_List_New(HPyContext *dctx, HPy_ssize_t len);
 int debug_ctx_List_Append(HPyContext *dctx, DHPy h_list, DHPy h_item);
@@ -401,6 +402,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_Unicode_ReadChar = &debug_ctx_Unicode_ReadChar;
     dctx->ctx_Unicode_DecodeASCII = &debug_ctx_Unicode_DecodeASCII;
     dctx->ctx_Unicode_DecodeLatin1 = &debug_ctx_Unicode_DecodeLatin1;
+    dctx->ctx_Unicode_FromEncodedObject = &debug_ctx_Unicode_FromEncodedObject;
     dctx->ctx_List_Check = &debug_ctx_List_Check;
     dctx->ctx_List_New = &debug_ctx_List_New;
     dctx->ctx_List_Append = &debug_ctx_List_Append;

--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -151,6 +151,7 @@ int debug_ctx_List_Append(HPyContext *dctx, DHPy h_list, DHPy h_item);
 int debug_ctx_Dict_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Dict_New(HPyContext *dctx);
 DHPy debug_ctx_Dict_Keys(HPyContext *dctx, DHPy h);
+DHPy debug_ctx_Dict_Copy(HPyContext *dctx, DHPy h);
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Tuple_FromArray(HPyContext *dctx, DHPy items[], HPy_ssize_t n);
 DHPy debug_ctx_Import_ImportModule(HPyContext *dctx, const char *utf8_name);
@@ -412,6 +413,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_Dict_Check = &debug_ctx_Dict_Check;
     dctx->ctx_Dict_New = &debug_ctx_Dict_New;
     dctx->ctx_Dict_Keys = &debug_ctx_Dict_Keys;
+    dctx->ctx_Dict_Copy = &debug_ctx_Dict_Copy;
     dctx->ctx_Tuple_Check = &debug_ctx_Tuple_Check;
     dctx->ctx_Tuple_FromArray = &debug_ctx_Tuple_FromArray;
     dctx->ctx_Import_ImportModule = &debug_ctx_Import_ImportModule;

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -1511,6 +1511,18 @@ DHPy debug_ctx_Dict_Keys(HPyContext *dctx, DHPy h)
     return DHPy_open(dctx, universal_result);
 }
 
+DHPy debug_ctx_Dict_Copy(HPyContext *dctx, DHPy h)
+{
+    if (!get_ctx_info(dctx)->is_valid) {
+        report_invalid_debug_context();
+    }
+    HPy dh_h = DHPy_unwrap(dctx, h);
+    get_ctx_info(dctx)->is_valid = false;
+    HPy universal_result = HPyDict_Copy(get_info(dctx)->uctx, dh_h);
+    get_ctx_info(dctx)->is_valid = true;
+    return DHPy_open(dctx, universal_result);
+}
+
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h)
 {
     if (!get_ctx_info(dctx)->is_valid) {

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -1428,6 +1428,18 @@ DHPy debug_ctx_Unicode_DecodeLatin1(HPyContext *dctx, const char *latin1, HPy_ss
     return DHPy_open(dctx, universal_result);
 }
 
+DHPy debug_ctx_Unicode_FromEncodedObject(HPyContext *dctx, DHPy obj, const char *encoding, const char *errors)
+{
+    if (!get_ctx_info(dctx)->is_valid) {
+        report_invalid_debug_context();
+    }
+    HPy dh_obj = DHPy_unwrap(dctx, obj);
+    get_ctx_info(dctx)->is_valid = false;
+    HPy universal_result = HPyUnicode_FromEncodedObject(get_info(dctx)->uctx, dh_obj, encoding, errors);
+    get_ctx_info(dctx)->is_valid = true;
+    return DHPy_open(dctx, universal_result);
+}
+
 int debug_ctx_List_Check(HPyContext *dctx, DHPy h)
 {
     if (!get_ctx_info(dctx)->is_valid) {

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -1499,6 +1499,18 @@ DHPy debug_ctx_Dict_New(HPyContext *dctx)
     return DHPy_open(dctx, universal_result);
 }
 
+DHPy debug_ctx_Dict_Keys(HPyContext *dctx, DHPy h)
+{
+    if (!get_ctx_info(dctx)->is_valid) {
+        report_invalid_debug_context();
+    }
+    HPy dh_h = DHPy_unwrap(dctx, h);
+    get_ctx_info(dctx)->is_valid = false;
+    HPy universal_result = HPyDict_Keys(get_info(dctx)->uctx, dh_h);
+    get_ctx_info(dctx)->is_valid = true;
+    return DHPy_open(dctx, universal_result);
+}
+
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h)
 {
     if (!get_ctx_info(dctx)->is_valid) {

--- a/hpy/debug/src/debug_ctx.c
+++ b/hpy/debug/src/debug_ctx.c
@@ -589,3 +589,24 @@ int debug_ctx_Type_IsSubtype(HPyContext *dctx, DHPy sub, DHPy type)
     ctx_info->is_valid = true;
     return res;
 }
+
+DHPy debug_ctx_Unicode_Substring(HPyContext *dctx, DHPy str, HPy_ssize_t start, HPy_ssize_t end)
+{
+    HPyDebugCtxInfo *ctx_info;
+    HPyContext *uctx;
+
+    ctx_info = get_ctx_info(dctx);
+    if (!ctx_info->is_valid) {
+        report_invalid_debug_context();
+    }
+
+    HPy uh_str = DHPy_unwrap(dctx, str);
+    uctx = ctx_info->info->uctx;
+    if (!HPy_TypeCheck(uctx, uh_str, uctx->h_UnicodeType)) {
+        HPy_FatalError(uctx, "HPyUnicode_Substring arg 1 must be a Unicode object");
+    }
+    ctx_info->is_valid = false;
+    HPy universal_result = HPyUnicode_Substring(uctx, uh_str, start, end);
+    ctx_info->is_valid = true;
+    return DHPy_open(dctx, universal_result);
+}

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -489,6 +489,11 @@ HPyAPI_FUNC HPy HPyUnicode_DecodeLatin1(HPyContext *ctx, const char *latin1, HPy
     return _py2h(PyUnicode_DecodeLatin1(latin1, size, errors));
 }
 
+HPyAPI_FUNC HPy HPyUnicode_FromEncodedObject(HPyContext *ctx, HPy obj, const char *encoding, const char *errors)
+{
+    return _py2h(PyUnicode_FromEncodedObject(_h2py(obj), encoding, errors));
+}
+
 HPyAPI_FUNC int HPyList_Check(HPyContext *ctx, HPy h)
 {
     return PyList_Check(_h2py(h));

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -494,6 +494,11 @@ HPyAPI_FUNC HPy HPyUnicode_FromEncodedObject(HPyContext *ctx, HPy obj, const cha
     return _py2h(PyUnicode_FromEncodedObject(_h2py(obj), encoding, errors));
 }
 
+HPyAPI_FUNC HPy HPyUnicode_Substring(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end)
+{
+    return _py2h(PyUnicode_Substring(_h2py(str), start, end));
+}
+
 HPyAPI_FUNC int HPyList_Check(HPyContext *ctx, HPy h)
 {
     return PyList_Check(_h2py(h));

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -529,6 +529,11 @@ HPyAPI_FUNC HPy HPyDict_Keys(HPyContext *ctx, HPy h)
     return _py2h(PyDict_Keys(_h2py(h)));
 }
 
+HPyAPI_FUNC HPy HPyDict_Copy(HPyContext *ctx, HPy h)
+{
+    return _py2h(PyDict_Copy(_h2py(h)));
+}
+
 HPyAPI_FUNC int HPyTuple_Check(HPyContext *ctx, HPy h)
 {
     return PyTuple_Check(_h2py(h));

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -524,6 +524,11 @@ HPyAPI_FUNC HPy HPyDict_New(HPyContext *ctx)
     return _py2h(PyDict_New());
 }
 
+HPyAPI_FUNC HPy HPyDict_Keys(HPyContext *ctx, HPy h)
+{
+    return _py2h(PyDict_Keys(_h2py(h)));
+}
+
 HPyAPI_FUNC int HPyTuple_Check(HPyContext *ctx, HPy h)
 {
     return PyTuple_Check(_h2py(h));

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -272,4 +272,5 @@ struct _HPyContext_s {
     HPy (*ctx_Unicode_FromEncodedObject)(HPyContext *ctx, HPy obj, const char *encoding, const char *errors);
     HPy (*ctx_Unicode_Substring)(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end);
     HPy (*ctx_Dict_Keys)(HPyContext *ctx, HPy h);
+    HPy (*ctx_Dict_Copy)(HPyContext *ctx, HPy h);
 };

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -269,4 +269,5 @@ struct _HPyContext_s {
     HPy (*ctx_ContextVar_Set)(HPyContext *ctx, HPy context_var, HPy value);
     const char *(*ctx_Type_GetName)(HPyContext *ctx, HPy type);
     int (*ctx_Type_IsSubtype)(HPyContext *ctx, HPy sub, HPy type);
+    HPy (*ctx_Unicode_FromEncodedObject)(HPyContext *ctx, HPy obj, const char *encoding, const char *errors);
 };

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -271,4 +271,5 @@ struct _HPyContext_s {
     int (*ctx_Type_IsSubtype)(HPyContext *ctx, HPy sub, HPy type);
     HPy (*ctx_Unicode_FromEncodedObject)(HPyContext *ctx, HPy obj, const char *encoding, const char *errors);
     HPy (*ctx_Unicode_Substring)(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end);
+    HPy (*ctx_Dict_Keys)(HPyContext *ctx, HPy h);
 };

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -270,4 +270,5 @@ struct _HPyContext_s {
     const char *(*ctx_Type_GetName)(HPyContext *ctx, HPy type);
     int (*ctx_Type_IsSubtype)(HPyContext *ctx, HPy sub, HPy type);
     HPy (*ctx_Unicode_FromEncodedObject)(HPyContext *ctx, HPy obj, const char *encoding, const char *errors);
+    HPy (*ctx_Unicode_Substring)(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end);
 };

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -566,6 +566,10 @@ HPyAPI_FUNC HPy HPyDict_Keys(HPyContext *ctx, HPy h) {
      return ctx->ctx_Dict_Keys ( ctx, h ); 
 }
 
+HPyAPI_FUNC HPy HPyDict_Copy(HPyContext *ctx, HPy h) {
+     return ctx->ctx_Dict_Copy ( ctx, h ); 
+}
+
 HPyAPI_FUNC int HPyTuple_Check(HPyContext *ctx, HPy h) {
      return ctx->ctx_Tuple_Check ( ctx, h ); 
 }

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -538,6 +538,10 @@ HPyAPI_FUNC HPy HPyUnicode_FromEncodedObject(HPyContext *ctx, HPy obj, const cha
      return ctx->ctx_Unicode_FromEncodedObject ( ctx, obj, encoding, errors ); 
 }
 
+HPyAPI_FUNC HPy HPyUnicode_Substring(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end) {
+     return ctx->ctx_Unicode_Substring ( ctx, str, start, end ); 
+}
+
 HPyAPI_FUNC int HPyList_Check(HPyContext *ctx, HPy h) {
      return ctx->ctx_List_Check ( ctx, h ); 
 }

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -562,6 +562,10 @@ HPyAPI_FUNC HPy HPyDict_New(HPyContext *ctx) {
      return ctx->ctx_Dict_New ( ctx ); 
 }
 
+HPyAPI_FUNC HPy HPyDict_Keys(HPyContext *ctx, HPy h) {
+     return ctx->ctx_Dict_Keys ( ctx, h ); 
+}
+
 HPyAPI_FUNC int HPyTuple_Check(HPyContext *ctx, HPy h) {
      return ctx->ctx_Tuple_Check ( ctx, h ); 
 }

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -534,6 +534,10 @@ HPyAPI_FUNC HPy HPyUnicode_DecodeLatin1(HPyContext *ctx, const char *latin1, HPy
      return ctx->ctx_Unicode_DecodeLatin1 ( ctx, latin1, size, errors ); 
 }
 
+HPyAPI_FUNC HPy HPyUnicode_FromEncodedObject(HPyContext *ctx, HPy obj, const char *encoding, const char *errors) {
+     return ctx->ctx_Unicode_FromEncodedObject ( ctx, obj, encoding, errors ); 
+}
+
 HPyAPI_FUNC int HPyList_Check(HPyContext *ctx, HPy h) {
      return ctx->ctx_List_Check ( ctx, h ); 
 }

--- a/hpy/tools/autogen/debug.py
+++ b/hpy/tools/autogen/debug.py
@@ -92,6 +92,7 @@ class autogen_debug_wrappers(AutoGenFile):
         'HPyContextVar_Get',
         'HPyType_GetName',
         'HPyType_IsSubtype',
+        'HPyUnicode_Substring',
     }
 
     def generate(self):

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -625,6 +625,22 @@ HPy HPyDict_New(HPyContext *ctx);
 HPy_ID(257)
 HPy HPyDict_Keys(HPyContext *ctx, HPy h);
 
+/**
+ * Creates a copy of the provided Python dict object.
+ *
+ * :param ctx:
+ *     The execution context.
+ * :param h:
+ *     A Python dict object. If this argument is ``HPy_NULL`` or not an
+ *     instance of a Python dict, a ``SystemError`` will be raised.
+ *
+ * :returns:
+ *     Return a new dictionary that contains the same key-value pairs as ``h``
+ *     or ``HPy_NULL`` in case of an error.
+ */
+HPy_ID(258)
+HPy HPyDict_Copy(HPyContext *ctx, HPy h);
+
 /* tupleobject.h */
 HPy_ID(203)
 int HPyTuple_Check(HPyContext *ctx, HPy h);

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -606,6 +606,25 @@ int HPyDict_Check(HPyContext *ctx, HPy h);
 HPy_ID(202)
 HPy HPyDict_New(HPyContext *ctx);
 
+/**
+ * Returns a list of all keys from the dictionary.
+ *
+ * Note: This function will directly access the storage of the dict object and
+ * therefore ignores if method ``keys`` was overwritten.
+ *
+ * :param ctx:
+ *     The execution context.
+ * :param h:
+ *     A Python dict object. If this argument is ``HPy_NULL`` or not an
+ *     instance of a Python dict, a ``SystemError`` will be raised.
+ *
+ * :returns:
+ *     A Python list object containing all keys of the given dictionary or
+ *     ``HPy_NULL`` in case of an error.
+ */
+HPy_ID(257)
+HPy HPyDict_Keys(HPyContext *ctx, HPy h);
+
 /* tupleobject.h */
 HPy_ID(203)
 int HPyTuple_Check(HPyContext *ctx, HPy h);

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -566,6 +566,32 @@ HPy HPyUnicode_DecodeLatin1(HPyContext *ctx, const char *latin1, HPy_ssize_t siz
 HPy_ID(255)
 HPy HPyUnicode_FromEncodedObject(HPyContext *ctx, HPy obj, const char *encoding, const char *errors);
 
+/**
+ * Return a substring of ``str``, from character index ``start`` (included) to
+ * character index ``end`` (excluded).
+ *
+ * Indices ``start`` and ``end`` must not be negative, otherwise an
+ * ``IndexError`` will be raised. If ``start >= len(str)`` or if
+ * ``end < start``, an empty string will be returned. If ``end > len(str)`` then
+ * ``end == len(str)`` will be assumed.
+ *
+ * :param ctx:
+ *     The execution context.
+ * :param str:
+ *     A Python Unicode object (must not be ``HPy_NULL``). Otherwise, the
+ *     behavior is undefined (verification of the argument is only done in
+ *     debug mode).
+ * :param start:
+ *     The non-negative start index (inclusive).
+ * :param end:
+ *    The non-negative end index (exclusive).
+ *
+ * :returns:
+ *     The requested substring or ``HPy_NULL`` in case of an error.
+ */
+HPy_ID(256)
+HPy HPyUnicode_Substring(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end);
+
 /* listobject.h */
 HPy_ID(198)
 int HPyList_Check(HPyContext *ctx, HPy h);

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -406,7 +406,7 @@ int HPy_TypeCheck(HPyContext *ctx, HPy obj, HPy type);
  * Return the type's name.
  *
  * Equivalent to getting the type's ``__name__`` attribute. If you want to
- * retrieve the type's name as Python Unicode object, then just use
+ * retrieve the type's name as a handle that refers to a ``str``, then just use
  * ``HPy_GetAttr_s(ctx, type, "__name__")``.
  *
  * :param ctx:
@@ -560,8 +560,8 @@ HPy HPyUnicode_DecodeLatin1(HPyContext *ctx, const char *latin1, HPy_ssize_t siz
  *     ``NULL`` in which case it will default to ``"strict"``.
  *
  * :returns:
- *     Unicode object created from the decoded bytes or ``HPy_NULL`` in case of
- *     errors.
+ *     A handle to a ``str`` object created from the decoded bytes or
+ *     ``HPy_NULL`` in case of errors.
  */
 HPy_ID(255)
 HPy HPyUnicode_FromEncodedObject(HPyContext *ctx, HPy obj, const char *encoding, const char *errors);

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -406,7 +406,7 @@ int HPy_TypeCheck(HPyContext *ctx, HPy obj, HPy type);
  * Return the type's name.
  *
  * Equivalent to getting the type's ``__name__`` attribute. If you want to
- * retrieve the type's name as Python unicode object, then just use
+ * retrieve the type's name as Python Unicode object, then just use
  * ``HPy_GetAttr_s(ctx, type, "__name__")``.
  *
  * :param ctx:
@@ -535,6 +535,36 @@ HPy_ID(196)
 HPy HPyUnicode_DecodeASCII(HPyContext *ctx, const char *ascii, HPy_ssize_t size, const char *errors);
 HPy_ID(197)
 HPy HPyUnicode_DecodeLatin1(HPyContext *ctx, const char *latin1, HPy_ssize_t size, const char *errors);
+
+/**
+ * Decode a bytes-like object to a Unicode object.
+ *
+ * The bytes of the bytes-like object are decoded according to the given
+ * encoding and using the error handling defined by ``errors``.
+ *
+ * :param ctx:
+ *     The execution context.
+ * :param obj:
+ *     A bytes-like object. This can be, for example, Python *bytes*,
+ *     *bytearray*, *memoryview*, *array.array* and objects that support the
+ *     Buffer protocol. If this argument is `HPy_NULL``, a ``SystemError`` will
+ *     be raised. If the argument is not a bytes-like object, a ``TypeError``
+ *     will be raised.
+ * :param encoding:
+ *     The name (UTF-8 encoded C string) of the encoding to use. If the encoding
+ *     does not exist, a ``LookupError`` will be raised. If this argument is
+ *     ``NULL``, the default encoding ``UTF-8`` will be used.
+ * :param errors:
+ *     The error handling (UTF-8 encoded C string) to use when decoding. The
+ *     possible values depend on the used encoding. This argument may be
+ *     ``NULL`` in which case it will default to ``"strict"``.
+ *
+ * :returns:
+ *     Unicode object created from the decoded bytes or ``HPy_NULL`` in case of
+ *     errors.
+ */
+HPy_ID(255)
+HPy HPyUnicode_FromEncodedObject(HPyContext *ctx, HPy obj, const char *encoding, const char *errors);
 
 /* listobject.h */
 HPy_ID(198)

--- a/hpy/trace/src/autogen_trace_ctx_init.h
+++ b/hpy/trace/src/autogen_trace_ctx_init.h
@@ -143,6 +143,7 @@ HPy_UCS4 trace_ctx_Unicode_ReadChar(HPyContext *tctx, HPy h, HPy_ssize_t index);
 HPy trace_ctx_Unicode_DecodeASCII(HPyContext *tctx, const char *ascii, HPy_ssize_t size, const char *errors);
 HPy trace_ctx_Unicode_DecodeLatin1(HPyContext *tctx, const char *latin1, HPy_ssize_t size, const char *errors);
 HPy trace_ctx_Unicode_FromEncodedObject(HPyContext *tctx, HPy obj, const char *encoding, const char *errors);
+HPy trace_ctx_Unicode_Substring(HPyContext *tctx, HPy str, HPy_ssize_t start, HPy_ssize_t end);
 int trace_ctx_List_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_List_New(HPyContext *tctx, HPy_ssize_t len);
 int trace_ctx_List_Append(HPyContext *tctx, HPy h_list, HPy h_item);
@@ -186,8 +187,8 @@ static inline void trace_ctx_init_info(HPyTraceInfo *info, HPyContext *uctx)
 {
     info->magic_number = HPY_TRACE_MAGIC;
     info->uctx = uctx;
-    info->call_counts = (uint64_t *)calloc(256, sizeof(uint64_t));
-    info->durations = (_HPyTime_t *)calloc(256, sizeof(_HPyTime_t));
+    info->call_counts = (uint64_t *)calloc(257, sizeof(uint64_t));
+    info->durations = (_HPyTime_t *)calloc(257, sizeof(_HPyTime_t));
     info->on_enter_func = HPy_NULL;
     info->on_exit_func = HPy_NULL;
 }
@@ -420,6 +421,7 @@ static inline void trace_ctx_init_fields(HPyContext *tctx, HPyContext *uctx)
     tctx->ctx_Unicode_DecodeASCII = &trace_ctx_Unicode_DecodeASCII;
     tctx->ctx_Unicode_DecodeLatin1 = &trace_ctx_Unicode_DecodeLatin1;
     tctx->ctx_Unicode_FromEncodedObject = &trace_ctx_Unicode_FromEncodedObject;
+    tctx->ctx_Unicode_Substring = &trace_ctx_Unicode_Substring;
     tctx->ctx_List_Check = &trace_ctx_List_Check;
     tctx->ctx_List_New = &trace_ctx_List_New;
     tctx->ctx_List_Append = &trace_ctx_List_Append;

--- a/hpy/trace/src/autogen_trace_ctx_init.h
+++ b/hpy/trace/src/autogen_trace_ctx_init.h
@@ -142,6 +142,7 @@ HPy trace_ctx_Unicode_EncodeFSDefault(HPyContext *tctx, HPy h);
 HPy_UCS4 trace_ctx_Unicode_ReadChar(HPyContext *tctx, HPy h, HPy_ssize_t index);
 HPy trace_ctx_Unicode_DecodeASCII(HPyContext *tctx, const char *ascii, HPy_ssize_t size, const char *errors);
 HPy trace_ctx_Unicode_DecodeLatin1(HPyContext *tctx, const char *latin1, HPy_ssize_t size, const char *errors);
+HPy trace_ctx_Unicode_FromEncodedObject(HPyContext *tctx, HPy obj, const char *encoding, const char *errors);
 int trace_ctx_List_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_List_New(HPyContext *tctx, HPy_ssize_t len);
 int trace_ctx_List_Append(HPyContext *tctx, HPy h_list, HPy h_item);
@@ -185,8 +186,8 @@ static inline void trace_ctx_init_info(HPyTraceInfo *info, HPyContext *uctx)
 {
     info->magic_number = HPY_TRACE_MAGIC;
     info->uctx = uctx;
-    info->call_counts = (uint64_t *)calloc(255, sizeof(uint64_t));
-    info->durations = (_HPyTime_t *)calloc(255, sizeof(_HPyTime_t));
+    info->call_counts = (uint64_t *)calloc(256, sizeof(uint64_t));
+    info->durations = (_HPyTime_t *)calloc(256, sizeof(_HPyTime_t));
     info->on_enter_func = HPy_NULL;
     info->on_exit_func = HPy_NULL;
 }
@@ -418,6 +419,7 @@ static inline void trace_ctx_init_fields(HPyContext *tctx, HPyContext *uctx)
     tctx->ctx_Unicode_ReadChar = &trace_ctx_Unicode_ReadChar;
     tctx->ctx_Unicode_DecodeASCII = &trace_ctx_Unicode_DecodeASCII;
     tctx->ctx_Unicode_DecodeLatin1 = &trace_ctx_Unicode_DecodeLatin1;
+    tctx->ctx_Unicode_FromEncodedObject = &trace_ctx_Unicode_FromEncodedObject;
     tctx->ctx_List_Check = &trace_ctx_List_Check;
     tctx->ctx_List_New = &trace_ctx_List_New;
     tctx->ctx_List_Append = &trace_ctx_List_Append;

--- a/hpy/trace/src/autogen_trace_ctx_init.h
+++ b/hpy/trace/src/autogen_trace_ctx_init.h
@@ -149,6 +149,7 @@ HPy trace_ctx_List_New(HPyContext *tctx, HPy_ssize_t len);
 int trace_ctx_List_Append(HPyContext *tctx, HPy h_list, HPy h_item);
 int trace_ctx_Dict_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_Dict_New(HPyContext *tctx);
+HPy trace_ctx_Dict_Keys(HPyContext *tctx, HPy h);
 int trace_ctx_Tuple_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_Tuple_FromArray(HPyContext *tctx, HPy items[], HPy_ssize_t n);
 HPy trace_ctx_Import_ImportModule(HPyContext *tctx, const char *utf8_name);
@@ -187,8 +188,8 @@ static inline void trace_ctx_init_info(HPyTraceInfo *info, HPyContext *uctx)
 {
     info->magic_number = HPY_TRACE_MAGIC;
     info->uctx = uctx;
-    info->call_counts = (uint64_t *)calloc(257, sizeof(uint64_t));
-    info->durations = (_HPyTime_t *)calloc(257, sizeof(_HPyTime_t));
+    info->call_counts = (uint64_t *)calloc(258, sizeof(uint64_t));
+    info->durations = (_HPyTime_t *)calloc(258, sizeof(_HPyTime_t));
     info->on_enter_func = HPy_NULL;
     info->on_exit_func = HPy_NULL;
 }
@@ -427,6 +428,7 @@ static inline void trace_ctx_init_fields(HPyContext *tctx, HPyContext *uctx)
     tctx->ctx_List_Append = &trace_ctx_List_Append;
     tctx->ctx_Dict_Check = &trace_ctx_Dict_Check;
     tctx->ctx_Dict_New = &trace_ctx_Dict_New;
+    tctx->ctx_Dict_Keys = &trace_ctx_Dict_Keys;
     tctx->ctx_Tuple_Check = &trace_ctx_Tuple_Check;
     tctx->ctx_Tuple_FromArray = &trace_ctx_Tuple_FromArray;
     tctx->ctx_Import_ImportModule = &trace_ctx_Import_ImportModule;

--- a/hpy/trace/src/autogen_trace_ctx_init.h
+++ b/hpy/trace/src/autogen_trace_ctx_init.h
@@ -150,6 +150,7 @@ int trace_ctx_List_Append(HPyContext *tctx, HPy h_list, HPy h_item);
 int trace_ctx_Dict_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_Dict_New(HPyContext *tctx);
 HPy trace_ctx_Dict_Keys(HPyContext *tctx, HPy h);
+HPy trace_ctx_Dict_Copy(HPyContext *tctx, HPy h);
 int trace_ctx_Tuple_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_Tuple_FromArray(HPyContext *tctx, HPy items[], HPy_ssize_t n);
 HPy trace_ctx_Import_ImportModule(HPyContext *tctx, const char *utf8_name);
@@ -188,8 +189,8 @@ static inline void trace_ctx_init_info(HPyTraceInfo *info, HPyContext *uctx)
 {
     info->magic_number = HPY_TRACE_MAGIC;
     info->uctx = uctx;
-    info->call_counts = (uint64_t *)calloc(258, sizeof(uint64_t));
-    info->durations = (_HPyTime_t *)calloc(258, sizeof(_HPyTime_t));
+    info->call_counts = (uint64_t *)calloc(259, sizeof(uint64_t));
+    info->durations = (_HPyTime_t *)calloc(259, sizeof(_HPyTime_t));
     info->on_enter_func = HPy_NULL;
     info->on_exit_func = HPy_NULL;
 }
@@ -429,6 +430,7 @@ static inline void trace_ctx_init_fields(HPyContext *tctx, HPyContext *uctx)
     tctx->ctx_Dict_Check = &trace_ctx_Dict_Check;
     tctx->ctx_Dict_New = &trace_ctx_Dict_New;
     tctx->ctx_Dict_Keys = &trace_ctx_Dict_Keys;
+    tctx->ctx_Dict_Copy = &trace_ctx_Dict_Copy;
     tctx->ctx_Tuple_Check = &trace_ctx_Tuple_Check;
     tctx->ctx_Tuple_FromArray = &trace_ctx_Tuple_FromArray;
     tctx->ctx_Import_ImportModule = &trace_ctx_Import_ImportModule;

--- a/hpy/trace/src/autogen_trace_func_table.c
+++ b/hpy/trace/src/autogen_trace_func_table.c
@@ -12,7 +12,7 @@
 
 #include "trace_internal.h"
 
-#define TRACE_NFUNC 172
+#define TRACE_NFUNC 173
 
 #define NO_FUNC ""
 static const char *trace_func_table[] = {
@@ -271,6 +271,7 @@ static const char *trace_func_table[] = {
     "ctx_ContextVar_Set",
     "ctx_Type_GetName",
     "ctx_Type_IsSubtype",
+    "ctx_Unicode_FromEncodedObject",
     NULL /* sentinel */
 };
 
@@ -281,7 +282,7 @@ int hpy_trace_get_nfunc(void)
 
 const char * hpy_trace_get_func_name(int idx)
 {
-    if (idx >= 0 && idx < 255)
+    if (idx >= 0 && idx < 256)
         return trace_func_table[idx];
     return NULL;
 }

--- a/hpy/trace/src/autogen_trace_func_table.c
+++ b/hpy/trace/src/autogen_trace_func_table.c
@@ -12,7 +12,7 @@
 
 #include "trace_internal.h"
 
-#define TRACE_NFUNC 173
+#define TRACE_NFUNC 174
 
 #define NO_FUNC ""
 static const char *trace_func_table[] = {
@@ -272,6 +272,7 @@ static const char *trace_func_table[] = {
     "ctx_Type_GetName",
     "ctx_Type_IsSubtype",
     "ctx_Unicode_FromEncodedObject",
+    "ctx_Unicode_Substring",
     NULL /* sentinel */
 };
 
@@ -282,7 +283,7 @@ int hpy_trace_get_nfunc(void)
 
 const char * hpy_trace_get_func_name(int idx)
 {
-    if (idx >= 0 && idx < 256)
+    if (idx >= 0 && idx < 257)
         return trace_func_table[idx];
     return NULL;
 }

--- a/hpy/trace/src/autogen_trace_func_table.c
+++ b/hpy/trace/src/autogen_trace_func_table.c
@@ -12,7 +12,7 @@
 
 #include "trace_internal.h"
 
-#define TRACE_NFUNC 175
+#define TRACE_NFUNC 176
 
 #define NO_FUNC ""
 static const char *trace_func_table[] = {
@@ -274,6 +274,7 @@ static const char *trace_func_table[] = {
     "ctx_Unicode_FromEncodedObject",
     "ctx_Unicode_Substring",
     "ctx_Dict_Keys",
+    "ctx_Dict_Copy",
     NULL /* sentinel */
 };
 
@@ -284,7 +285,7 @@ int hpy_trace_get_nfunc(void)
 
 const char * hpy_trace_get_func_name(int idx)
 {
-    if (idx >= 0 && idx < 258)
+    if (idx >= 0 && idx < 259)
         return trace_func_table[idx];
     return NULL;
 }

--- a/hpy/trace/src/autogen_trace_func_table.c
+++ b/hpy/trace/src/autogen_trace_func_table.c
@@ -12,7 +12,7 @@
 
 #include "trace_internal.h"
 
-#define TRACE_NFUNC 174
+#define TRACE_NFUNC 175
 
 #define NO_FUNC ""
 static const char *trace_func_table[] = {
@@ -273,6 +273,7 @@ static const char *trace_func_table[] = {
     "ctx_Type_IsSubtype",
     "ctx_Unicode_FromEncodedObject",
     "ctx_Unicode_Substring",
+    "ctx_Dict_Keys",
     NULL /* sentinel */
 };
 
@@ -283,7 +284,7 @@ int hpy_trace_get_nfunc(void)
 
 const char * hpy_trace_get_func_name(int idx)
 {
-    if (idx >= 0 && idx < 257)
+    if (idx >= 0 && idx < 258)
         return trace_func_table[idx];
     return NULL;
 }

--- a/hpy/trace/src/autogen_trace_wrappers.c
+++ b/hpy/trace/src/autogen_trace_wrappers.c
@@ -1825,6 +1825,19 @@ HPy trace_ctx_Dict_Keys(HPyContext *tctx, HPy h)
     return res;
 }
 
+HPy trace_ctx_Dict_Copy(HPyContext *tctx, HPy h)
+{
+    HPyTraceInfo *info = hpy_trace_on_enter(tctx, 258);
+    HPyContext *uctx = info->uctx;
+    _HPyTime_t _ts_start, _ts_end;
+    _HPyClockStatus_t r0, r1;
+    r0 = get_monotonic_clock(&_ts_start);
+    HPy res = HPyDict_Copy(uctx, h);
+    r1 = get_monotonic_clock(&_ts_end);
+    hpy_trace_on_exit(info, 258, r0, r1, &_ts_start, &_ts_end);
+    return res;
+}
+
 int trace_ctx_Tuple_Check(HPyContext *tctx, HPy h)
 {
     HPyTraceInfo *info = hpy_trace_on_enter(tctx, 203);

--- a/hpy/trace/src/autogen_trace_wrappers.c
+++ b/hpy/trace/src/autogen_trace_wrappers.c
@@ -1721,6 +1721,19 @@ HPy trace_ctx_Unicode_DecodeLatin1(HPyContext *tctx, const char *latin1, HPy_ssi
     return res;
 }
 
+HPy trace_ctx_Unicode_FromEncodedObject(HPyContext *tctx, HPy obj, const char *encoding, const char *errors)
+{
+    HPyTraceInfo *info = hpy_trace_on_enter(tctx, 255);
+    HPyContext *uctx = info->uctx;
+    _HPyTime_t _ts_start, _ts_end;
+    _HPyClockStatus_t r0, r1;
+    r0 = get_monotonic_clock(&_ts_start);
+    HPy res = HPyUnicode_FromEncodedObject(uctx, obj, encoding, errors);
+    r1 = get_monotonic_clock(&_ts_end);
+    hpy_trace_on_exit(info, 255, r0, r1, &_ts_start, &_ts_end);
+    return res;
+}
+
 int trace_ctx_List_Check(HPyContext *tctx, HPy h)
 {
     HPyTraceInfo *info = hpy_trace_on_enter(tctx, 198);

--- a/hpy/trace/src/autogen_trace_wrappers.c
+++ b/hpy/trace/src/autogen_trace_wrappers.c
@@ -1812,6 +1812,19 @@ HPy trace_ctx_Dict_New(HPyContext *tctx)
     return res;
 }
 
+HPy trace_ctx_Dict_Keys(HPyContext *tctx, HPy h)
+{
+    HPyTraceInfo *info = hpy_trace_on_enter(tctx, 257);
+    HPyContext *uctx = info->uctx;
+    _HPyTime_t _ts_start, _ts_end;
+    _HPyClockStatus_t r0, r1;
+    r0 = get_monotonic_clock(&_ts_start);
+    HPy res = HPyDict_Keys(uctx, h);
+    r1 = get_monotonic_clock(&_ts_end);
+    hpy_trace_on_exit(info, 257, r0, r1, &_ts_start, &_ts_end);
+    return res;
+}
+
 int trace_ctx_Tuple_Check(HPyContext *tctx, HPy h)
 {
     HPyTraceInfo *info = hpy_trace_on_enter(tctx, 203);

--- a/hpy/trace/src/autogen_trace_wrappers.c
+++ b/hpy/trace/src/autogen_trace_wrappers.c
@@ -1734,6 +1734,19 @@ HPy trace_ctx_Unicode_FromEncodedObject(HPyContext *tctx, HPy obj, const char *e
     return res;
 }
 
+HPy trace_ctx_Unicode_Substring(HPyContext *tctx, HPy str, HPy_ssize_t start, HPy_ssize_t end)
+{
+    HPyTraceInfo *info = hpy_trace_on_enter(tctx, 256);
+    HPyContext *uctx = info->uctx;
+    _HPyTime_t _ts_start, _ts_end;
+    _HPyClockStatus_t r0, r1;
+    r0 = get_monotonic_clock(&_ts_start);
+    HPy res = HPyUnicode_Substring(uctx, str, start, end);
+    r1 = get_monotonic_clock(&_ts_end);
+    hpy_trace_on_exit(info, 256, r0, r1, &_ts_start, &_ts_end);
+    return res;
+}
+
 int trace_ctx_List_Check(HPyContext *tctx, HPy h)
 {
     HPyTraceInfo *info = hpy_trace_on_enter(tctx, 198);

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -156,6 +156,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_Dict_Check = &ctx_Dict_Check,
     .ctx_Dict_New = &ctx_Dict_New,
     .ctx_Dict_Keys = &ctx_Dict_Keys,
+    .ctx_Dict_Copy = &ctx_Dict_Copy,
     .ctx_Tuple_Check = &ctx_Tuple_Check,
     .ctx_Tuple_FromArray = &ctx_Tuple_FromArray,
     .ctx_Import_ImportModule = &ctx_Import_ImportModule,

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -148,6 +148,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_Unicode_ReadChar = &ctx_Unicode_ReadChar,
     .ctx_Unicode_DecodeASCII = &ctx_Unicode_DecodeASCII,
     .ctx_Unicode_DecodeLatin1 = &ctx_Unicode_DecodeLatin1,
+    .ctx_Unicode_FromEncodedObject = &ctx_Unicode_FromEncodedObject,
     .ctx_List_Check = &ctx_List_Check,
     .ctx_List_New = &ctx_List_New,
     .ctx_List_Append = &ctx_List_Append,

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -149,6 +149,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_Unicode_DecodeASCII = &ctx_Unicode_DecodeASCII,
     .ctx_Unicode_DecodeLatin1 = &ctx_Unicode_DecodeLatin1,
     .ctx_Unicode_FromEncodedObject = &ctx_Unicode_FromEncodedObject,
+    .ctx_Unicode_Substring = &ctx_Unicode_Substring,
     .ctx_List_Check = &ctx_List_Check,
     .ctx_List_New = &ctx_List_New,
     .ctx_List_Append = &ctx_List_Append,

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -155,6 +155,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_List_Append = &ctx_List_Append,
     .ctx_Dict_Check = &ctx_Dict_Check,
     .ctx_Dict_New = &ctx_Dict_New,
+    .ctx_Dict_Keys = &ctx_Dict_Keys,
     .ctx_Tuple_Check = &ctx_Tuple_Check,
     .ctx_Tuple_FromArray = &ctx_Tuple_FromArray,
     .ctx_Import_ImportModule = &ctx_Import_ImportModule,

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -490,6 +490,11 @@ HPyAPI_IMPL HPy ctx_Unicode_FromEncodedObject(HPyContext *ctx, HPy obj, const ch
     return _py2h(PyUnicode_FromEncodedObject(_h2py(obj), encoding, errors));
 }
 
+HPyAPI_IMPL HPy ctx_Unicode_Substring(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end)
+{
+    return _py2h(PyUnicode_Substring(_h2py(str), start, end));
+}
+
 HPyAPI_IMPL int ctx_List_Check(HPyContext *ctx, HPy h)
 {
     return PyList_Check(_h2py(h));

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -520,6 +520,11 @@ HPyAPI_IMPL HPy ctx_Dict_New(HPyContext *ctx)
     return _py2h(PyDict_New());
 }
 
+HPyAPI_IMPL HPy ctx_Dict_Keys(HPyContext *ctx, HPy h)
+{
+    return _py2h(PyDict_Keys(_h2py(h)));
+}
+
 HPyAPI_IMPL int ctx_Tuple_Check(HPyContext *ctx, HPy h)
 {
     return PyTuple_Check(_h2py(h));

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -485,6 +485,11 @@ HPyAPI_IMPL HPy ctx_Unicode_DecodeLatin1(HPyContext *ctx, const char *latin1, HP
     return _py2h(PyUnicode_DecodeLatin1(latin1, size, errors));
 }
 
+HPyAPI_IMPL HPy ctx_Unicode_FromEncodedObject(HPyContext *ctx, HPy obj, const char *encoding, const char *errors)
+{
+    return _py2h(PyUnicode_FromEncodedObject(_h2py(obj), encoding, errors));
+}
+
 HPyAPI_IMPL int ctx_List_Check(HPyContext *ctx, HPy h)
 {
     return PyList_Check(_h2py(h));

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -525,6 +525,11 @@ HPyAPI_IMPL HPy ctx_Dict_Keys(HPyContext *ctx, HPy h)
     return _py2h(PyDict_Keys(_h2py(h)));
 }
 
+HPyAPI_IMPL HPy ctx_Dict_Copy(HPyContext *ctx, HPy h)
+{
+    return _py2h(PyDict_Copy(_h2py(h)));
+}
+
 HPyAPI_IMPL int ctx_Tuple_Check(HPyContext *ctx, HPy h)
 {
     return PyTuple_Check(_h2py(h));

--- a/test/test_hpydict.py
+++ b/test/test_hpydict.py
@@ -73,3 +73,27 @@ class TestDict(HPyTest):
         """)
         assert mod.f({'hello': 1}) == 1
         assert mod.f({}) is None
+
+    def test_keys(self):
+        import pytest
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                HPy h_dict = HPy_Is(ctx, arg, ctx->h_None) ? HPy_NULL : arg;
+                return HPyDict_Keys(ctx, h_dict);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+
+        class SubDict(dict):
+            def keys(self):
+                return [1, 2, 3]
+        assert mod.f({}) == []
+        assert mod.f({'hello': 1}) == ['hello']
+        assert mod.f(SubDict(hello=1)) == ['hello']
+        with pytest.raises(SystemError):
+            mod.f(None)
+        with pytest.raises(SystemError):
+            mod.f(42)

--- a/test/test_hpydict.py
+++ b/test/test_hpydict.py
@@ -97,3 +97,25 @@ class TestDict(HPyTest):
             mod.f(None)
         with pytest.raises(SystemError):
             mod.f(42)
+
+    def test_copy(self):
+        import pytest
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                HPy h_dict = HPy_Is(ctx, arg, ctx->h_None) ? HPy_NULL : arg;
+                return HPyDict_Copy(ctx, h_dict);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        dicts = ({}, {'hello': 1})
+        for d in dicts:
+            d_copy = mod.f(d)
+            assert d_copy == d
+            assert d_copy is not d
+        with pytest.raises(SystemError):
+            mod.f(None)
+        with pytest.raises(SystemError):
+            mod.f(42)

--- a/test/test_hpyunicode.py
+++ b/test/test_hpyunicode.py
@@ -907,7 +907,7 @@ class TestUnicode(HPyTest):
 
         # test unknown encoding
         with pytest.raises(LookupError):
-            mod.f(b"", "qwertyasdf13", None)
+            mod.f(b"hello", "qwertyasdf13", None)
 
         with pytest.raises(SystemError):
             mod.f(None, None, None)

--- a/test/test_hpyunicode.py
+++ b/test/test_hpyunicode.py
@@ -850,3 +850,68 @@ class TestUnicode(HPyTest):
         with pytest.raises(ValueError) as exc:
             mod.precision()
         assert str(exc.value) == "precision too big"
+
+    def test_FromEncodedObject(self):
+        import pytest
+        mod = self.make_module("""
+            static const char *as_string(HPyContext *ctx, HPy h)
+            {
+                const char *res = HPyUnicode_AsUTF8AndSize(ctx, h, NULL);
+                if (res == NULL)
+                    HPyErr_Clear(ctx);
+                return res;
+            }
+
+            HPyDef_METH(f, "f", HPyFunc_VARARGS)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy *args, HPy_ssize_t nargs)
+            {
+                HPy h_obj;
+                const char *encoding, *errors;
+                if (nargs != 3) {
+                    HPyErr_SetString(ctx, ctx->h_TypeError, "expected exactly 3 arguments");
+                    return HPy_NULL;
+                }
+                h_obj = HPy_Is(ctx, args[0], ctx->h_None) ? HPy_NULL : args[0];
+                encoding = as_string(ctx, args[1]);
+                errors = as_string(ctx, args[2]);
+                return HPyUnicode_FromEncodedObject(ctx, h_obj, encoding, errors);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        # "hellö" as UTF-8 encoded bytes
+        utf8_bytes = b"hell\xc3\xb6"
+        # "hellö" as UTF-16 encoded bytes
+        utf16_bytes = b'\xff\xfeh\x00e\x00l\x00l\x00\xf6\x00'
+        ascii_codepoints = bytes(range(1, 128))
+
+        # note: None (if passed to arguments 'encoding' or 'errors') will be
+        # translated to a NULL pointer
+
+        for errors in (None, "strict", "ignore", "replace"):
+            assert mod.f(b"hello", "ascii", errors) == "hello"
+            assert mod.f(utf8_bytes, "utf8", errors) == "hellö"
+            assert mod.f(utf16_bytes, "utf16", errors) == "hellö"
+            assert len(mod.f(ascii_codepoints, "ascii", errors)) == 127
+            assert len(mod.f(ascii_codepoints, "utf8", errors)) == 127
+
+        # None will be translated to NULL and then defaults to UTF-8 encoding
+        for encoding in (None, "utf8"):
+            assert mod.f(utf8_bytes, encoding, None) == "hellö"
+
+            with pytest.raises(UnicodeDecodeError):
+                mod.f(utf16_bytes, encoding, None)
+
+            assert mod.f(utf16_bytes, encoding, "replace") == '��h\x00e\x00l\x00l\x00�\x00'
+            assert mod.f(utf16_bytes, encoding, "ignore") == 'h\x00e\x00l\x00l\x00\x00'
+
+        # test unknown encoding
+        with pytest.raises(LookupError):
+            mod.f(b"", "qwertyasdf13", None)
+
+        with pytest.raises(SystemError):
+            mod.f(None, None, None)
+        with pytest.raises(TypeError):
+            mod.f("hello", None, None)
+        with pytest.raises(TypeError):
+            mod.f(123, None, None)


### PR DESCRIPTION
Also used in the Numpy/HPy port (builds on PR #410).
I recommend reviewing commit by commit.