### PR TITLE
Add structseq.c to extra sources.

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -126,16 +126,11 @@ jobs:
         name: artifact
         path: dist
 
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.tag }}
-
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
         files: dist/*
         # consider tags in form '*.*.*rc*' to indicate a pre-release
-        prerelease: ${{ contains(github.ref, 'rc') }}
+        prerelease: ${{ contains(inputs.tag, 'rc') }}
         draft: ${{ !inputs.official }}
         tag_name: ${{ inputs.tag }}

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -74,6 +74,7 @@ class HPyDevel:
             self.src_dir.joinpath('buildvalue.c'),
             self.src_dir.joinpath('format.c'),
             self.src_dir.joinpath('helpers.c'),
+            self.src_dir.joinpath('structseq.c'),
         ]))
 
     def _scan_static_lib_dir(self):

--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -188,8 +188,11 @@ def handle_hpy_ext_modules(dist, attr, hpy_ext_modules):
     dist.__class__.hpy_abi = DEFAULT_HPY_ABI
     dist.__class__.hpy_use_static_libs = False
     dist.__class__.global_options += [
-        ('hpy-abi=', None, 'Specify the HPy ABI mode (default: %s)' % DEFAULT_HPY_ABI),
-        ('hpy-no-static-libs', None, 'Compile context and extra sources with extension (default: False)')
+        ('hpy-abi=', None, 'Specify the HPy ABI mode (default: %s)'
+                           % DEFAULT_HPY_ABI),
+        ('hpy-use-static-libs', None, 'Use static library containing context '
+                                      'and helper functions for building '
+                                      'extensions (default: False)')
     ]
     hpydevel = HPyDevel()
     hpydevel.fix_distribution(dist)


### PR DESCRIPTION
This is an important bug fix for HPy `0.9.0rc1` (and I will create `rc2` after this is merged).

When I've added the helper functions `HPyStructSequence_New/NewType` in PR #415 , I obviously forgot to add it to the list of extra sources in `hpy.devel`.  This may result in an undefined symbol error when linking.

It doesn't show up in the tests because we build a static lib containing the helpers and I did add the new source file to there (in `setup.py`).

In order to avoid such problems in future, I plan to have the list of helper sources just in one place.