### PR TITLE
Add separate authors file to track contributions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,38 @@
+# This is the list of HPy's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Alexander Schremmer
+Ammar Askar
+Ankith (ankith26)
+Antonio Cuni
+Armin Rigo
+Charlie Hayden
+Christian Klein
+Daniel Alley
+Dominic Davis-Foster
+Jaime Resano Aísa
+Joachim Trouverie
+Julian Berman
+Krish Patel
+Kyle Lawlor-Bagcal
+Mathieu Dupuy
+Matti Picus
+Max Horn
+Maxwell Bernstein
+Mohamed Koubaa
+Nico Rittinghaus
+Omer Katz
+Oracle and/or its affiliates
+Paul Prescod
+Pierre Augier 
+Robert O'Shea
+Ronan Lamy
+Simon Cross
+Stefan Behnel
+Stefano Rivera
+Victor Stinner
+Vytautas Liuolia
+Łukasz Langa

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 pyhandle
+Copyright (c) 2019 The HPy Authors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The project is no longer called pyhandle, so the old copyright notice was a bit confusing. Also, contributions by Oracle folks as part of their work should be attributed to Oracle, not the employees personally, so the git history alone is not a great way to track copyright. I suppose if/when other companies start contributing, they might similarly like to be mentioned as contributors.

I have so far not put any other companies in the AUTHORS file, just people's names. If e.g. @mattip or @antocuni want to attribute their work to Quansight or Anaconda, we should add them as well