### PR TITLE
Allow building the C extension on GraalPy and running tests with it.

### DIFF
--- a/hpy/universal/src/hpymodule.c
+++ b/hpy/universal/src/hpymodule.c
@@ -22,9 +22,6 @@
 #ifdef PYPY_VERSION
 #  error "Cannot build hpy.universal on top of PyPy. PyPy comes with its own version of it"
 #endif
-#ifdef GRAALVM_PYTHON
-#  error "Cannot build hpy.universal on top of GraalPy. GraalPy comes with its own version of it"
-#endif
 
 static const char *hpy_mode_names[] = {
         "MODE_UNIVERSAL",

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from setuptools import setup, Extension
 from setuptools.command.build_clib import build_clib
 import platform
 
-# this package is supposed to be installed ONLY on CPython. Try to bail out
-# with a meaningful error message in other cases.
-if sys.implementation.name != 'cpython':
+# this package is supposed to be installed ONLY on CPython and GraalPy. Try to
+# bail out with a meaningful error message in other cases.
+if sys.implementation.name not in ('cpython', 'graalpy'):
     msg = 'ERROR: Cannot install and/or update hpy on this python implementation:\n'
     msg += f'    sys.implementation.name == {sys.implementation.name!r}\n\n'
     if '_hpy_universal' in sys.builtin_module_names:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 from .support import ExtensionCompiler, DefaultExtensionTemplate,\
     PythonSubprocessRunner, HPyDebugCapture, make_hpy_abi_fixture
 from pathlib import Path
@@ -31,6 +32,13 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "syncgc: Mark tests that rely on a synchronous GC."
     )
+
+
+def pytest_runtest_setup(item):
+    if any(item.iter_markers(name="syncgc")):
+        if sys.implementation.name in ("pypy", "graalpy"):
+            pytest.skip("requires synchronous garbage collector")
+
 
 # this is the default set of hpy_abi for all the tests. Individual files and
 # classes can override it.

--- a/test/debug/test_charptr.py
+++ b/test/debug/test_charptr.py
@@ -1,6 +1,7 @@
 import os
 import pytest
-from ..support import SUPPORTS_SYS_EXECUTABLE, SUPPORTS_MEM_PROTECTION
+import sys
+from ..support import SUPPORTS_SYS_EXECUTABLE, SUPPORTS_MEM_PROTECTION, IS_GRAALPY
 
 # Tests detection of usage of char pointers associated with invalid already
 # closed handles. For now, the debug mode does not provide any hook for this
@@ -13,6 +14,7 @@ def hpy_abi():
         yield "debug"
 
 
+@pytest.mark.skipif(IS_GRAALPY, reason="fails on GraalPy")
 @pytest.mark.skipif(not SUPPORTS_SYS_EXECUTABLE, reason="needs subprocess")
 def test_charptr_use_after_implicit_arg_handle_close(compiler, python_subprocess):
     mod = compiler.compile_module("""
@@ -70,6 +72,7 @@ def test_charptr_use_after_implicit_arg_handle_close(compiler, python_subprocess
             assert b"UnicodeDecodeError" in result.stderr
 
 
+@pytest.mark.skipif(IS_GRAALPY, reason="fails on GraalPy")
 @pytest.mark.skipif(not SUPPORTS_SYS_EXECUTABLE, reason="needs subprocess")
 def test_charptr_use_after_handle_close(compiler, python_subprocess):
     mod = compiler.compile_module("""
@@ -121,6 +124,7 @@ def test_charptr_use_after_handle_close(compiler, python_subprocess):
             assert b"UnicodeDecodeError" in result.stderr
 
 
+@pytest.mark.skipif(IS_GRAALPY, reason="transiently fails on GraalPy")
 @pytest.mark.skipif(not SUPPORTS_MEM_PROTECTION, reason=
                     "Could be implemented by checking the contents on close.")
 @pytest.mark.skipif(not SUPPORTS_SYS_EXECUTABLE, reason="needs subprocess")

--- a/test/debug/test_context_reuse.py
+++ b/test/debug/test_context_reuse.py
@@ -1,10 +1,15 @@
 import pytest
+import sys
+
+from ..support import IS_GRAALPY
+
 
 @pytest.fixture
 def hpy_abi():
     return "debug"
 
 
+@pytest.mark.skipif(IS_GRAALPY, reason="Hangs on GraalPy")
 def test_reuse_context_from_global_variable(compiler, python_subprocess):
     mod = compiler.compile_module("""
         #include <stdio.h>

--- a/test/debug/test_misc.py
+++ b/test/debug/test_misc.py
@@ -1,11 +1,13 @@
 import pytest
-from ..support import SUPPORTS_SYS_EXECUTABLE, SUPPORTS_MEM_PROTECTION
+import sys
+from ..support import SUPPORTS_SYS_EXECUTABLE, SUPPORTS_MEM_PROTECTION, IS_GRAALPY
 
 @pytest.fixture
 def hpy_abi():
     return "debug"
 
 
+@pytest.mark.skipif(IS_GRAALPY, reason="hangs on GraalPy")
 @pytest.mark.skipif(not SUPPORTS_SYS_EXECUTABLE, reason="needs subprocess")
 def test_use_invalid_as_struct(compiler, python_subprocess):
     mod = compiler.compile_module("""
@@ -38,6 +40,7 @@ def test_use_invalid_as_struct(compiler, python_subprocess):
     assert "Invalid usage of _HPy_AsStruct_Object" in result.stderr.decode("utf-8")
 
 
+@pytest.mark.skipif(IS_GRAALPY, reason="hangs on GraalPy")
 @pytest.mark.skipif(not SUPPORTS_SYS_EXECUTABLE, reason="needs subprocess")
 def test_typecheck(compiler, python_subprocess):
     mod = compiler.compile_module("""
@@ -60,6 +63,7 @@ def test_typecheck(compiler, python_subprocess):
     assert "HPy_TypeCheck arg 2 must be a type" in result.stderr.decode("utf-8")
 
 
+@pytest.mark.skipif(IS_GRAALPY, reason="hangs on GraalPy")
 @pytest.mark.skipif(not SUPPORTS_MEM_PROTECTION, reason=
                     "Could be implemented by checking the contents on close.")
 @pytest.mark.skipif(not SUPPORTS_SYS_EXECUTABLE, reason="needs subprocess")
@@ -119,6 +123,7 @@ def test_type_getname(compiler, python_subprocess):
     assert result.returncode != 0
 
 
+@pytest.mark.skipif(IS_GRAALPY, reason="hangs on GraalPy")
 @pytest.mark.skipif(not SUPPORTS_SYS_EXECUTABLE, reason="needs subprocess")
 def test_type_issubtype(compiler, python_subprocess):
     mod = compiler.compile_module("""
@@ -143,6 +148,7 @@ def test_type_issubtype(compiler, python_subprocess):
     assert "HPyType_IsSubtype arg 1 must be a type" in result.stderr.decode("utf-8")
 
 
+@pytest.mark.skipif(IS_GRAALPY, reason="transiently fails on GraalPy")
 @pytest.mark.skipif(not SUPPORTS_SYS_EXECUTABLE, reason="needs subprocess")
 def test_unicode_substring(compiler, python_subprocess):
     mod = compiler.compile_module("""

--- a/test/support.py
+++ b/test/support.py
@@ -19,6 +19,8 @@ SUPPORTS_SYS_EXECUTABLE = bool(getattr(sys, "executable", None))
 # True if we are running on the CPython debug build
 IS_PYTHON_DEBUG_BUILD = hasattr(sys, 'gettotalrefcount')
 
+IS_GRAALPY = getattr(getattr(sys, "implementation", None), "name", None) == 'graalpy'
+
 # pytest marker to run tests only on linux
 ONLY_LINUX = pytest.mark.skipif(sys.platform!='linux', reason='linux only')
 
@@ -441,6 +443,7 @@ class PythonSubprocessRunner:
 
 @pytest.mark.usefixtures('initargs')
 class HPyTest:
+    is_graalpy = IS_GRAALPY  # Exposed here for tests running as PyPy apptests
     ExtensionTemplate = DefaultExtensionTemplate
 
     @pytest.fixture()

--- a/test/test_cpy_compat.py
+++ b/test/test_cpy_compat.py
@@ -1,4 +1,5 @@
-from .support import HPyTest, make_hpy_abi_fixture
+import pytest
+from .support import HPyTest, make_hpy_abi_fixture, IS_GRAALPY
 
 class TestCPythonCompatibility(HPyTest):
 
@@ -30,6 +31,7 @@ class TestCPythonCompatibility(HPyTest):
             expected = 'hybrid'
         assert hpy_abi == expected
 
+    @pytest.mark.skipif(IS_GRAALPY, reason="Crashes on GraalPy")
     def test_frompyobject(self):
         mod = self.make_module("""
             #include <Python.h>
@@ -132,6 +134,7 @@ class TestCPythonCompatibility(HPyTest):
         obj = MyClass()
         assert mod.f(obj) == 1234
 
+    @pytest.mark.skipif(IS_GRAALPY, reason="Crashes on GraalPy")
     def test_hpy_close(self):
         mod = self.make_module("""
             #include <Python.h>
@@ -156,6 +159,7 @@ class TestCPythonCompatibility(HPyTest):
         if self.supports_refcounts():
             assert x == -1
 
+    @pytest.mark.skipif(IS_GRAALPY, reason="Crashes on GraalPy")
     def test_hpy_dup(self):
         mod = self.make_module("""
             #include <Python.h>
@@ -182,6 +186,7 @@ class TestCPythonCompatibility(HPyTest):
         if self.supports_refcounts():
             assert x == +1
 
+    @pytest.mark.skipif(IS_GRAALPY, reason="Crashes on GraalPy")
     def test_many_handles(self):
         mod = self.make_module("""
             #include <Python.h>

--- a/test/test_hpyerr.py
+++ b/test/test_hpyerr.py
@@ -1,4 +1,5 @@
-from .support import HPyTest, SUPPORTS_SYS_EXECUTABLE, trampoline
+import pytest
+from .support import HPyTest, SUPPORTS_SYS_EXECUTABLE, trampoline, IS_GRAALPY
 
 
 class TestErr(HPyTest):
@@ -17,6 +18,7 @@ class TestErr(HPyTest):
         with pytest.raises(MemoryError):
             mod.f()
 
+    @pytest.mark.skipif(IS_GRAALPY, reason="Fails transiently on GraalPy especially with xdist")
     def test_FatalError(self, python_subprocess, fatal_exit_code):
         mod = self.compile_module("""
             HPyDef_METH(f, "f", HPyFunc_NOARGS)
@@ -672,6 +674,7 @@ class TestErr(HPyTest):
         with pytest.raises(DummyException):
             mod.f(raise_exception, (DummyException, ), exc_types)
 
+    @pytest.mark.skipif(IS_GRAALPY, reason="Fails transiently on GraalPy especially with xdist")
     def test_HPyErr_WriteUnraisable(self, python_subprocess):
         mod = self.compile_module("""
             HPyDef_METH(f, "f", HPyFunc_NOARGS)

--- a/test/test_hpyfield.py
+++ b/test/test_hpyfield.py
@@ -145,7 +145,9 @@ class TestHPyField(HPyTest):
         assert not gc.is_tracked(p)
 
     def test_tp_traverse(self):
-        import sys
+        if self.is_graalpy:
+            import pytest
+            pytest.skip("Crashes on GraalPy")
         import gc
         mod = self.make_module("""
             @DEFINE_PairObject
@@ -308,6 +310,9 @@ class TestHPyField(HPyTest):
         assert count_pairs() == 0
 
     def test_tp_finalize(self):
+        if self.is_graalpy:
+            import pytest
+            pytest.skip("Crashes on GraalPy")
         # Tests the contract of tp_finalize: what it should see
         # if called from within HPyField_Store
         mod = self.make_module("""

--- a/test/test_hpytype.py
+++ b/test/test_hpytype.py
@@ -1594,6 +1594,9 @@ class TestPureHPyType(HPyTest):
     ExtensionTemplate = PointTemplate
 
     def test_builtin_shape(self):
+        if self.is_graalpy:
+            import pytest
+            pytest.skip("Not yet implemented on GraalPy")
         mod = self.make_module("""
             @DEFINE_PointObject(HPyType_BuiltinShape_Long)
             @DEFINE_Point_xy

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -532,6 +532,8 @@ class TestObject(HPyTest):
 
     def test_getslice(self):
         import pytest
+        if self.is_graalpy:
+            pytest.skip("Not yet implemented on GraalPy")
         mod = self.make_module("""
             HPyDef_METH(f, "f", HPyFunc_VARARGS)
             static HPy f_impl(HPyContext *ctx, HPy self, const HPy *args, size_t nargs)
@@ -653,6 +655,8 @@ class TestObject(HPyTest):
 
     def test_setslice(self):
         import pytest
+        if self.is_graalpy:
+            pytest.skip("Not yet implemented on GraalPy")
         mod = self.make_module("""
             HPyDef_METH(f, "f", HPyFunc_VARARGS)
             static HPy f_impl(HPyContext *ctx, HPy self, const HPy *args, size_t nargs)
@@ -786,6 +790,8 @@ class TestObject(HPyTest):
 
     def test_delslice(self):
         import pytest
+        if self.is_graalpy:
+            pytest.skip("Not yet implemented on GraalPy")
         mod = self.make_module("""
             HPyDef_METH(f, "f", HPyFunc_VARARGS)
             static HPy f_impl(HPyContext *ctx, HPy self, const HPy *args, size_t nargs)


### PR DESCRIPTION
With these changes we can build the HPy C extension on GraalPy and run the tests.