### PR TITLE
fix issue #493

### DIFF
--- a/hpy/devel/include/hpy/universal/autogen_hpyfunc_trampolines.h
+++ b/hpy/devel/include/hpy/universal/autogen_hpyfunc_trampolines.h
@@ -15,8 +15,12 @@ typedef struct {
     cpy_PyObject * result;
 } _HPyFunc_args_NOARGS;
 
+/* NOTE: METH_NOARGS requires 2 parameters per CPython C API docs:
+   "The function must have 2 parameters. Since the second parameter is unused,
+   Py_UNUSED can be used to prevent a compiler warning."
+   The second parameter is always NULL but must be present in the signature. */
 #define _HPyFunc_TRAMPOLINE_HPyFunc_NOARGS(SYM, IMPL) \
-    static cpy_PyObject *SYM(cpy_PyObject *self) \
+    static cpy_PyObject *SYM(cpy_PyObject *self, cpy_PyObject *_HPy_UNUSED_ARG(ignored)) \
     { \
         _HPyFunc_args_NOARGS a = { self }; \
         _HPy_CallRealFunctionFromTrampoline( \

--- a/test/test_type_method_crash.py
+++ b/test/test_type_method_crash.py
@@ -1,0 +1,149 @@
+"""
+Test for method calls on custom types - reproduces crash in Universal ABI.
+
+This test creates a simple custom type with a NOARGS method and verifies
+that the method can be called on an instance.
+"""
+from .support import HPyTest
+
+
+class TestTypeMethodCrash(HPyTest):
+    """
+    Reproducer for crash when calling methods on custom types in Universal ABI.
+    
+    The crash occurs when:
+    1. A custom type is created via HPyType_FromSpec
+    2. An instance is created via HPy_New
+    3. A method (defined via HPyDef_METH) is called on the instance
+    
+    The crash happens before the method body is entered, suggesting an issue
+    in the method dispatch mechanism for Universal ABI.
+    """
+
+    def test_simple_noargs_method(self):
+        """
+        Minimal reproducer: type with HPyType_HELPERS and a NOARGS method.
+        """
+        mod = self.make_module("""
+            typedef struct {
+                long value;
+            } MyObject;
+            
+            HPyType_HELPERS(MyObject)
+            
+            HPyDef_SLOT(My_new, HPy_tp_new)
+            static HPy My_new_impl(HPyContext *ctx, HPy cls, const HPy *args,
+                                   HPy_ssize_t nargs, HPy kw)
+            {
+                MyObject *obj;
+                HPy h = HPy_New(ctx, cls, &obj);
+                if (HPy_IsNull(h))
+                    return HPy_NULL;
+                obj->value = 42;
+                return h;
+            }
+            
+            HPyDef_METH(My_get_value, "get_value", HPyFunc_NOARGS)
+            static HPy My_get_value_impl(HPyContext *ctx, HPy self)
+            {
+                MyObject *obj = MyObject_AsStruct(ctx, self);
+                return HPyLong_FromLong(ctx, obj->value);
+            }
+            
+            static HPyDef *My_defines[] = {
+                &My_new,
+                &My_get_value,
+                NULL
+            };
+            
+            static HPyType_Spec My_spec = {
+                .name = "mytest.MyType",
+                .basicsize = sizeof(MyObject),
+                .defines = My_defines,
+            };
+            
+            @EXPORT_TYPE("MyType", My_spec)
+            @INIT
+        """)
+        obj = mod.MyType()
+        # This call crashes in Universal ABI before the method body is entered
+        result = obj.get_value()
+        assert result == 42
+
+    def test_simple_noargs_method_no_struct_access(self):
+        """
+        Even simpler: method that doesn't access struct at all.
+        """
+        mod = self.make_module("""
+            typedef struct {
+                long value;
+            } MyObject;
+            
+            HPyType_HELPERS(MyObject)
+            
+            HPyDef_SLOT(My_new, HPy_tp_new)
+            static HPy My_new_impl(HPyContext *ctx, HPy cls, const HPy *args,
+                                   HPy_ssize_t nargs, HPy kw)
+            {
+                MyObject *obj;
+                HPy h = HPy_New(ctx, cls, &obj);
+                if (HPy_IsNull(h))
+                    return HPy_NULL;
+                obj->value = 42;
+                return h;
+            }
+            
+            HPyDef_METH(My_constant, "constant", HPyFunc_NOARGS)
+            static HPy My_constant_impl(HPyContext *ctx, HPy self)
+            {
+                // Doesn't access struct at all - just returns a constant
+                return HPyLong_FromLong(ctx, 123);
+            }
+            
+            static HPyDef *My_defines[] = {
+                &My_new,
+                &My_constant,
+                NULL
+            };
+            
+            static HPyType_Spec My_spec = {
+                .name = "mytest.MyType",
+                .basicsize = sizeof(MyObject),
+                .defines = My_defines,
+            };
+            
+            @EXPORT_TYPE("MyType", My_spec)
+            @INIT
+        """)
+        obj = mod.MyType()
+        # This also crashes - proving the issue is not in AsStruct
+        result = obj.constant()
+        assert result == 123
+
+    def test_type_without_basicsize(self):
+        """
+        Test with basicsize=0 - no custom struct, just methods.
+        """
+        mod = self.make_module("""
+            HPyDef_METH(My_constant, "constant", HPyFunc_NOARGS)
+            static HPy My_constant_impl(HPyContext *ctx, HPy self)
+            {
+                return HPyLong_FromLong(ctx, 456);
+            }
+            
+            static HPyDef *My_defines[] = {
+                &My_constant,
+                NULL
+            };
+            
+            static HPyType_Spec My_spec = {
+                .name = "mytest.MyType",
+                .defines = My_defines,
+            };
+            
+            @EXPORT_TYPE("MyType", My_spec)
+            @INIT
+        """)
+        obj = mod.MyType()
+        result = obj.constant()
+        assert result == 456

--- a/test/test_type_method_crash.py
+++ b/test/test_type_method_crash.py
@@ -10,12 +10,12 @@ from .support import HPyTest
 class TestTypeMethodCrash(HPyTest):
     """
     Reproducer for crash when calling methods on custom types in Universal ABI.
-    
+
     The crash occurs when:
     1. A custom type is created via HPyType_FromSpec
     2. An instance is created via HPy_New
     3. A method (defined via HPyDef_METH) is called on the instance
-    
+
     The crash happens before the method body is entered, suggesting an issue
     in the method dispatch mechanism for Universal ABI.
     """
@@ -28,9 +28,9 @@ class TestTypeMethodCrash(HPyTest):
             typedef struct {
                 long value;
             } MyObject;
-            
+
             HPyType_HELPERS(MyObject)
-            
+
             HPyDef_SLOT(My_new, HPy_tp_new)
             static HPy My_new_impl(HPyContext *ctx, HPy cls, const HPy *args,
                                    HPy_ssize_t nargs, HPy kw)
@@ -42,26 +42,26 @@ class TestTypeMethodCrash(HPyTest):
                 obj->value = 42;
                 return h;
             }
-            
+
             HPyDef_METH(My_get_value, "get_value", HPyFunc_NOARGS)
             static HPy My_get_value_impl(HPyContext *ctx, HPy self)
             {
                 MyObject *obj = MyObject_AsStruct(ctx, self);
                 return HPyLong_FromLong(ctx, obj->value);
             }
-            
+
             static HPyDef *My_defines[] = {
                 &My_new,
                 &My_get_value,
                 NULL
             };
-            
+
             static HPyType_Spec My_spec = {
                 .name = "mytest.MyType",
                 .basicsize = sizeof(MyObject),
                 .defines = My_defines,
             };
-            
+
             @EXPORT_TYPE("MyType", My_spec)
             @INIT
         """)
@@ -78,9 +78,9 @@ class TestTypeMethodCrash(HPyTest):
             typedef struct {
                 long value;
             } MyObject;
-            
+
             HPyType_HELPERS(MyObject)
-            
+
             HPyDef_SLOT(My_new, HPy_tp_new)
             static HPy My_new_impl(HPyContext *ctx, HPy cls, const HPy *args,
                                    HPy_ssize_t nargs, HPy kw)
@@ -92,26 +92,26 @@ class TestTypeMethodCrash(HPyTest):
                 obj->value = 42;
                 return h;
             }
-            
+
             HPyDef_METH(My_constant, "constant", HPyFunc_NOARGS)
             static HPy My_constant_impl(HPyContext *ctx, HPy self)
             {
                 // Doesn't access struct at all - just returns a constant
                 return HPyLong_FromLong(ctx, 123);
             }
-            
+
             static HPyDef *My_defines[] = {
                 &My_new,
                 &My_constant,
                 NULL
             };
-            
+
             static HPyType_Spec My_spec = {
                 .name = "mytest.MyType",
                 .basicsize = sizeof(MyObject),
                 .defines = My_defines,
             };
-            
+
             @EXPORT_TYPE("MyType", My_spec)
             @INIT
         """)
@@ -130,17 +130,17 @@ class TestTypeMethodCrash(HPyTest):
             {
                 return HPyLong_FromLong(ctx, 456);
             }
-            
+
             static HPyDef *My_defines[] = {
                 &My_constant,
                 NULL
             };
-            
+
             static HPyType_Spec My_spec = {
                 .name = "mytest.MyType",
                 .defines = My_defines,
             };
-            
+
             @EXPORT_TYPE("MyType", My_spec)
             @INIT
         """)


### PR DESCRIPTION
HPy-defined types crashed with a segmentation fault on Python 3.13 when creating or instantiating types using the Universal ABI.
