### PR TITLE
Improve implementation of HPy_(Type | Is | GetItem_i) in CPython ABI mode.

### DIFF
--- a/hpy/devel/include/hpy/cpython/autogen_api_impl.h
+++ b/hpy/devel/include/hpy/cpython/autogen_api_impl.h
@@ -369,11 +369,6 @@ HPyAPI_FUNC int HPy_DelSlice(HPyContext *ctx, HPy obj, HPy_ssize_t start, HPy_ss
     return PySequence_DelSlice(_h2py(obj), start, end);
 }
 
-HPyAPI_FUNC HPy HPy_Type(HPyContext *ctx, HPy obj)
-{
-    return _py2h(PyObject_Type(_h2py(obj)));
-}
-
 HPyAPI_FUNC HPy HPy_Repr(HPyContext *ctx, HPy obj)
 {
     return _py2h(PyObject_Repr(_h2py(obj)));

--- a/hpy/devel/include/hpy/cpython/misc.h
+++ b/hpy/devel/include/hpy/cpython/misc.h
@@ -318,7 +318,7 @@ HPyAPI_FUNC int HPy_TypeCheck(HPyContext *ctx, HPy h_obj, HPy h_type)
 
 HPyAPI_FUNC int HPy_Is(HPyContext *ctx, HPy h_obj, HPy h_other)
 {
-    return ctx_Is(ctx, h_obj, h_other);
+    return _h2py(h_obj) == _h2py(h_other);
 }
 
 HPyAPI_FUNC HPyListBuilder HPyListBuilder_New(HPyContext *ctx, HPy_ssize_t initial_size)

--- a/hpy/devel/include/hpy/cpython/misc.h
+++ b/hpy/devel/include/hpy/cpython/misc.h
@@ -311,6 +311,13 @@ HPyAPI_FUNC void _HPy_Dump(HPyContext *ctx, HPy h)
     ctx_Dump(ctx, h);
 }
 
+HPyAPI_FUNC HPy HPy_Type(HPyContext *ctx, HPy h_obj)
+{
+    PyTypeObject *tp = Py_TYPE(_h2py(h_obj));
+    Py_INCREF(tp);
+    return _py2h((PyObject *)tp);
+}
+
 HPyAPI_FUNC int HPy_TypeCheck(HPyContext *ctx, HPy h_obj, HPy h_type)
 {
     return ctx_TypeCheck(ctx, h_obj, h_type);

--- a/hpy/devel/include/hpy/runtime/ctx_funcs.h
+++ b/hpy/devel/include/hpy/runtime/ctx_funcs.h
@@ -31,6 +31,7 @@ _HPy_HIDDEN HPy ctx_Module_Create(HPyContext *ctx, HPyModuleDef *hpydef);
 
 // ctx_object.c
 _HPy_HIDDEN void ctx_Dump(HPyContext *ctx, HPy h);
+_HPy_HIDDEN HPy ctx_Type(HPyContext *ctx, HPy h_obj);
 _HPy_HIDDEN int ctx_TypeCheck(HPyContext *ctx, HPy h_obj, HPy h_type);
 _HPy_HIDDEN int ctx_Is(HPyContext *ctx, HPy h_obj, HPy h_other);
 _HPy_HIDDEN HPy ctx_GetItem_i(HPyContext *ctx, HPy obj, HPy_ssize_t idx);

--- a/hpy/devel/src/runtime/ctx_object.c
+++ b/hpy/devel/src/runtime/ctx_object.c
@@ -15,6 +15,14 @@ ctx_Dump(HPyContext *ctx, HPy h)
     _PyObject_Dump(_h2py(h));
 }
 
+_HPy_HIDDEN HPy
+ctx_Type(HPyContext *ctx, HPy obj)
+{
+    PyTypeObject *tp = Py_TYPE(_h2py(obj));
+    Py_INCREF(tp);
+    return _py2h((PyObject *)tp);
+}
+
 /* NOTE: In contrast to CPython, HPy has to check that 'h_type' is a type. This
    is not necessary on CPython because it requires C type 'PyTypeObject *' but
    here we can only receive an HPy handle. Appropriate checking of the argument

--- a/hpy/devel/src/runtime/ctx_object.c
+++ b/hpy/devel/src/runtime/ctx_object.c
@@ -42,10 +42,14 @@ ctx_Is(HPyContext *ctx, HPy h_obj, HPy h_other)
 
 _HPy_HIDDEN HPy
 ctx_GetItem_i(HPyContext *ctx, HPy obj, HPy_ssize_t idx) {
+    PyObject *py_obj = _h2py(obj);
+    if (PySequence_Check(py_obj)) {
+        return _py2h(PySequence_GetItem(py_obj, idx));
+    }
     PyObject* key = PyLong_FromSsize_t(idx);
     if (key == NULL)
         return HPy_NULL;
-    HPy result = _py2h(PyObject_GetItem(_h2py(obj), key));
+    HPy result = _py2h(PyObject_GetItem(py_obj, key));
     Py_DECREF(key);
     return result;
 }

--- a/hpy/tools/autogen/conf.py
+++ b/hpy/tools/autogen/conf.py
@@ -121,7 +121,7 @@ SPECIAL_CASES = {
     'HPyTracker_ForgetAll': None,
     'HPyTracker_Close': None,
     '_HPy_Dump': None,
-    'HPy_Type': 'PyObject_Type',
+    'HPy_Type': None,
     'HPy_TypeCheck': None,
     'HPy_Is': None,
     'HPyBytes_FromStringAndSize': None,
@@ -182,6 +182,7 @@ DOC_MANUAL_API_MAPPING = {
     'PySlice_AdjustIndices': 'HPySlice_AdjustIndices',
     'PyType_IsSubtype': 'HPyType_IsSubtype',
     'PyObject_Call': 'HPy_CallTupleDict',
+    'PyObject_Type': 'HPy_Type',
     'PyObject_Vectorcall': 'HPy_Call',
     'PyObject_VectorcallMethod': 'HPy_CallMethod',
 }

--- a/hpy/universal/src/autogen_ctx_impl.h
+++ b/hpy/universal/src/autogen_ctx_impl.h
@@ -365,11 +365,6 @@ HPyAPI_IMPL int ctx_DelSlice(HPyContext *ctx, HPy obj, HPy_ssize_t start, HPy_ss
     return PySequence_DelSlice(_h2py(obj), start, end);
 }
 
-HPyAPI_IMPL HPy ctx_Type(HPyContext *ctx, HPy obj)
-{
-    return _py2h(PyObject_Type(_h2py(obj)));
-}
-
 HPyAPI_IMPL HPy ctx_Repr(HPyContext *ctx, HPy obj)
 {
     return _py2h(PyObject_Repr(_h2py(obj)));


### PR DESCRIPTION
Some time ago, I've mentioned that the call overhead in the implementation of `HPy_Type` was crucial (in CPython ABI mode) for the NumPy/HPy demo. The same applies to `HPy_Is`. Therefore, I'm essentially _inlining_ the implementation into the appropriate API functions.
I also did a little improvement in `HPy_GetItem_i` to avoid unnecessary allocation of long objects.