### PR TITLE
test_legacy_forbidden.py: Remove unused imports

### DIFF
--- a/test/test_legacy_forbidden.py
+++ b/test/test_legacy_forbidden.py
@@ -3,8 +3,6 @@ In this file we check that if we use legacy features in universal mode, we
 get the expected compile time errors
 """
 
-import sys
-import pytest
 from .support import HPyTest, make_hpy_abi_fixture, ONLY_LINUX
 
 # this is not strictly correct, we should check whether the actual compiler


### PR DESCRIPTION
% `ruff test/test_legacy_forbidden.py`
```
Error: test/test_legacy_forbidden.py:6:8: F401 `sys` imported but unused
Error: test/test_legacy_forbidden.py:7:8: F401 `pytest` imported but unused
```