### PR TITLE
Remove support for Python 3.7.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
         compiler: [""]
         include:
           - os: ubuntu-latest
-            python-version: '3.7'
-          - os: ubuntu-latest
             python-version: '3.8'
           - os: ubuntu-latest
             python-version: '3.10'
@@ -63,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
+        python-version: ['3.11', '3.10', '3.9', '3.8']
 
     steps:
       - uses: actions/checkout@v3
@@ -98,8 +96,6 @@ jobs:
         os: [ubuntu-latest, macos-11, windows-latest]
         python-version: ['3.10']
         include:
-          - os: ubuntu-latest
-            python-version: '3.7'
           - os: ubuntu-latest
             python-version: '3.8'
           - os: ubuntu-latest

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -102,7 +102,7 @@ In general it is possible to compile the same source into multiple compiled
 libraries, each one targeting a different ABI. :pep:`3149` states that the
 filename of the compiled extension should contain the *ABI tag* to specify
 what the target ABI is. For example, if you compile an extension called
-``simple.c`` on CPython 3.7, you get a DLL called
+``simple.c`` on CPython 3.8, you get a DLL called
 ``simple.cpython-38-x86_64-linux-gnu.so``:
 
   - ``cpython-38`` is the ABI tag, in this case CPython 3.8

--- a/hpy/devel/src/runtime/ctx_type.c
+++ b/hpy/devel/src/runtime/ctx_type.c
@@ -1148,17 +1148,6 @@ ctx_Type_FromSpec(HPyContext *ctx, HPyType_Spec *hpyspec,
     ht->ht_type.tp_name = (const char *)extra->name;
 #endif
 
-#if PY_VERSION_HEX < 0x03080000
-    /*
-    py3.7 compatibility
-    Before 3.8, the tp_finalize slot is only considered if the type has
-    Py_TPFLAGS_HAVE_FINALIZE. That flag is ignored in 3.8+ (see bpo-32388).
-    */
-    if (((PyTypeObject*)result)->tp_finalize != NULL) {
-        ((PyTypeObject*)result)->tp_flags |= Py_TPFLAGS_HAVE_FINALIZE;
-    }
-#endif
-
     PyBufferProcs* buffer_procs = create_buffer_procs(hpyspec);
     if (buffer_procs) {
         ((PyTypeObject*)result)->tp_as_buffer = buffer_procs;
@@ -1219,11 +1208,6 @@ ctx_New(HPyContext *ctx, HPy h_type, void **data)
 
     if (!result)
         return HPy_NULL;
-#if PY_VERSION_HEX < 0x03080000
-    // Workaround for Python issue 35810; no longer necessary in Python 3.8
-    // TODO: Remove this workaround once we no longer support Python versions older than 3.8
-    Py_INCREF(tp);
-#endif
 
     *data = payload;
 
@@ -1388,7 +1372,7 @@ _HPy_HIDDEN const char *ctx_Type_GetName(HPyContext *ctx, HPy type)
         return PyUnicode_AsUTF8(et->ht_name);
     }
     else {
-        // '_PyType_Name' is at least available from 3.7 to 3.12
+        // '_PyType_Name' is at least available from 3.8 to 3.12
         return _PyType_Name(tp);
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -263,5 +263,5 @@ setup(
     use_scm_version=get_scm_config,
     setup_requires=['setuptools_scm'],
     install_requires=['setuptools>=64.0'],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
Python 3.7 is soon EOL (see https://devguide.python.org/versions/).
This is also a preparation for the vectorcall PR #390 because 3.7 did not have vectorcall API yet.