### PR TITLE
fix typo: HPy_mod_execute -> HPy_mod_exec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,10 +322,16 @@ jobs:
     #   parameters:
     #     pythonVersion: "2.7"
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '2.7'
+      - name: Set up Python2
+        # Copied from cython's ci.yml
+        run: |
+            sudo ln -fs python2 /usr/bin/python
+            sudo apt-get update
+            sudo apt-get install python-setuptools python2.7 python2.7-dev
+            curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+            sudo python2 get-pip.py
+            ls -l /usr/bin/pip* /usr/local/bin/pip*
+            which pip
 
       - name: Install/Upgrade Python dependencies
         run: python -m pip install --upgrade pip wheel

--- a/docs/examples/quickstart/quickstart.c
+++ b/docs/examples/quickstart/quickstart.c
@@ -35,5 +35,5 @@ static HPyModuleDef quickstart_def = {
 
 // The Python interpreter will create the module for us from the
 // HPyModuleDef specification. Additional initialization can be
-// done in the HPy_mod_execute slot
+// done in the HPy_mod_exec slot
 HPy_MODINIT(quickstart, quickstart_def)

--- a/hpy/devel/include/hpy/hpymodule.h
+++ b/hpy/devel/include/hpy/hpymodule.h
@@ -119,7 +119,7 @@ typedef struct {
  *   structure that will serve as a specification of the module that should be
  *   created by the interpreter. HPy supports only multi-phase module
  *   initialization (PEP 451). Any module initialization code can be added
- *   to the HPy_mod_execute slot of the module if needed.
+ *   to the HPy_mod_exec slot of the module if needed.
  *
  * Example:
  *


### PR DESCRIPTION
Closes #443 

HPy_mod_execute in documentation should be HPy_mod_exec