### PR TITLE
Introduce HPySlice_Unpack and HPySlice_AdjustIndices.

### DIFF
--- a/docs/api-reference/function-index.rst
+++ b/docs/api-reference/function-index.rst
@@ -72,6 +72,7 @@ HPy Core API Function Index
 * :c:func:`HPyLong_FromUInt32_t`
 * :c:func:`HPyLong_FromUInt64_t`
 * :c:func:`HPyNumber_Check`
+* :c:func:`HPySlice_Unpack`
 * :c:func:`HPyTracker_Add`
 * :c:func:`HPyTracker_Close`
 * :c:func:`HPyTracker_ForgetAll`

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -1,11 +1,14 @@
+Contributing
+============
+
 Getting Started
-===============
+---------------
 
 TBD
 
 
 Adding New API
-==============
+--------------
 
 1. Add the function to ``hpy/tools/autogen/public_api.h``. If the CPython
    equivalent function name is not the same (after removing the leading ``H``,

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -259,6 +259,7 @@ with the code for the :term:`CPython ABI` mode, so it is guaranteed to be correc
     `PyObject_Type <https://docs.python.org/3/c-api/object.html#c.PyObject_Type>`_                                                     :c:func:`HPy_Type`
     `PyObject_TypeCheck <https://docs.python.org/3/c-api/object.html#c.PyObject_TypeCheck>`_                                           :c:func:`HPy_TypeCheck`
     `PySequence_Contains <https://docs.python.org/3/c-api/sequence.html#c.PySequence_Contains>`_                                       :c:func:`HPy_Contains`
+    `PySlice_Unpack <https://docs.python.org/3/c-api/slice.html#c.PySlice_Unpack>`_                                                    :c:func:`HPySlice_Unpack`
     `PyTuple_Check <https://docs.python.org/3/c-api/tuple.html#c.PyTuple_Check>`_                                                      :c:func:`HPyTuple_Check`
     `PyType_IsSubtype <https://docs.python.org/3/c-api/type.html#c.PyType_IsSubtype>`_                                                 :c:func:`HPyType_IsSubtype`
     `PyUnicode_AsASCIIString <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsASCIIString>`_                                :c:func:`HPyUnicode_AsASCIIString`

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -259,6 +259,7 @@ with the code for the :term:`CPython ABI` mode, so it is guaranteed to be correc
     `PyObject_Type <https://docs.python.org/3/c-api/object.html#c.PyObject_Type>`_                                                     :c:func:`HPy_Type`
     `PyObject_TypeCheck <https://docs.python.org/3/c-api/object.html#c.PyObject_TypeCheck>`_                                           :c:func:`HPy_TypeCheck`
     `PySequence_Contains <https://docs.python.org/3/c-api/sequence.html#c.PySequence_Contains>`_                                       :c:func:`HPy_Contains`
+    `PySlice_AdjustIndices <https://docs.python.org/3/c-api/slice.html#c.PySlice_AdjustIndices>`_                                      :c:func:`HPySlice_AdjustIndices`
     `PySlice_Unpack <https://docs.python.org/3/c-api/slice.html#c.PySlice_Unpack>`_                                                    :c:func:`HPySlice_Unpack`
     `PyTuple_Check <https://docs.python.org/3/c-api/tuple.html#c.PyTuple_Check>`_                                                      :c:func:`HPyTuple_Check`
     `PyType_IsSubtype <https://docs.python.org/3/c-api/type.html#c.PyType_IsSubtype>`_                                                 :c:func:`HPyType_IsSubtype`

--- a/hpy/debug/src/autogen_debug_ctx_init.h
+++ b/hpy/debug/src/autogen_debug_ctx_init.h
@@ -154,6 +154,7 @@ DHPy debug_ctx_Dict_Keys(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Dict_Copy(HPyContext *dctx, DHPy h);
 int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h);
 DHPy debug_ctx_Tuple_FromArray(HPyContext *dctx, DHPy items[], HPy_ssize_t n);
+int debug_ctx_Slice_Unpack(HPyContext *dctx, DHPy slice, HPy_ssize_t *start, HPy_ssize_t *stop, HPy_ssize_t *step);
 DHPy debug_ctx_Import_ImportModule(HPyContext *dctx, const char *utf8_name);
 DHPy debug_ctx_Capsule_New(HPyContext *dctx, void *pointer, const char *utf8_name, HPyCapsule_Destructor *destructor);
 void *debug_ctx_Capsule_Get(HPyContext *dctx, DHPy capsule, _HPyCapsule_key key, const char *utf8_name);
@@ -416,6 +417,7 @@ static inline void debug_ctx_init_fields(HPyContext *dctx, HPyContext *uctx)
     dctx->ctx_Dict_Copy = &debug_ctx_Dict_Copy;
     dctx->ctx_Tuple_Check = &debug_ctx_Tuple_Check;
     dctx->ctx_Tuple_FromArray = &debug_ctx_Tuple_FromArray;
+    dctx->ctx_Slice_Unpack = &debug_ctx_Slice_Unpack;
     dctx->ctx_Import_ImportModule = &debug_ctx_Import_ImportModule;
     dctx->ctx_Capsule_New = &debug_ctx_Capsule_New;
     dctx->ctx_Capsule_Get = &debug_ctx_Capsule_Get;

--- a/hpy/debug/src/autogen_debug_wrappers.c
+++ b/hpy/debug/src/autogen_debug_wrappers.c
@@ -1535,6 +1535,18 @@ int debug_ctx_Tuple_Check(HPyContext *dctx, DHPy h)
     return universal_result;
 }
 
+int debug_ctx_Slice_Unpack(HPyContext *dctx, DHPy slice, HPy_ssize_t *start, HPy_ssize_t *stop, HPy_ssize_t *step)
+{
+    if (!get_ctx_info(dctx)->is_valid) {
+        report_invalid_debug_context();
+    }
+    HPy dh_slice = DHPy_unwrap(dctx, slice);
+    get_ctx_info(dctx)->is_valid = false;
+    int universal_result = HPySlice_Unpack(get_info(dctx)->uctx, dh_slice, start, stop, step);
+    get_ctx_info(dctx)->is_valid = true;
+    return universal_result;
+}
+
 DHPy debug_ctx_Import_ImportModule(HPyContext *dctx, const char *utf8_name)
 {
     if (!get_ctx_info(dctx)->is_valid) {

--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -539,6 +539,11 @@ HPyAPI_FUNC int HPyTuple_Check(HPyContext *ctx, HPy h)
     return PyTuple_Check(_h2py(h));
 }
 
+HPyAPI_FUNC int HPySlice_Unpack(HPyContext *ctx, HPy slice, HPy_ssize_t *start, HPy_ssize_t *stop, HPy_ssize_t *step)
+{
+    return PySlice_Unpack(_h2py(slice), start, stop, step);
+}
+
 HPyAPI_FUNC HPy HPyImport_ImportModule(HPyContext *ctx, const char *utf8_name)
 {
     return _py2h(PyImport_ImportModule(utf8_name));

--- a/hpy/devel/include/hpy/runtime/ctx_funcs.h
+++ b/hpy/devel/include/hpy/runtime/ctx_funcs.h
@@ -113,6 +113,6 @@ _HPy_HIDDEN HPy ctx_Compile_s(HPyContext *ctx, const char *utf8_source,
                               const char *utf8_filename, HPy_SourceKind kind);
 
 // ctx_contextvar.c
-_HPy_HIDDEN int ctx_ContextVar_Get(HPyContext *ctx, HPy context_var,
-                                   HPy default_value, HPy *result);
+_HPy_HIDDEN int32_t ctx_ContextVar_Get(HPyContext *ctx, HPy context_var,
+                                       HPy default_value, HPy *result);
 #endif /* HPY_RUNTIME_CTX_FUNCS_H */

--- a/hpy/devel/include/hpy/universal/autogen_ctx.h
+++ b/hpy/devel/include/hpy/universal/autogen_ctx.h
@@ -273,4 +273,5 @@ struct _HPyContext_s {
     HPy (*ctx_Unicode_Substring)(HPyContext *ctx, HPy str, HPy_ssize_t start, HPy_ssize_t end);
     HPy (*ctx_Dict_Keys)(HPyContext *ctx, HPy h);
     HPy (*ctx_Dict_Copy)(HPyContext *ctx, HPy h);
+    int (*ctx_Slice_Unpack)(HPyContext *ctx, HPy slice, HPy_ssize_t *start, HPy_ssize_t *stop, HPy_ssize_t *step);
 };

--- a/hpy/devel/include/hpy/universal/autogen_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_trampolines.h
@@ -578,6 +578,10 @@ HPyAPI_FUNC HPy HPyTuple_FromArray(HPyContext *ctx, HPy items[], HPy_ssize_t n) 
      return ctx->ctx_Tuple_FromArray ( ctx, items, n ); 
 }
 
+HPyAPI_FUNC int HPySlice_Unpack(HPyContext *ctx, HPy slice, HPy_ssize_t *start, HPy_ssize_t *stop, HPy_ssize_t *step) {
+     return ctx->ctx_Slice_Unpack ( ctx, slice, start, stop, step ); 
+}
+
 HPyAPI_FUNC HPy HPyImport_ImportModule(HPyContext *ctx, const char *utf8_name) {
      return ctx->ctx_Import_ImportModule ( ctx, utf8_name ); 
 }

--- a/hpy/devel/src/runtime/buildvalue.c
+++ b/hpy/devel/src/runtime/buildvalue.c
@@ -48,6 +48,9 @@
  * ``K (int) [unsigned long long]``
  *     Convert a C unsigned long long to a Python integer object.
  *
+ * ``n (int) [HPy_ssize_t]``
+ *     Convert a C HPy_ssize_t to a Python integer object.
+ *
  * ``f (float) [float]``
  *     Convert a C float to a Python floating point number.
  *
@@ -226,6 +229,9 @@ static HPy build_single(HPyContext *ctx, const char **fmt, va_list *values, int 
 
         case 'K':
             return HPyLong_FromUnsignedLongLong(ctx, va_arg(*values, unsigned long long));
+
+        case 'n':
+            return HPyLong_FromSsize_t(ctx, va_arg(*values, HPy_ssize_t));
 
         case 's':
             return HPyUnicode_FromString(ctx, va_arg(*values, const char*));

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -648,6 +648,40 @@ HPy_ID(204)
 HPy HPyTuple_FromArray(HPyContext *ctx, HPy items[], HPy_ssize_t n);
 // note: HPyTuple_Pack is implemented as a macro in common/macros.h
 
+/* sliceobject.h */
+
+/**
+ * Extract the start, stop and step data members from a slice object as C
+ * integers.
+ *
+ * The slice members may be arbitrary int-like objects. If they are not Python
+ * int objects, they will be coerced to int objects by calling their
+ * ``__index__`` method.
+ *
+ * If a slice member value is out of bounds, it will be set to the maximum value
+ * of ``HPy_ssize_t`` if the member was a positive number, or to the minimum
+ * value of ``HPy_ssize_t`` if it was a negative number.
+ *
+ * :param ctx:
+ *     The execution context.
+ * :param slice:
+ *     A handle to a Python slice object. This argument must be a slice object
+ *     and must not be ``HPy_NULL``. Otherwise, behavior is undefined.
+ * :param start:
+ *     A pointer to a variable where to write the unpacked slice start. Must not
+ *     be ``NULL``.
+ * :param end:
+ *     A pointer to a variable where to write the unpacked slice end. Must not
+ * :param step:
+ *     A pointer to a variable where to write the unpacked slice step. Must not
+ *     be ``NULL``.
+ *
+ * :returns:
+ *     ``-1`` on error, ``0`` on success
+ */
+HPy_ID(259)
+int HPySlice_Unpack(HPyContext *ctx, HPy slice, HPy_ssize_t *start, HPy_ssize_t *stop, HPy_ssize_t *step);
+
 /* import.h */
 HPy_ID(205)
 HPy HPyImport_ImportModule(HPyContext *ctx, const char *utf8_name);

--- a/hpy/trace/src/autogen_trace_ctx_init.h
+++ b/hpy/trace/src/autogen_trace_ctx_init.h
@@ -153,6 +153,7 @@ HPy trace_ctx_Dict_Keys(HPyContext *tctx, HPy h);
 HPy trace_ctx_Dict_Copy(HPyContext *tctx, HPy h);
 int trace_ctx_Tuple_Check(HPyContext *tctx, HPy h);
 HPy trace_ctx_Tuple_FromArray(HPyContext *tctx, HPy items[], HPy_ssize_t n);
+int trace_ctx_Slice_Unpack(HPyContext *tctx, HPy slice, HPy_ssize_t *start, HPy_ssize_t *stop, HPy_ssize_t *step);
 HPy trace_ctx_Import_ImportModule(HPyContext *tctx, const char *utf8_name);
 HPy trace_ctx_Capsule_New(HPyContext *tctx, void *pointer, const char *utf8_name, HPyCapsule_Destructor *destructor);
 void *trace_ctx_Capsule_Get(HPyContext *tctx, HPy capsule, _HPyCapsule_key key, const char *utf8_name);
@@ -189,8 +190,8 @@ static inline void trace_ctx_init_info(HPyTraceInfo *info, HPyContext *uctx)
 {
     info->magic_number = HPY_TRACE_MAGIC;
     info->uctx = uctx;
-    info->call_counts = (uint64_t *)calloc(259, sizeof(uint64_t));
-    info->durations = (_HPyTime_t *)calloc(259, sizeof(_HPyTime_t));
+    info->call_counts = (uint64_t *)calloc(260, sizeof(uint64_t));
+    info->durations = (_HPyTime_t *)calloc(260, sizeof(_HPyTime_t));
     info->on_enter_func = HPy_NULL;
     info->on_exit_func = HPy_NULL;
 }
@@ -433,6 +434,7 @@ static inline void trace_ctx_init_fields(HPyContext *tctx, HPyContext *uctx)
     tctx->ctx_Dict_Copy = &trace_ctx_Dict_Copy;
     tctx->ctx_Tuple_Check = &trace_ctx_Tuple_Check;
     tctx->ctx_Tuple_FromArray = &trace_ctx_Tuple_FromArray;
+    tctx->ctx_Slice_Unpack = &trace_ctx_Slice_Unpack;
     tctx->ctx_Import_ImportModule = &trace_ctx_Import_ImportModule;
     tctx->ctx_Capsule_New = &trace_ctx_Capsule_New;
     tctx->ctx_Capsule_Get = &trace_ctx_Capsule_Get;

--- a/hpy/trace/src/autogen_trace_func_table.c
+++ b/hpy/trace/src/autogen_trace_func_table.c
@@ -12,7 +12,7 @@
 
 #include "trace_internal.h"
 
-#define TRACE_NFUNC 176
+#define TRACE_NFUNC 177
 
 #define NO_FUNC ""
 static const char *trace_func_table[] = {
@@ -275,6 +275,7 @@ static const char *trace_func_table[] = {
     "ctx_Unicode_Substring",
     "ctx_Dict_Keys",
     "ctx_Dict_Copy",
+    "ctx_Slice_Unpack",
     NULL /* sentinel */
 };
 
@@ -285,7 +286,7 @@ int hpy_trace_get_nfunc(void)
 
 const char * hpy_trace_get_func_name(int idx)
 {
-    if (idx >= 0 && idx < 259)
+    if (idx >= 0 && idx < 260)
         return trace_func_table[idx];
     return NULL;
 }

--- a/hpy/trace/src/autogen_trace_wrappers.c
+++ b/hpy/trace/src/autogen_trace_wrappers.c
@@ -1864,6 +1864,19 @@ HPy trace_ctx_Tuple_FromArray(HPyContext *tctx, HPy items[], HPy_ssize_t n)
     return res;
 }
 
+int trace_ctx_Slice_Unpack(HPyContext *tctx, HPy slice, HPy_ssize_t *start, HPy_ssize_t *stop, HPy_ssize_t *step)
+{
+    HPyTraceInfo *info = hpy_trace_on_enter(tctx, 259);
+    HPyContext *uctx = info->uctx;
+    _HPyTime_t _ts_start, _ts_end;
+    _HPyClockStatus_t r0, r1;
+    r0 = get_monotonic_clock(&_ts_start);
+    int res = HPySlice_Unpack(uctx, slice, start, stop, step);
+    r1 = get_monotonic_clock(&_ts_end);
+    hpy_trace_on_exit(info, 259, r0, r1, &_ts_start, &_ts_end);
+    return res;
+}
+
 HPy trace_ctx_Import_ImportModule(HPyContext *tctx, const char *utf8_name)
 {
     HPyTraceInfo *info = hpy_trace_on_enter(tctx, 205);

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -159,6 +159,7 @@ struct _HPyContext_s g_universal_ctx = {
     .ctx_Dict_Copy = &ctx_Dict_Copy,
     .ctx_Tuple_Check = &ctx_Tuple_Check,
     .ctx_Tuple_FromArray = &ctx_Tuple_FromArray,
+    .ctx_Slice_Unpack = &ctx_Slice_Unpack,
     .ctx_Import_ImportModule = &ctx_Import_ImportModule,
     .ctx_Capsule_New = &ctx_Capsule_New,
     .ctx_Capsule_Get = &ctx_Capsule_Get,

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -535,6 +535,11 @@ HPyAPI_IMPL int ctx_Tuple_Check(HPyContext *ctx, HPy h)
     return PyTuple_Check(_h2py(h));
 }
 
+HPyAPI_IMPL int ctx_Slice_Unpack(HPyContext *ctx, HPy slice, HPy_ssize_t *start, HPy_ssize_t *stop, HPy_ssize_t *step)
+{
+    return PySlice_Unpack(_h2py(slice), start, stop, step);
+}
+
 HPyAPI_IMPL HPy ctx_Import_ImportModule(HPyContext *ctx, const char *utf8_name)
 {
     return _py2h(PyImport_ImportModule(utf8_name));

--- a/test/support.py
+++ b/test/support.py
@@ -164,6 +164,7 @@ class DefaultExtensionTemplate(object):
                 textwrap.dedent('''
                 static HPyGlobal *module_globals[] = {
                     %s
+                    NULL
                 };''') % NL_INDENT.join(self.globals_table)
             globals_field = '.globals = module_globals'
 

--- a/test/test_hpybuildvalue.py
+++ b/test/test_hpybuildvalue.py
@@ -36,6 +36,7 @@ class TestBuildValue(HPyTest):
             ('return HPy_BuildValue(ctx, "I", 33);', 33),
             ('return HPy_BuildValue(ctx, "k", 1);', 1),
             ('return HPy_BuildValue(ctx, "K", 6543);', 6543),
+            ('return HPy_BuildValue(ctx, "n", 9876);', 9876),
             ('return HPy_BuildValue(ctx, "l", 345L);', 345),
             ('return HPy_BuildValue(ctx, "l", -876L);', -876),
             ('return HPy_BuildValue(ctx, "L", 545LL);', 545),
@@ -208,6 +209,7 @@ class TestBuildValue(HPyTest):
             ('return HPy_BuildValue(ctx, "(iI)", -1, UINT_MAX);',),
             ('return HPy_BuildValue(ctx, "(ik)", -1, ULONG_MAX);',),
             ('return HPy_BuildValue(ctx, "(iK)", -1, ULLONG_MAX);',),
+            ('return HPy_BuildValue(ctx, "(nn)", HPY_SSIZE_T_MIN, HPY_SSIZE_T_MAX);',),
         ]
         mod = self.make_tests_module(test_cases)
         for i, (test,) in enumerate(test_cases):

--- a/test/test_hpyslice.py
+++ b/test/test_hpyslice.py
@@ -1,0 +1,57 @@
+from .support import HPyTest
+
+class TestSlice(HPyTest):
+
+    def test_unpack(self):
+        import pytest
+        mod = self.make_module("""
+            HPyDef_METH(sizeof_ssize_t, "sizeof_ssize_t", HPyFunc_NOARGS)
+            static HPy sizeof_ssize_t_impl(HPyContext *ctx, HPy self)
+            {
+                return HPyLong_FromLong(ctx, sizeof(HPy_ssize_t));
+            }
+
+            HPyDef_METH(f, "f", HPyFunc_O)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy arg)
+            {
+                HPy_ssize_t start, stop, step;
+                HPy h_start, h_stop, h_step;
+                if (HPySlice_Unpack(ctx, arg, &start, &stop, &step))
+                    return HPy_NULL;
+
+                h_start = HPyLong_FromSsize_t(ctx, start);
+                h_stop = HPyLong_FromSsize_t(ctx, stop);
+                h_step = HPyLong_FromSsize_t(ctx, step);
+                HPy result = HPyTuple_Pack(ctx, 3, h_start, h_stop, h_step);
+                HPy_Close(ctx, h_start);
+                HPy_Close(ctx, h_stop);
+                HPy_Close(ctx, h_step);
+                return result;
+            }
+            @EXPORT(f)
+            @EXPORT(sizeof_ssize_t)
+            @INIT
+        """)
+
+        ssize_t_max = (1 << (mod.sizeof_ssize_t() * 8 - 1)) - 1
+        ssize_t_min = -(1 << (mod.sizeof_ssize_t() * 8 - 1))
+        assert mod.f(slice(2, 20, 2)) == (2, 20, 2)
+        assert mod.f(slice(4, 20)) == (4, 20, 1)
+        assert mod.f(slice(5, (1 << 129))) == (5, ssize_t_max, 1)
+        assert mod.f(slice(13, -27, -1)) == (13, -27, -1)
+        assert mod.f(slice(ssize_t_min - 1000, ssize_t_max + 1000, 1)) == (ssize_t_min, ssize_t_max, 1)
+        assert mod.f(slice(ssize_t_max, 0, -ssize_t_max-1000)) == (ssize_t_max, 0, -ssize_t_max)
+        assert mod.f(slice(None, 10, 1)) == (0, 10, 1)
+        assert mod.f(slice(None, 10, -1)) == (ssize_t_max, 10, -1)
+        assert mod.f(slice(None, None, -1)) == (ssize_t_max, ssize_t_min, -1)
+        assert mod.f(slice(None, None, None)) == (0, ssize_t_max, 1)
+        assert mod.f(slice(13, None, None)) == (13, ssize_t_max, 1)
+        assert mod.f(slice(13, None, -1)) == (13, ssize_t_min, -1)
+        with pytest.raises(ValueError):
+            mod.f(slice(1, 10, 0))
+        with pytest.raises(TypeError):
+            mod.f(slice(1, 10, "1"))
+        with pytest.raises(TypeError):
+            mod.f(slice(1, "10", 1))
+        with pytest.raises(TypeError):
+            mod.f(slice("0", 10, 1))

--- a/test/test_hpyslice.py
+++ b/test/test_hpyslice.py
@@ -55,3 +55,56 @@ class TestSlice(HPyTest):
             mod.f(slice(1, "10", 1))
         with pytest.raises(TypeError):
             mod.f(slice("0", 10, 1))
+
+    def test_adjust_indices(self):
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", HPyFunc_VARARGS)
+            static HPy f_impl(HPyContext *ctx, HPy self, HPy *args, HPy_ssize_t nargs)
+            {
+                HPy_ssize_t length, start, stop, step;
+
+                if (nargs != 4) {
+                    HPyErr_SetString(ctx, ctx->h_TypeError,
+                        "expected exactly 4 arguments");
+                    return HPy_NULL;
+                }
+
+                if (HPyArg_Parse(ctx, NULL, args, nargs, "nnnn",
+                        &length, &start, &stop, &step) < 0) {
+                    return HPy_NULL;
+                }
+                length = HPySlice_AdjustIndices(ctx, length, &start, &stop, step);
+                return HPy_BuildValue(ctx, "nnnn", length, start, stop, step);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+
+        # For the following tests, assume we work on a list:
+        # [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        assert mod.f(10, 0, 10, 1) == (10, 0, 10, 1)
+        assert mod.f(10, 0, -1, 1) == (9, 0, 9, 1)
+        assert mod.f(10, -10, -1, 1) == (9, 0, 9, 1)
+        assert mod.f(10, 15, 20, 1) == (0, 10, 10, 1)
+        # start at index 9 and to go index 1 (inclusive; since 0 is exclusive)
+        assert mod.f(10, 9, 0, -1) == (9, 9, 0, -1)
+        assert mod.f(10, -1, -10, -1) == (9, 9, 0, -1)
+        assert mod.f(10, 5, 5, -1) == (0, 5, 5, -1)
+
+        # same as above but with step 2
+        assert mod.f(10, 0, 10, 2) == (5, 0, 10, 2)
+        assert mod.f(10, 0, -1, 2) == (5, 0, 9, 2)
+        assert mod.f(10, -10, -1, 2) == (5, 0, 9, 2)
+        assert mod.f(10, 15, 20, 2) == (0, 10, 10, 2)
+        assert mod.f(10, 9, 0, -2) == (5, 9, 0, -2)
+        assert mod.f(10, -1, -10, -2) == (5, 9, 0, -2)
+        assert mod.f(10, 5, 5, -2) == (0, 5, 5, -2)
+
+        # same as above but with step 3
+        assert mod.f(10, 0, 10, 3) == (4, 0, 10, 3)
+        assert mod.f(10, 0, -1, 3) == (3, 0, 9, 3)
+        assert mod.f(10, -10, -1, 3) == (3, 0, 9, 3)
+        assert mod.f(10, 15, 20, 3) == (0, 10, 10, 3)
+        assert mod.f(10, 9, 0, -3) == (3, 9, 0, -3)
+        assert mod.f(10, -1, -10, -3) == (3, 9, 0, -3)
+        assert mod.f(10, 5, 5, -3) == (0, 5, 5, -3)


### PR DESCRIPTION
Two more functions required for NumPy/HPy:

* `HPySlice_Unpack` implemented as full API/ABI function
* `HPySlice_AdjustIndices` implemented as inline helper function. This one would not even need the context since it is actually just doing some arithmetic on the given arguments but for consistency, it still has a `HPyContext *ctx` argument.

This PR also includes some other small fixes:

* Minor fixes for Python 3.12 compatibility
* Fix missing `NULL` terminator in test template
* Fix caption level in contributing docs
* Implement format specifier `'n'` (`HPy_ssize_t`) in `HPy_BuildValue`. Not sure why we didn't have it since we already have it in `HPyArg_Parse`.
* We incorrectly used return type `int` for `ctx_ContextVar_Get` in `ctx_funcs.h` (should be type `int32_t`).

