### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+# https://beta.ruff.rs
+name: ruff
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --format=github .

--- a/docs/examples/tests.py
+++ b/docs/examples/tests.py
@@ -61,7 +61,7 @@ def test_builtin_type():
 
 def test_leak_detector():
     from hpy.debug.pytest import LeakDetector
-    with LeakDetector() as ld:
+    with LeakDetector():
         # add_ints is an HPy C function. If it forgets to close a handle,
         # LeakDetector will complain
         assert mixed.add_ints(40, 2) == 42

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,23 @@
 [build-system]
 requires = [ "setuptools>=64.0", "setuptools-scm[toml]>=6.0", "wheel>=0.34.2",]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+ignore = [
+    "F401",  # imported but unused
+    "F541",  # f-string without any placeholders
+]
+line-length = 107
+show-source = true
+target-version = "py37"
+
+[tool.ruff.per-file-ignores]
+"docs/*" = [
+    "E402",  # module level import not at top of file
+    "F811",  # redefinition of unused variable
+]
+"test/*" = [
+    "E",     # pycodestyle errors
+    "F811",  # redefinition of unused variable
+    "F841",  # local variable is assigned to but unused
+]

--- a/test/debug/test_charptr.py
+++ b/test/debug/test_charptr.py
@@ -188,7 +188,7 @@ def test_charptr_correct_usage(compiler):
         @EXPORT(f)
         @INIT
     """)
-    assert mod.f('I wont be leaked!') == 'I wont be leaked!';
+    assert mod.f('I wont be leaked!') == 'I wont be leaked!'
 
 
 def test_charptr_limit_stress_test(compiler):

--- a/test/test_capsule.py
+++ b/test/test_capsule.py
@@ -350,7 +350,7 @@ class TestHPyCapsule(HPyTest):
             assert mod.capsule_setpointer(p, 456, "lorem ipsum", True) is None
             assert mod.capsule_getpointer(p) == (456, "lorem ipsum")
 
-            assert mod.capsule_getcontext(p) == None
+            assert mod.capsule_getcontext(p) is None
             assert mod.capsule_setcontext(p, 123, "hello") is None
             assert mod.capsule_getcontext(p) == (123, "hello")
 

--- a/test/test_hpylong.py
+++ b/test/test_hpylong.py
@@ -418,8 +418,8 @@ class TestLong(HPyTest):
             @EXPORT(f)
             @INIT
         """)
-        assert mod.is_null(0) == True
-        assert mod.is_null(10) == False
+        assert mod.is_null(0) is True
+        assert mod.is_null(10) is False
 
     def test_Long_AsDouble(self):
         import pytest


### PR DESCRIPTION
As suggested at https://github.com/hpyproject/hpy/wiki/dev-call-20201105#topics-deferred-to-the-next-dev-call

[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including bandit, isort, pylint, pyupgrade, and flake8 plus its plugins, and is written in Rust for speed.

The `ruff` Action uses minimal steps to run in ~10 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)

Python file edits were done with:
% [`ruff --select=E703,E711,E712,F841 --fix .`](https://beta.ruff.rs/docs/rules/#error-e)