### PR TITLE
Introduce HPyDict_Keys and HPyDict_Copy.

### DIFF
--- a/docs/api-reference/function-index.rst
+++ b/docs/api-reference/function-index.rst
@@ -26,6 +26,7 @@ HPy Core API Function Index
 * :c:func:`HPyContextVar_New`
 * :c:func:`HPyContextVar_Set`
 * :c:func:`HPyDict_Check`
+* :c:func:`HPyDict_Keys`
 * :c:func:`HPyDict_New`
 * :c:func:`HPyErr_Clear`
 * :c:func:`HPyErr_ExceptionMatches`

--- a/docs/api-reference/function-index.rst
+++ b/docs/api-reference/function-index.rst
@@ -26,6 +26,7 @@ HPy Core API Function Index
 * :c:func:`HPyContextVar_New`
 * :c:func:`HPyContextVar_Set`
 * :c:func:`HPyDict_Check`
+* :c:func:`HPyDict_Copy`
 * :c:func:`HPyDict_Keys`
 * :c:func:`HPyDict_New`
 * :c:func:`HPyErr_Clear`

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -170,6 +170,7 @@ with the code for the :term:`CPython ABI` mode, so it is guaranteed to be correc
     `PyContextVar_New <https://docs.python.org/3/c-api/contextvars.html#c.PyContextVar_New>`_                                          :c:func:`HPyContextVar_New`
     `PyContextVar_Set <https://docs.python.org/3/c-api/contextvars.html#c.PyContextVar_Set>`_                                          :c:func:`HPyContextVar_Set`
     `PyDict_Check <https://docs.python.org/3/c-api/dict.html#c.PyDict_Check>`_                                                         :c:func:`HPyDict_Check`
+    `PyDict_Copy <https://docs.python.org/3/c-api/dict.html#c.PyDict_Copy>`_                                                           :c:func:`HPyDict_Copy`
     `PyDict_Keys <https://docs.python.org/3/c-api/dict.html#c.PyDict_Keys>`_                                                           :c:func:`HPyDict_Keys`
     `PyDict_New <https://docs.python.org/3/c-api/dict.html#c.PyDict_New>`_                                                             :c:func:`HPyDict_New`
     `PyErr_Clear <https://docs.python.org/3/c-api/exceptions.html#c.PyErr_Clear>`_                                                     :c:func:`HPyErr_Clear`

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -170,6 +170,7 @@ with the code for the :term:`CPython ABI` mode, so it is guaranteed to be correc
     `PyContextVar_New <https://docs.python.org/3/c-api/contextvars.html#c.PyContextVar_New>`_                                          :c:func:`HPyContextVar_New`
     `PyContextVar_Set <https://docs.python.org/3/c-api/contextvars.html#c.PyContextVar_Set>`_                                          :c:func:`HPyContextVar_Set`
     `PyDict_Check <https://docs.python.org/3/c-api/dict.html#c.PyDict_Check>`_                                                         :c:func:`HPyDict_Check`
+    `PyDict_Keys <https://docs.python.org/3/c-api/dict.html#c.PyDict_Keys>`_                                                           :c:func:`HPyDict_Keys`
     `PyDict_New <https://docs.python.org/3/c-api/dict.html#c.PyDict_New>`_                                                             :c:func:`HPyDict_New`
     `PyErr_Clear <https://docs.python.org/3/c-api/exceptions.html#c.PyErr_Clear>`_                                                     :c:func:`HPyErr_Clear`
     `PyErr_ExceptionMatches <https://docs.python.org/3/c-api/exceptions.html#c.PyErr_ExceptionMatches>`_                               :c:func:`HPyErr_ExceptionMatches`

--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -150,6 +150,7 @@ DHPy debug_ctx_List_New(HPyContext *dctx, HPy_ssize_t len);
 int debug_ctx_List_Append(HPyContext *dctx, DHPy h_list, DHPy h_item);
 int debug_ctx_Dict_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Dict_New(HPyContext *dctx);
+DHPy debug_ctx_Dict_Keys(HPyContext *dctx, DHPy h);
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Tuple_FromArray(HPyContext *dctx, DHPy items[], HPy_ssize_t n);
 DHPy debug_ctx_Import_ImportModule(HPyContext *dctx, const char *utf8_name);
@@ -410,6 +411,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_List_Append = &debug_ctx_List_Append;
     dctx->ctx_Dict_Check = &debug_ctx_Dict_Check;
     dctx->ctx_Dict_New = &debug_ctx_Dict_New;
+    dctx->ctx_Dict_Keys = &debug_ctx_Dict_Keys;
     dctx->ctx_Tuple_Check = &debug_ctx_Tuple_Check;
     dctx->ctx_Tuple_FromArray = &debug_ctx_Tuple_FromArray;
     dctx->ctx_Import_ImportModule = &debug_ctx_Import_ImportModule;

--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -151,6 +151,7 @@ int debug_ctx_List_Append(HPyContext *dctx, DHPy h_list, DHPy h_item);
 int debug_ctx_Dict_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Dict_New(HPyContext *dctx);
 DHPy debug_ctx_Dict_Keys(HPyContext *dctx, DHPy h);
+DHPy debug_ctx_Dict_Copy(HPyContext *dctx, DHPy h);
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Tuple_FromArray(HPyContext *dctx, DHPy items[], HPy_ssize_t n);
 DHPy debug_ctx_Import_ImportModule(HPyContext *dctx, const char *utf8_name);
@@ -412,6 +413,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_Dict_Check = &debug_ctx_Dict_Check;
     dctx->ctx_Dict_New = &debug_ctx_Dict_New;
     dctx->ctx_Dict_Keys = &debug_ctx_Dict_Keys;
+    dctx->ctx_Dict_Copy = &debug_ctx_Dict_Copy;
     dctx->ctx_Tuple_Check = &debug_ctx_Tuple_Check;
     dctx->ctx_Tuple_FromArray = &debug_ctx_Tuple_FromArray;
     dctx->ctx_Import_ImportModule = &debug_ctx_Import_ImportModule;

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -1511,6 +1511,18 @@ DHPy debug_ctx_Dict_Keys(HPyContext *dctx, DHPy h)
     return DHPy_open(dctx, universal_result);
 }
 
+DHPy debug_ctx_Dict_Copy(HPyContext *dctx, DHPy h)
+{
+    if (!get_ctx_info(dctx)->is_valid) {
+        report_invalid_debug_context();
+    }
+    HPy dh_h = DHPy_unwrap(dctx, h);
+    get_ctx_info(dctx)->is_valid = false;
+    HPy universal_result = HPyDict_Copy(get_info(dctx)->uctx, dh_h);
+    get_ctx_info(dctx)->is_valid = true;
+    return DHPy_open(dctx, universal_result);
+}
+
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h)
 {
     if (!get_ctx_info(dctx)->is_valid) {

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -1499,6 +1499,18 @@ DHPy debug_ctx_Dict_New(HPyContext *dctx)
     return DHPy_open(dctx, universal_result);
 }
 
+DHPy debug_ctx_Dict_Keys(HPyContext *dctx, DHPy h)
+{
+    if (!get_ctx_info(dctx)->is_valid) {
+        report_invalid_debug_context();
+    }
+    HPy dh_h = DHPy_unwrap(dctx, h);
+    get_ctx_info(dctx)->is_valid = false;
+    HPy universal_result = HPyDict_Keys(get_info(dctx)->uctx, dh_h);
+    get_ctx_info(dctx)->is_valid = true;
+    return DHPy_open(dctx, universal_result);
+}
+
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h)
 {
     if (!get_ctx_info(dctx)->is_valid) {

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -529,6 +529,11 @@ HPyAPI_FUNC HPy HPyDict_Keys(HPyContext *ctx, HPy h)
     return _py2h(PyDict_Keys(_h2py(h)));
 }
 
+HPyAPI_FUNC HPy HPyDict_Copy(HPyContext *ctx, HPy h)
+{
+    return _py2h(PyDict_Copy(_h2py(h)));
+}
+
 HPyAPI_FUNC int HPyTuple_Check(HPyContext *ctx, HPy h)
 {
     return PyTuple_Check(_h2py(h));

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -524,6 +524,11 @@ HPyAPI_FUNC HPy HPyDict_New(HPyContext *ctx)
     return _py2h(PyDict_New());
 }
 
+HPyAPI_FUNC HPy HPyDict_Keys(HPyContext *ctx, HPy h)
+{
+    return _py2h(PyDict_Keys(_h2py(h)));
+}
+
 HPyAPI_FUNC int HPyTuple_Check(HPyContext *ctx, HPy h)
 {
     return PyTuple_Check(_h2py(h));

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -272,4 +272,5 @@ struct _HPyContext_s {
     HPy (*ctx_Unicode_FromEncodedObject)(HPyContext *ctx, HPy obj, const char *encoding, const char *errors);
     HPy (*ctx_Unicode_Substring)(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end);
     HPy (*ctx_Dict_Keys)(HPyContext *ctx, HPy h);
+    HPy (*ctx_Dict_Copy)(HPyContext *ctx, HPy h);
 };

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -271,4 +271,5 @@ struct _HPyContext_s {
     int (*ctx_Type_IsSubtype)(HPyContext *ctx, HPy sub, HPy type);
     HPy (*ctx_Unicode_FromEncodedObject)(HPyContext *ctx, HPy obj, const char *encoding, const char *errors);
     HPy (*ctx_Unicode_Substring)(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end);
+    HPy (*ctx_Dict_Keys)(HPyContext *ctx, HPy h);
 };

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -566,6 +566,10 @@ HPyAPI_FUNC HPy HPyDict_Keys(HPyContext *ctx, HPy h) {
      return ctx->ctx_Dict_Keys ( ctx, h ); 
 }
 
+HPyAPI_FUNC HPy HPyDict_Copy(HPyContext *ctx, HPy h) {
+     return ctx->ctx_Dict_Copy ( ctx, h ); 
+}
+
 HPyAPI_FUNC int HPyTuple_Check(HPyContext *ctx, HPy h) {
      return ctx->ctx_Tuple_Check ( ctx, h ); 
 }

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -562,6 +562,10 @@ HPyAPI_FUNC HPy HPyDict_New(HPyContext *ctx) {
      return ctx->ctx_Dict_New ( ctx ); 
 }
 
+HPyAPI_FUNC HPy HPyDict_Keys(HPyContext *ctx, HPy h) {
+     return ctx->ctx_Dict_Keys ( ctx, h ); 
+}
+
 HPyAPI_FUNC int HPyTuple_Check(HPyContext *ctx, HPy h) {
      return ctx->ctx_Tuple_Check ( ctx, h ); 
 }

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -625,6 +625,22 @@ HPy HPyDict_New(HPyContext *ctx);
 HPy_ID(257)
 HPy HPyDict_Keys(HPyContext *ctx, HPy h);
 
+/**
+ * Creates a copy of the provided Python dict object.
+ *
+ * :param ctx:
+ *     The execution context.
+ * :param h:
+ *     A Python dict object. If this argument is ``HPy_NULL`` or not an
+ *     instance of a Python dict, a ``SystemError`` will be raised.
+ *
+ * :returns:
+ *     Return a new dictionary that contains the same key-value pairs as ``h``
+ *     or ``HPy_NULL`` in case of an error.
+ */
+HPy_ID(258)
+HPy HPyDict_Copy(HPyContext *ctx, HPy h);
+
 /* tupleobject.h */
 HPy_ID(203)
 int HPyTuple_Check(HPyContext *ctx, HPy h);

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -606,6 +606,25 @@ int HPyDict_Check(HPyContext *ctx, HPy h);
 HPy_ID(202)
 HPy HPyDict_New(HPyContext *ctx);
 
+/**
+ * Returns a list of all keys from the dictionary.
+ *
+ * Note: This function will directly access the storage of the dict object and
+ * therefore ignores if method ``keys`` was overwritten.
+ *
+ * :param ctx:
+ *     The execution context.
+ * :param h:
+ *     A Python dict object. If this argument is ``HPy_NULL`` or not an
+ *     instance of a Python dict, a ``SystemError`` will be raised.
+ *
+ * :returns:
+ *     A Python list object containing all keys of the given dictionary or
+ *     ``HPy_NULL`` in case of an error.
+ */
+HPy_ID(257)
+HPy HPyDict_Keys(HPyContext *ctx, HPy h);
+
 /* tupleobject.h */
 HPy_ID(203)
 int HPyTuple_Check(HPyContext *ctx, HPy h);

--- a/hpy/trace/src/autogen_trace_ctx_init.h
+++ b/hpy/trace/src/autogen_trace_ctx_init.h
@@ -149,6 +149,7 @@ HPy trace_ctx_List_New(HPyContext *tctx, HPy_ssize_t len);
 int trace_ctx_List_Append(HPyContext *tctx, HPy h_list, HPy h_item);
 int trace_ctx_Dict_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_Dict_New(HPyContext *tctx);
+HPy trace_ctx_Dict_Keys(HPyContext *tctx, HPy h);
 int trace_ctx_Tuple_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_Tuple_FromArray(HPyContext *tctx, HPy items[], HPy_ssize_t n);
 HPy trace_ctx_Import_ImportModule(HPyContext *tctx, const char *utf8_name);
@@ -187,8 +188,8 @@ static inline void trace_ctx_init_info(HPyTraceInfo *info, HPyContext *uctx)
 {
     info->magic_number = HPY_TRACE_MAGIC;
     info->uctx = uctx;
-    info->call_counts = (uint64_t *)calloc(257, sizeof(uint64_t));
-    info->durations = (_HPyTime_t *)calloc(257, sizeof(_HPyTime_t));
+    info->call_counts = (uint64_t *)calloc(258, sizeof(uint64_t));
+    info->durations = (_HPyTime_t *)calloc(258, sizeof(_HPyTime_t));
     info->on_enter_func = HPy_NULL;
     info->on_exit_func = HPy_NULL;
 }
@@ -427,6 +428,7 @@ static inline void trace_ctx_init_fields(HPyContext *tctx, HPyContext *uctx)
     tctx->ctx_List_Append = &trace_ctx_List_Append;
     tctx->ctx_Dict_Check = &trace_ctx_Dict_Check;
     tctx->ctx_Dict_New = &trace_ctx_Dict_New;
+    tctx->ctx_Dict_Keys = &trace_ctx_Dict_Keys;
     tctx->ctx_Tuple_Check = &trace_ctx_Tuple_Check;
     tctx->ctx_Tuple_FromArray = &trace_ctx_Tuple_FromArray;
     tctx->ctx_Import_ImportModule = &trace_ctx_Import_ImportModule;

--- a/hpy/trace/src/autogen_trace_ctx_init.h
+++ b/hpy/trace/src/autogen_trace_ctx_init.h
@@ -150,6 +150,7 @@ int trace_ctx_List_Append(HPyContext *tctx, HPy h_list, HPy h_item);
 int trace_ctx_Dict_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_Dict_New(HPyContext *tctx);
 HPy trace_ctx_Dict_Keys(HPyContext *tctx, HPy h);
+HPy trace_ctx_Dict_Copy(HPyContext *tctx, HPy h);
 int trace_ctx_Tuple_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_Tuple_FromArray(HPyContext *tctx, HPy items[], HPy_ssize_t n);
 HPy trace_ctx_Import_ImportModule(HPyContext *tctx, const char *utf8_name);
@@ -188,8 +189,8 @@ static inline void trace_ctx_init_info(HPyTraceInfo *info, HPyContext *uctx)
 {
     info->magic_number = HPY_TRACE_MAGIC;
     info->uctx = uctx;
-    info->call_counts = (uint64_t *)calloc(258, sizeof(uint64_t));
-    info->durations = (_HPyTime_t *)calloc(258, sizeof(_HPyTime_t));
+    info->call_counts = (uint64_t *)calloc(259, sizeof(uint64_t));
+    info->durations = (_HPyTime_t *)calloc(259, sizeof(_HPyTime_t));
     info->on_enter_func = HPy_NULL;
     info->on_exit_func = HPy_NULL;
 }
@@ -429,6 +430,7 @@ static inline void trace_ctx_init_fields(HPyContext *tctx, HPyContext *uctx)
     tctx->ctx_Dict_Check = &trace_ctx_Dict_Check;
     tctx->ctx_Dict_New = &trace_ctx_Dict_New;
     tctx->ctx_Dict_Keys = &trace_ctx_Dict_Keys;
+    tctx->ctx_Dict_Copy = &trace_ctx_Dict_Copy;
     tctx->ctx_Tuple_Check = &trace_ctx_Tuple_Check;
     tctx->ctx_Tuple_FromArray = &trace_ctx_Tuple_FromArray;
     tctx->ctx_Import_ImportModule = &trace_ctx_Import_ImportModule;

--- a/hpy/trace/src/autogen_trace_func_table.c
+++ b/hpy/trace/src/autogen_trace_func_table.c
@@ -12,7 +12,7 @@
 
 #include "trace_internal.h"
 
-#define TRACE_NFUNC 175
+#define TRACE_NFUNC 176
 
 #define NO_FUNC ""
 static const char *trace_func_table[] = {
@@ -274,6 +274,7 @@ static const char *trace_func_table[] = {
     "ctx_Unicode_FromEncodedObject",
     "ctx_Unicode_Substring",
     "ctx_Dict_Keys",
+    "ctx_Dict_Copy",
     NULL /* sentinel */
 };
 
@@ -284,7 +285,7 @@ int hpy_trace_get_nfunc(void)
 
 const char * hpy_trace_get_func_name(int idx)
 {
-    if (idx >= 0 && idx < 258)
+    if (idx >= 0 && idx < 259)
         return trace_func_table[idx];
     return NULL;
 }

--- a/hpy/trace/src/autogen_trace_func_table.c
+++ b/hpy/trace/src/autogen_trace_func_table.c
@@ -12,7 +12,7 @@
 
 #include "trace_internal.h"
 
-#define TRACE_NFUNC 174
+#define TRACE_NFUNC 175
 
 #define NO_FUNC ""
 static const char *trace_func_table[] = {
@@ -273,6 +273,7 @@ static const char *trace_func_table[] = {
     "ctx_Type_IsSubtype",
     "ctx_Unicode_FromEncodedObject",
     "ctx_Unicode_Substring",
+    "ctx_Dict_Keys",
     NULL /* sentinel */
 };
 
@@ -283,7 +284,7 @@ int hpy_trace_get_nfunc(void)
 
 const char * hpy_trace_get_func_name(int idx)
 {
-    if (idx >= 0 && idx < 257)
+    if (idx >= 0 && idx < 258)
         return trace_func_table[idx];
     return NULL;
 }

--- a/hpy/trace/src/autogen_trace_wrappers.c
+++ b/hpy/trace/src/autogen_trace_wrappers.c
@@ -1825,6 +1825,19 @@ HPy trace_ctx_Dict_Keys(HPyContext *tctx, HPy h)
     return res;
 }
 
+HPy trace_ctx_Dict_Copy(HPyContext *tctx, HPy h)
+{
+    HPyTraceInfo *info = hpy_trace_on_enter(tctx, 258);
+    HPyContext *uctx = info->uctx;
+    _HPyTime_t _ts_start, _ts_end;
+    _HPyClockStatus_t r0, r1;
+    r0 = get_monotonic_clock(&_ts_start);
+    HPy res = HPyDict_Copy(uctx, h);
+    r1 = get_monotonic_clock(&_ts_end);
+    hpy_trace_on_exit(info, 258, r0, r1, &_ts_start, &_ts_end);
+    return res;
+}
+
 int trace_ctx_Tuple_Check(HPyContext *tctx, HPy h)
 {
     HPyTraceInfo *info = hpy_trace_on_enter(tctx, 203);

--- a/hpy/trace/src/autogen_trace_wrappers.c
+++ b/hpy/trace/src/autogen_trace_wrappers.c
@@ -1812,6 +1812,19 @@ HPy trace_ctx_Dict_New(HPyContext *tctx)
     return res;
 }
 
+HPy trace_ctx_Dict_Keys(HPyContext *tctx, HPy h)
+{
+    HPyTraceInfo *info = hpy_trace_on_enter(tctx, 257);
+    HPyContext *uctx = info->uctx;
+    _HPyTime_t _ts_start, _ts_end;
+    _HPyClockStatus_t r0, r1;
+    r0 = get_monotonic_clock(&_ts_start);
+    HPy res = HPyDict_Keys(uctx, h);
+    r1 = get_monotonic_clock(&_ts_end);
+    hpy_trace_on_exit(info, 257, r0, r1, &_ts_start, &_ts_end);
+    return res;
+}
+
 int trace_ctx_Tuple_Check(HPyContext *tctx, HPy h)
 {
     HPyTraceInfo *info = hpy_trace_on_enter(tctx, 203);

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -156,6 +156,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_Dict_Check = &ctx_Dict_Check,
     .ctx_Dict_New = &ctx_Dict_New,
     .ctx_Dict_Keys = &ctx_Dict_Keys,
+    .ctx_Dict_Copy = &ctx_Dict_Copy,
     .ctx_Tuple_Check = &ctx_Tuple_Check,
     .ctx_Tuple_FromArray = &ctx_Tuple_FromArray,
     .ctx_Import_ImportModule = &ctx_Import_ImportModule,

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -155,6 +155,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_List_Append = &ctx_List_Append,
     .ctx_Dict_Check = &ctx_Dict_Check,
     .ctx_Dict_New = &ctx_Dict_New,
+    .ctx_Dict_Keys = &ctx_Dict_Keys,
     .ctx_Tuple_Check = &ctx_Tuple_Check,
     .ctx_Tuple_FromArray = &ctx_Tuple_FromArray,
     .ctx_Import_ImportModule = &ctx_Import_ImportModule,

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -520,6 +520,11 @@ HPyAPI_IMPL HPy ctx_Dict_New(HPyContext *ctx)
     return _py2h(PyDict_New());
 }
 
+HPyAPI_IMPL HPy ctx_Dict_Keys(HPyContext *ctx, HPy h)
+{
+    return _py2h(PyDict_Keys(_h2py(h)));
+}
+
 HPyAPI_IMPL int ctx_Tuple_Check(HPyContext *ctx, HPy h)
 {
     return PyTuple_Check(_h2py(h));

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -525,6 +525,11 @@ HPyAPI_IMPL HPy ctx_Dict_Keys(HPyContext *ctx, HPy h)
     return _py2h(PyDict_Keys(_h2py(h)));
 }
 
+HPyAPI_IMPL HPy ctx_Dict_Copy(HPyContext *ctx, HPy h)
+{
+    return _py2h(PyDict_Copy(_h2py(h)));
+}
+
 HPyAPI_IMPL int ctx_Tuple_Check(HPyContext *ctx, HPy h)
 {
     return PyTuple_Check(_h2py(h));

--- a/test/test_hpydict.py
+++ b/test/test_hpydict.py
@@ -73,3 +73,27 @@ class TestDict(HPyTest):
         """)
         assert mod.f({'hello': 1}) == 1
         assert mod.f({}) is None
+
+    def test_keys(self):
+        import pytest
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                HPy h_dict = HPy_Is(ctx, arg, ctx->h_None) ? HPy_NULL : arg;
+                return HPyDict_Keys(ctx, h_dict);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+
+        class SubDict(dict):
+            def keys(self):
+                return [1, 2, 3]
+        assert mod.f({}) == []
+        assert mod.f({'hello': 1}) == ['hello']
+        assert mod.f(SubDict(hello=1)) == ['hello']
+        with pytest.raises(SystemError):
+            mod.f(None)
+        with pytest.raises(SystemError):
+            mod.f(42)

--- a/test/test_hpydict.py
+++ b/test/test_hpydict.py
@@ -97,3 +97,25 @@ class TestDict(HPyTest):
             mod.f(None)
         with pytest.raises(SystemError):
             mod.f(42)
+
+    def test_copy(self):
+        import pytest
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                HPy h_dict = HPy_Is(ctx, arg, ctx->h_None) ? HPy_NULL : arg;
+                return HPyDict_Copy(ctx, h_dict);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        dicts = ({}, {'hello': 1})
+        for d in dicts:
+            d_copy = mod.f(d)
+            assert d_copy == d
+            assert d_copy is not d
+        with pytest.raises(SystemError):
+            mod.f(None)
+        with pytest.raises(SystemError):
+            mod.f(42)


### PR DESCRIPTION
Also used in the Numpy/HPy port (builds on PR #411).
I recommend reviewing commit by commit.