### PR TITLE
Make autogen work under Windows+MSVC

### DIFF
--- a/hpy/devel/__init__.py
+++ b/hpy/devel/__init__.py
@@ -428,7 +428,7 @@ class build_ext_hpy_mixin:
         ext_file = os.path.basename(ext._file_name)
         module_name = ext_file.split(".")[0]
         if not self.dry_run:
-            with open(stub_file, 'w') as f:
+            with open(stub_file, 'w', encoding='utf-8') as f:
                 f.write(_HPY_UNIVERSAL_MODULE_STUB_TEMPLATE.format(
                     ext_file=ext_file, module_name=module_name)
                 )

--- a/hpy/tools/autogen/autogenfile.py
+++ b/hpy/tools/autogen/autogenfile.py
@@ -27,7 +27,7 @@ class AutoGenFile:
     def write(self, root):
         cls = self.__class__
         clsname = '%s.%s' % (cls.__module__, cls.__name__)
-        with root.join(self.PATH).open('w') as f:
+        with root.join(self.PATH).open('w', encoding='utf-8') as f:
             if self.DISCLAIMER is not None:
                 f.write(self.DISCLAIMER.format(clsname=clsname))
                 f.write('\n')

--- a/hpy/tools/autogen/doc.py
+++ b/hpy/tools/autogen/doc.py
@@ -64,7 +64,7 @@ class AutoGenFilePart:
         if not self.BEGIN_MARKER or not self.END_MARKER:
             raise RuntimeError("missing BEGIN_MARKER or END_MARKER")
         n_begin = len(self.BEGIN_MARKER)
-        with root.join(self.PATH).open('r') as f:
+        with root.join(self.PATH).open('r', encoding='utf-8') as f:
             content = f.read()
         start = content.find(self.BEGIN_MARKER)
         if start < 0:
@@ -75,7 +75,7 @@ class AutoGenFilePart:
             raise RuntimeError(f'end marker "{self.END_MARKER}" not found in'
                                f'file {self.PATH}')
         new_content = self.generate(content[(start+n_begin):end])
-        with root.join(self.PATH).open('w') as f:
+        with root.join(self.PATH).open('w', encoding='utf-8') as f:
             f.write(content[:start + n_begin] + new_content + content[end:])
 
 

--- a/hpy/tools/autogen/parse.py
+++ b/hpy/tools/autogen/parse.py
@@ -4,6 +4,7 @@ import attr
 import re
 import py
 import pycparser
+import shutil
 from pycparser import c_ast
 from pycparser.c_generator import CGenerator
 from distutils.sysconfig import get_config_var
@@ -202,15 +203,26 @@ class HPyAPI:
                             re.DOTALL | re.MULTILINE)
 
     def __init__(self, filename):
-        cpp_cmd = get_config_var('CC').split(' ')
+        cpp_cmd = get_config_var('CC')
+        if cpp_cmd:
+            cpp_cmd = cpp_cmd.split(' ')
+        elif sys.platform == 'win32':
+            cpp_cmd = [shutil.which("cl.exe")]
         if sys.platform == 'win32':
             cpp_cmd += ['/E', '/I%s' % CURRENT_DIR]
         else:
             cpp_cmd += ['-E', '-I%s' % CURRENT_DIR]
 
+        msvc = "cl.exe" in cpp_cmd[0].casefold()
+
         csource = pycparser.preprocess_file(filename,
                                   cpp_path=str(cpp_cmd[0]),
                                   cpp_args=cpp_cmd[1:])
+
+        # MSVC preprocesses _Pragma(foo) to __pragma(foo),
+        # but cparser needs to see a #pragma, not __pragma.
+        if msvc:
+            csource = re.sub(r'__pragma\(([^)]+)\)', r'#pragma \1\n', csource)
 
         # Remove comments.  NOTE: this assumes that comments are never inside
         # string literals, but there shouldn't be any here.


### PR DESCRIPTION
1. Default encoding on Windows isn't UTF-8. This caused autogen to mangle the documentation files.
2. Add detection of MSVC so that autogen will work under msvc command line.

This helps when using hpy under MSVC.