### PR TITLE
skip cppcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,8 @@ jobs:
     name: Cppcheck static analysis
     runs-on: 'ubuntu-20.04'
     continue-on-error: true
+    # Skip it, see issue gh-188
+    if: false
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Related to #188 and #395. The check has been failing for a few months. It seems to check way too much